### PR TITLE
Improve extensibility and context caching boundaries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Shared runtime context provider** — MCP tools and `rails://...` resources now read through `RailsAiBridge::ContextProvider`, keeping cache invalidation and snapshot semantics aligned across both entry points.
+- **Explicit extension registries** — `config.additional_introspectors`, `config.additional_tools`, and `config.additional_resources` allow host apps or companion gems to extend the built-ins without patching core constants.
+- **HTTP transport Rack builder** — `RailsAiBridge::HttpTransportApp` centralizes HTTP MCP request handling for both standalone server mode and middleware auto-mount.
+- **Section-level context reads** — `ContextProvider.fetch_section` and `BaseTool.cached_section` let single-section tools avoid rebuilding or materializing the full snapshot path when unnecessary.
+- **Folder-level contributor docs** — key runtime folders now include local `README.md` guides for structure, boundaries, and extension points.
+- **Extensibility integration coverage** — specs now prove that a custom introspector, tool, and resource can be registered and used together from the host app configuration surface.
+
+### Changed
+
+- **Install generator messages** — the install flow now reports created vs unchanged files correctly and the generated initializer comments reflect the current preset sizes.
+- **Fingerprint reuse on invalidation** — context refresh reuses a single fingerprint snapshot per fetch cycle instead of scanning twice when cached context becomes stale.
+
+### Fixed
+
+- **Install generator output bug** — `generate_context` results are no longer iterated as raw hash pairs during install-time file generation.
+
 ## [1.1.0] - 2026-03-20
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ flowchart LR
 2. **`rails ai:bridge`** writes bounded bridge files for Claude, Cursor, Copilot, Codex, Windsurf, and JSON.
 3. **`rails ai:serve`** exposes **9 MCP tools** so assistants pull detail on demand (`detail: "summary"` first, then drill down).
 
+### Folder guides
+
+For contributors, key folders now include local `README.md` guides:
+
+- [`lib/rails_ai_bridge/README.md`](lib/rails_ai_bridge/README.md)
+- [`lib/rails_ai_bridge/introspectors/README.md`](lib/rails_ai_bridge/introspectors/README.md)
+- [`lib/rails_ai_bridge/tools/README.md`](lib/rails_ai_bridge/tools/README.md)
+- [`lib/rails_ai_bridge/serializers/README.md`](lib/rails_ai_bridge/serializers/README.md)
+- [`lib/generators/rails_ai_bridge/README.md`](lib/generators/rails_ai_bridge/README.md)
+- [`spec/lib/rails_ai_bridge/README.md`](spec/lib/rails_ai_bridge/README.md)
+
 ---
 
 ## Quick start
@@ -338,10 +349,35 @@ end
 | `http_mcp_token` | `nil` | Bearer token for HTTP MCP; `ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]` overrides when set |
 | `search_code_allowed_file_types` | `[]` | Extra extensions allowed for `rails_search_code` `file_type` |
 | `expose_credentials_key_names` | `false` | Include `credentials_keys` in config introspection / `rails://config` |
+| `additional_introspectors` | `{}` | Optional custom introspector classes keyed by symbol |
+| `additional_tools` | `[]` | Optional MCP tool classes appended to the built-in toolset |
+| `additional_resources` | `{}` | Optional MCP resources merged with the built-in `rails://...` resources |
 | `http_path` | `"/mcp"` | HTTP endpoint path |
 | `http_port` | `6029` | HTTP server port |
 | `cache_ttl` | `30` | Cache TTL in seconds |
 </details>
+
+### Extending the built-ins
+
+If you need host-app or companion-gem extensions, register them explicitly in the initializer:
+
+```ruby
+RailsAiBridge.configure do |config|
+  config.additional_introspectors[:billing] = MyCompany::BillingIntrospector
+  config.introspectors << :billing
+
+  config.additional_tools << MyCompany::Tools::GetBillingContext
+
+  config.additional_resources["rails://billing"] = {
+    name: "Billing",
+    description: "Billing-specific AI context",
+    mime_type: "application/json",
+    key: :billing
+  }
+end
+```
+
+Built-in MCP tools and resources now read through a shared runtime context provider, so tool calls and `rails://...` resource reads stay aligned to the same cached snapshot.
 
 ---
 

--- a/lib/generators/rails_ai_bridge/README.md
+++ b/lib/generators/rails_ai_bridge/README.md
@@ -1,0 +1,29 @@
+# `lib/generators/rails_ai_bridge`
+
+This folder contains install-time developer experience for host apps.
+
+## Purpose
+
+The install generator is responsible for creating the minimum working setup:
+
+- `.mcp.json`
+- `config/initializers/rails_ai_bridge.rb`
+- `config/rails_ai_bridge/overrides.md`
+- `config/rails_ai_bridge/overrides.md.example`
+
+It also triggers initial bridge-file generation when Rails is fully loaded.
+
+## Expectations
+
+Generator behavior should stay:
+
+- idempotent
+- explicit about what changed
+- aligned with current configuration defaults
+- covered by generator specs
+
+## Important file
+
+- `install/install_generator.rb`: the main install flow and user-facing setup messages.
+
+If the runtime contract changes, update the generator comments and setup output in the same change.

--- a/lib/generators/rails_ai_bridge/install/install_generator.rb
+++ b/lib/generators/rails_ai_bridge/install/install_generator.rb
@@ -23,13 +23,16 @@ module RailsAiBridge
       end
 
       def create_initializer
+        standard_count = RailsAiBridge::Configuration::PRESETS[:standard].size
+        full_count = RailsAiBridge::Configuration::PRESETS[:full].size
+
         create_file "config/initializers/rails_ai_bridge.rb", <<~RUBY
           # frozen_string_literal: true
 
           RailsAiBridge.configure do |config|
             # Introspector preset:
-            #   :standard — 8 core introspectors (schema, models, routes, jobs, gems, conventions, controllers, tests)
-            #   :full     — all 21 introspectors (adds views, turbo, auth, API, config, assets, devops, etc.)
+            #   :standard — #{standard_count} core introspectors (schema, models, routes, jobs, gems, conventions, controllers, tests, migrations)
+            #   :full     — all #{full_count} introspectors (adds views, turbo, auth, API, config, assets, devops, etc.)
             # config.preset = :standard
 
             # Or cherry-pick individual introspectors:
@@ -118,9 +121,9 @@ module RailsAiBridge
 
         if Rails.application
           require "rails_ai_bridge"
-          context = RailsAiBridge.introspect
-          files = RailsAiBridge.generate_context(format: :all)
-          files.each { |f| say "  Created #{f}", :green }
+          result = RailsAiBridge.generate_context(format: :all)
+          result[:written].each { |file| say "  Created #{file}", :green }
+          result[:skipped].each { |file| say "  Unchanged #{file}", :blue }
         else
           say "  Skipped (Rails app not fully loaded). Run `rails ai:bridge` after install.", :yellow
         end

--- a/lib/rails_ai_bridge.rb
+++ b/lib/rails_ai_bridge.rb
@@ -36,10 +36,11 @@ module RailsAiBridge
     # Returns a hash of all discovered context.
     #
     # @param app [Rails::Application, nil] app to introspect, defaults to Rails.application
+    # @param only [Array<Symbol>, nil] optional subset of introspector keys to run
     # @return [Hash] introspection payload with enabled sections
-    def introspect(app = nil)
+    def introspect(app = nil, only: nil)
       app ||= Rails.application
-      Introspector.new(app).call
+      Introspector.new(app).call(only: only)
     end
 
     # Generate context files (CLAUDE.md, .cursorrules, etc.)

--- a/lib/rails_ai_bridge/README.md
+++ b/lib/rails_ai_bridge/README.md
@@ -1,0 +1,37 @@
+# `lib/rails_ai_bridge`
+
+This folder contains the runtime core of `rails-ai-bridge`.
+
+## Purpose
+
+These files define the public API, configuration surface, MCP runtime wiring, and the internal boundaries used to introspect a Rails app and expose that data to AI clients.
+
+## Key files
+
+- `configuration.rb`: global configuration object and extension registries.
+- `context_provider.rb`: shared runtime cache for full context snapshots and per-section fetches.
+- `introspector.rb`: orchestrates built-in and custom introspectors.
+- `server.rb`: builds the MCP server and registers tools/resources.
+- `resources.rb`: serves `rails://...` resources through the shared context provider.
+- `middleware.rb`: Rack middleware for auto-mounted HTTP MCP.
+- `http_transport_app.rb`: shared Rack endpoint used by both `Server` and `Middleware`.
+- `fingerprinter.rb`: file-change detection used for cache invalidation.
+- `doctor.rb`: diagnostics and readiness checks.
+- `watcher.rb`: file watcher that regenerates bridge files in development.
+
+## Runtime flow
+
+1. `RailsAiBridge.introspect` delegates to `Introspector`.
+2. `ContextProvider` caches either the full snapshot or individual sections.
+3. MCP tools and MCP resources read through `ContextProvider`.
+4. `Server` or `Middleware` expose the data over stdio or HTTP.
+
+## Extension points
+
+The supported extension seams live on `RailsAiBridge.configuration`:
+
+- `additional_introspectors`
+- `additional_tools`
+- `additional_resources`
+
+Use these instead of patching internal constants.

--- a/lib/rails_ai_bridge/configuration.rb
+++ b/lib/rails_ai_bridge/configuration.rb
@@ -66,6 +66,15 @@ module RailsAiBridge
     # When true, +credentials_keys+ appears in config introspection / +rails://config+ resource
     attr_accessor :expose_credentials_key_names
 
+    # Optional custom introspectors keyed by symbol name.
+    attr_accessor :additional_introspectors
+
+    # Optional custom MCP tools appended to the built-in tool list.
+    attr_accessor :additional_tools
+
+    # Optional custom MCP resources merged with built-in resources.
+    attr_accessor :additional_resources
+
     def initialize
       @server_name         = "rails-ai-bridge"
       @server_version      = RailsAiBridge::VERSION
@@ -93,6 +102,9 @@ module RailsAiBridge
       @codex_compact_model_list_limit   = 3
       @search_code_allowed_file_types   = []
       @expose_credentials_key_names     = false
+      @additional_introspectors         = {}
+      @additional_tools                 = []
+      @additional_resources             = {}
     end
 
     def preset=(name)

--- a/lib/rails_ai_bridge/context_provider.rb
+++ b/lib/rails_ai_bridge/context_provider.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  # Builds and caches introspection snapshots for MCP tools and resources.
+  # This keeps all runtime reads aligned behind one explicit boundary.
+  class ContextProvider
+    @cache = Hash.new { |hash, key| hash[key] = { sections: {} } }
+
+    class << self
+      # Returns the latest introspection snapshot for the given app, reusing a
+      # cached value while the TTL is valid and the fingerprint is unchanged.
+      #
+      # @param app [Rails::Application] application to introspect
+      # @return [Hash] introspection payload
+      def fetch(app = Rails.application)
+        cached = cache[cache_key(app)]
+        return rebuild(app) unless cached[:full]
+
+        current_fingerprint = Fingerprinter.snapshot(app)
+        if ttl_valid?(cached[:full]) && current_fingerprint == cached[:full][:fingerprint]
+          return cached[:full][:context]
+        end
+
+        rebuild(app, fingerprint: current_fingerprint)
+      end
+
+      # Returns a single introspection section using a dedicated cache entry for
+      # that section. If a valid full snapshot is already cached, reuse it.
+      #
+      # @param section [Symbol] introspector key to retrieve
+      # @param app [Rails::Application] application to introspect
+      # @return [Object, nil] requested section payload
+      def fetch_section(section, app = Rails.application)
+        key = cache_key(app)
+        cached = cache[key]
+        current_fingerprint = Fingerprinter.snapshot(app)
+
+        full = cached[:full]
+        if full && ttl_valid?(full) && current_fingerprint == full[:fingerprint]
+          return full[:context][section]
+        end
+
+        section_entry = cached[:sections][section]
+        if section_entry && ttl_valid?(section_entry) && current_fingerprint == section_entry[:fingerprint]
+          return section_entry[:context]
+        end
+
+        rebuild_section(section, app, fingerprint: current_fingerprint)
+      end
+
+      # Clears all cached snapshots.
+      #
+      # @return [void]
+      def reset!
+        @cache = Hash.new { |hash, key| hash[key] = { sections: {} } }
+      end
+
+      private
+
+      attr_reader :cache
+
+      def rebuild(app, fingerprint: nil)
+        context = RailsAiBridge.introspect(app)
+        key = cache_key(app)
+        cache[key][:full] = {
+          context: context,
+          fingerprint: fingerprint || Fingerprinter.snapshot(app),
+          fetched_at: monotonic_now
+        }
+        context.each do |section_name, section_value|
+          next unless section_name.is_a?(Symbol)
+          next if metadata_key?(section_name)
+
+          cache[key][:sections][section_name] = {
+            context: section_value,
+            fingerprint: cache[key][:full][:fingerprint],
+            fetched_at: cache[key][:full][:fetched_at]
+          }
+        end
+        context
+      end
+
+      def rebuild_section(section, app, fingerprint:)
+        context = RailsAiBridge.introspect(app, only: [ section ])
+        cache[cache_key(app)][:sections][section] = {
+          context: context[section],
+          fingerprint: fingerprint,
+          fetched_at: monotonic_now
+        }
+        context[section]
+      end
+
+      def ttl_valid?(cached)
+        (monotonic_now - cached[:fetched_at]) < RailsAiBridge.configuration.cache_ttl
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def cache_key(app)
+        app.object_id
+      end
+
+      def metadata_key?(section_name)
+        %i[app_name ruby_version rails_version environment generated_at generator].include?(section_name)
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/fingerprinter.rb
+++ b/lib/rails_ai_bridge/fingerprinter.rb
@@ -28,7 +28,7 @@ module RailsAiBridge
     ].freeze
 
     class << self
-      def compute(app)
+      def snapshot(app)
         root = app.root.to_s
         digest = Digest::SHA256.new
 
@@ -49,8 +49,12 @@ module RailsAiBridge
         digest.hexdigest
       end
 
+      def compute(app)
+        snapshot(app)
+      end
+
       def changed?(app, previous)
-        compute(app) != previous
+        snapshot(app) != previous
       end
     end
   end

--- a/lib/rails_ai_bridge/http_transport_app.rb
+++ b/lib/rails_ai_bridge/http_transport_app.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  # Builds the Rack endpoint used by both standalone HTTP mode and the
+  # middleware auto-mount path so request handling stays in one place.
+  class HttpTransportApp
+    class << self
+      # @param transport [MCP::Server::Transports::StreamableHTTPTransport] transport to delegate to
+      # @param path [String] configured MCP endpoint path
+      # @return [Proc] rack-compatible app
+      def build(transport:, path:)
+        lambda do |env|
+          unless env["PATH_INFO"] == path || env["PATH_INFO"] == "#{path}/"
+            return [ 404, { "Content-Type" => "application/json" }, [ '{"error":"Not found"}' ] ]
+          end
+
+          request = Rack::Request.new(env)
+          unless McpHttpAuth.authorized_request?(request)
+            return McpHttpAuth.unauthorized_rack_response
+          end
+
+          transport.handle_request(request)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/introspector.rb
+++ b/lib/rails_ai_bridge/introspector.rb
@@ -13,8 +13,9 @@ module RailsAiBridge
 
     # Run all configured introspectors and return unified context hash
     #
-    # @return [Hash] complete application context
-    def call
+    # @param only [Array<Symbol>, nil] optional subset of introspectors to execute
+    # @return [Hash] complete application context or metadata + requested sections
+    def call(only: nil)
       context = {
         app_name: app_name,
         ruby_version: RUBY_VERSION,
@@ -24,7 +25,7 @@ module RailsAiBridge
         generator: "rails-ai-bridge v#{RailsAiBridge::VERSION}"
       }
 
-      config.introspectors.each do |name|
+      selected_introspectors(only).each do |name|
         introspector = resolve_introspector(name)
         context[name] = introspector.call
       rescue => e
@@ -37,6 +38,36 @@ module RailsAiBridge
 
     private
 
+    BUILTIN_INTROSPECTORS = {
+      schema: Introspectors::SchemaIntrospector,
+      models: Introspectors::ModelIntrospector,
+      routes: Introspectors::RouteIntrospector,
+      jobs: Introspectors::JobIntrospector,
+      gems: Introspectors::GemIntrospector,
+      conventions: Introspectors::ConventionDetector,
+      stimulus: Introspectors::StimulusIntrospector,
+      database_stats: Introspectors::DatabaseStatsIntrospector,
+      controllers: Introspectors::ControllerIntrospector,
+      views: Introspectors::ViewIntrospector,
+      turbo: Introspectors::TurboIntrospector,
+      i18n: Introspectors::I18nIntrospector,
+      config: Introspectors::ConfigIntrospector,
+      active_storage: Introspectors::ActiveStorageIntrospector,
+      action_text: Introspectors::ActionTextIntrospector,
+      auth: Introspectors::AuthIntrospector,
+      api: Introspectors::ApiIntrospector,
+      tests: Introspectors::TestIntrospector,
+      rake_tasks: Introspectors::RakeTaskIntrospector,
+      assets: Introspectors::AssetPipelineIntrospector,
+      devops: Introspectors::DevOpsIntrospector,
+      action_mailbox: Introspectors::ActionMailboxIntrospector,
+      migrations: Introspectors::MigrationIntrospector,
+      seeds: Introspectors::SeedsIntrospector,
+      middleware: Introspectors::MiddlewareIntrospector,
+      engines: Introspectors::EngineIntrospector,
+      multi_database: Introspectors::MultiDatabaseIntrospector
+    }.freeze
+
     def app_name
       if app.class.respond_to?(:module_parent_name)
         app.class.module_parent_name
@@ -45,38 +76,18 @@ module RailsAiBridge
       end
     end
 
+    def selected_introspectors(only)
+      names = Array(only).compact
+      return config.introspectors if names.empty?
+
+      names
+    end
+
     def resolve_introspector(name)
-      case name
-      when :schema      then Introspectors::SchemaIntrospector.new(app)
-      when :models      then Introspectors::ModelIntrospector.new(app)
-      when :routes      then Introspectors::RouteIntrospector.new(app)
-      when :jobs        then Introspectors::JobIntrospector.new(app)
-      when :gems        then Introspectors::GemIntrospector.new(app)
-      when :conventions then Introspectors::ConventionDetector.new(app)
-      when :stimulus       then Introspectors::StimulusIntrospector.new(app)
-      when :database_stats then Introspectors::DatabaseStatsIntrospector.new(app)
-      when :controllers    then Introspectors::ControllerIntrospector.new(app)
-      when :views          then Introspectors::ViewIntrospector.new(app)
-      when :turbo          then Introspectors::TurboIntrospector.new(app)
-      when :i18n           then Introspectors::I18nIntrospector.new(app)
-      when :config         then Introspectors::ConfigIntrospector.new(app)
-      when :active_storage then Introspectors::ActiveStorageIntrospector.new(app)
-      when :action_text    then Introspectors::ActionTextIntrospector.new(app)
-      when :auth           then Introspectors::AuthIntrospector.new(app)
-      when :api            then Introspectors::ApiIntrospector.new(app)
-      when :tests          then Introspectors::TestIntrospector.new(app)
-      when :rake_tasks     then Introspectors::RakeTaskIntrospector.new(app)
-      when :assets         then Introspectors::AssetPipelineIntrospector.new(app)
-      when :devops         then Introspectors::DevOpsIntrospector.new(app)
-      when :action_mailbox then Introspectors::ActionMailboxIntrospector.new(app)
-      when :migrations      then Introspectors::MigrationIntrospector.new(app)
-      when :seeds           then Introspectors::SeedsIntrospector.new(app)
-      when :middleware       then Introspectors::MiddlewareIntrospector.new(app)
-      when :engines         then Introspectors::EngineIntrospector.new(app)
-      when :multi_database  then Introspectors::MultiDatabaseIntrospector.new(app)
-      else
-        raise ConfigurationError, "Unknown introspector: #{name}"
-      end
+      introspector_class = config.additional_introspectors[name] || BUILTIN_INTROSPECTORS[name]
+      raise ConfigurationError, "Unknown introspector: #{name}" unless introspector_class
+
+      introspector_class.new(app)
     end
   end
 end

--- a/lib/rails_ai_bridge/introspectors/README.md
+++ b/lib/rails_ai_bridge/introspectors/README.md
@@ -1,0 +1,43 @@
+# `lib/rails_ai_bridge/introspectors`
+
+This folder contains the built-in introspectors.
+
+## Contract
+
+Each introspector should:
+
+- be a small PORO
+- accept the Rails app in `initialize(app)`
+- expose a single public `#call`
+- return a `Hash`
+- avoid raising for expected app-shape differences
+
+## Design intent
+
+Introspectors are the data collection layer. They should not format output for AI clients and should not know about MCP transport concerns.
+
+## Registration
+
+Built-ins are mapped in `lib/rails_ai_bridge/introspector.rb`.
+
+Host apps or companion gems can add new introspectors with:
+
+```ruby
+RailsAiBridge.configure do |config|
+  config.additional_introspectors[:billing] = MyCompany::BillingIntrospector
+  config.introspectors << :billing
+end
+```
+
+## Good boundaries
+
+An introspector should answer one domain question well:
+
+- schema
+- models
+- routes
+- controllers
+- tests
+- conventions
+
+If a new file starts mixing multiple domains, split it before it grows.

--- a/lib/rails_ai_bridge/middleware.rb
+++ b/lib/rails_ai_bridge/middleware.rb
@@ -18,12 +18,7 @@ module RailsAiBridge
       path = config.http_path
 
       if env["PATH_INFO"] == path || env["PATH_INFO"] == "#{path}/"
-        request = Rack::Request.new(env)
-        unless McpHttpAuth.authorized_request?(request)
-          return McpHttpAuth.unauthorized_rack_response
-        end
-
-        transport.handle_request(request)
+        rack_app.call(env)
       else
         @app.call(env)
       end
@@ -38,6 +33,10 @@ module RailsAiBridge
           MCP::Server::Transports::StreamableHTTPTransport.new(server)
         end
       end
+    end
+
+    def rack_app
+      @rack_app ||= HttpTransportApp.build(transport: transport, path: RailsAiBridge.configuration.http_path)
     end
   end
 end

--- a/lib/rails_ai_bridge/resources.rb
+++ b/lib/rails_ai_bridge/resources.rb
@@ -64,10 +64,14 @@ module RailsAiBridge
     }.freeze
 
     class << self
+      def resource_definitions
+        STATIC_RESOURCES.merge(RailsAiBridge.configuration.additional_resources)
+      end
+
       def register(server)
         require "json"
 
-        resources = STATIC_RESOURCES.map do |uri, meta|
+        resources = resource_definitions.map do |uri, meta|
           MCP::Resource.new(
             uri: uri,
             name: meta[:name],
@@ -96,15 +100,14 @@ module RailsAiBridge
 
       def handle_read(params)
         uri = params[:uri]
-        context = RailsAiBridge.introspect
 
-        if STATIC_RESOURCES.key?(uri)
-          key = STATIC_RESOURCES[uri][:key]
-          content = JSON.pretty_generate(context[key] || {})
+        if resource_definitions.key?(uri)
+          key = resource_definitions[uri][:key]
+          content = JSON.pretty_generate(ContextProvider.fetch_section(key) || {})
           [ { uri: uri, mime_type: "application/json", text: content } ]
         elsif (match = uri.match(%r{\Arails://models/(.+)\z}))
           model_name = match[1]
-          models = context[:models] || {}
+          models = ContextProvider.fetch_section(:models) || {}
           data = models[model_name] || { error: "Model '#{model_name}' not found" }
           content = JSON.pretty_generate(data)
           [ { uri: uri, mime_type: "application/json", text: content } ]

--- a/lib/rails_ai_bridge/serializers/README.md
+++ b/lib/rails_ai_bridge/serializers/README.md
@@ -1,0 +1,36 @@
+# `lib/rails_ai_bridge/serializers`
+
+This folder contains the output layer for generated bridge files.
+
+## Responsibilities
+
+Serializers turn introspection hashes into assistant-specific files such as:
+
+- `CLAUDE.md`
+- `AGENTS.md`
+- `.cursorrules`
+- `.windsurfrules`
+- `.github/copilot-instructions.md`
+- split rule files under assistant-specific subfolders
+
+## Boundaries
+
+Serializers should:
+
+- format data, not collect it
+- stay independent from MCP transport code
+- respect assistant-specific limits and conventions
+- keep compact vs full behavior explicit
+
+## Entry point
+
+`context_file_serializer.rb` is the orchestrator for writing files and split-rule support files.
+
+## Adding a serializer
+
+If you add support for a new AI client:
+
+1. add the serializer class
+2. register its main output in `ContextFileSerializer::FORMAT_MAP`
+3. add split-rule support only if the target client benefits from path-scoped or always-on files
+4. cover unchanged-file behavior in specs

--- a/lib/rails_ai_bridge/server.rb
+++ b/lib/rails_ai_bridge/server.rb
@@ -25,6 +25,10 @@ module RailsAiBridge
       @transport_type = transport
     end
 
+    def tool_classes
+      TOOLS + RailsAiBridge.configuration.additional_tools
+    end
+
     # Build and return the configured MCP::Server instance
     def build
       config = RailsAiBridge.configuration
@@ -32,7 +36,7 @@ module RailsAiBridge
       server = MCP::Server.new(
         name: config.server_name,
         version: config.server_version,
-        tools: TOOLS
+        tools: tool_classes
       )
 
       Resources.register(server)
@@ -60,7 +64,7 @@ module RailsAiBridge
       transport = MCP::Server::Transports::StdioTransport.new(server)
       # Log to stderr so we don't pollute the JSON-RPC channel on stdout
       $stderr.puts "[rails-ai-bridge] MCP server started (stdio transport)"
-      $stderr.puts "[rails-ai-bridge] Tools: #{TOOLS.map { |t| t.tool_name }.join(', ')}"
+      $stderr.puts "[rails-ai-bridge] Tools: #{tool_classes.map { |t| t.tool_name }.join(', ')}"
       transport.open
     end
 
@@ -74,7 +78,7 @@ module RailsAiBridge
       rack_app = build_rack_app(transport, config.http_path)
 
       $stderr.puts "[rails-ai-bridge] MCP server starting on #{config.http_bind}:#{config.http_port}#{config.http_path}"
-      $stderr.puts "[rails-ai-bridge] Tools: #{TOOLS.map { |t| t.tool_name }.join(', ')}"
+      $stderr.puts "[rails-ai-bridge] Tools: #{tool_classes.map { |t| t.tool_name }.join(', ')}"
 
       require "rackup"
       Rackup::Handler.default.run(rack_app, Host: config.http_bind, Port: config.http_port)
@@ -85,19 +89,7 @@ module RailsAiBridge
     end
 
     def build_rack_app(transport, path)
-      lambda do |env|
-        # Only handle requests at the configured MCP path
-        unless env["PATH_INFO"] == path || env["PATH_INFO"] == "#{path}/"
-          return [ 404, { "Content-Type" => "application/json" }, [ '{"error":"Not found"}' ] ]
-        end
-
-        request = Rack::Request.new(env)
-        unless McpHttpAuth.authorized_request?(request)
-          return McpHttpAuth.unauthorized_rack_response
-        end
-
-        transport.handle_request(request)
-      end
+      HttpTransportApp.build(transport: transport, path: path)
     end
   end
 end

--- a/lib/rails_ai_bridge/tools/README.md
+++ b/lib/rails_ai_bridge/tools/README.md
@@ -1,0 +1,46 @@
+# `lib/rails_ai_bridge/tools`
+
+This folder contains the MCP tool classes exposed to AI clients.
+
+## Contract
+
+Each tool should:
+
+- inherit from `RailsAiBridge::Tools::BaseTool`
+- define `tool_name`, `description`, and `input_schema`
+- expose a class-level `.call`
+- return `MCP::Tool::Response`
+- stay read-only
+
+## Shared helpers
+
+Use `BaseTool` helpers instead of rolling your own runtime behavior:
+
+- `cached_context` for a full snapshot
+- `cached_section(:name)` for section-level reads
+- `text_response(text)` for truncation-safe responses
+
+## When to use `cached_section`
+
+Prefer `cached_section` when the tool only needs one introspection section:
+
+- `:schema`
+- `:routes`
+- `:models`
+- `:controllers`
+- `:config`
+- `:tests`
+
+Use `cached_context` only when the tool genuinely needs multiple sections at once.
+
+## Registration
+
+Built-in tools are listed in `lib/rails_ai_bridge/server.rb`.
+
+Custom tools can be appended with:
+
+```ruby
+RailsAiBridge.configure do |config|
+  config.additional_tools << MyCompany::Tools::GetBillingContext
+end
+```

--- a/lib/rails_ai_bridge/tools/base_tool.rb
+++ b/lib/rails_ai_bridge/tools/base_tool.rb
@@ -20,23 +20,19 @@ module RailsAiBridge
 
         # Cache introspection results with TTL + fingerprint invalidation
         def cached_context
-          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          ttl = RailsAiBridge.configuration.cache_ttl
+          ContextProvider.fetch(rails_app)
+        end
 
-          if @cached_context && (now - @cache_timestamp) < ttl && !Fingerprinter.changed?(rails_app, @cache_fingerprint)
-            return @cached_context
-          end
-
-          @cached_context = RailsAiBridge.introspect
-          @cache_timestamp = now
-          @cache_fingerprint = Fingerprinter.compute(rails_app)
-          @cached_context
+        # Returns a single introspection section via the shared context provider.
+        #
+        # @param section [Symbol] introspector key
+        # @return [Object, nil] section payload
+        def cached_section(section)
+          ContextProvider.fetch_section(section, rails_app)
         end
 
         def reset_cache!
-          @cached_context = nil
-          @cache_timestamp = nil
-          @cache_fingerprint = nil
+          ContextProvider.reset!
         end
 
         # Helper: wrap text in an MCP::Tool::Response with safety-net truncation

--- a/lib/rails_ai_bridge/tools/get_config.rb
+++ b/lib/rails_ai_bridge/tools/get_config.rb
@@ -11,7 +11,7 @@ module RailsAiBridge
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(server_context: nil)
-        data = cached_context[:config]
+        data = cached_section(:config)
         return text_response("Config introspection not available. Add :config to introspectors or use `config.preset = :full`.") unless data
         return text_response("Config introspection failed: #{data[:error]}") if data[:error]
 

--- a/lib/rails_ai_bridge/tools/get_controllers.rb
+++ b/lib/rails_ai_bridge/tools/get_controllers.rb
@@ -23,7 +23,7 @@ module RailsAiBridge
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(controller: nil, detail: "standard", server_context: nil)
-        data = cached_context[:controllers]
+        data = cached_section(:controllers)
         return text_response("Controller introspection not available. Add :controllers to introspectors.") unless data
         return text_response("Controller introspection failed: #{data[:error]}") if data[:error]
 

--- a/lib/rails_ai_bridge/tools/get_conventions.rb
+++ b/lib/rails_ai_bridge/tools/get_conventions.rb
@@ -11,7 +11,7 @@ module RailsAiBridge
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(server_context: nil)
-        conventions = cached_context[:conventions]
+        conventions = cached_section(:conventions)
         return text_response("Convention detection not available. Add :conventions to introspectors.") unless conventions
         return text_response("Convention detection failed: #{conventions[:error]}") if conventions[:error]
 

--- a/lib/rails_ai_bridge/tools/get_gems.rb
+++ b/lib/rails_ai_bridge/tools/get_gems.rb
@@ -19,7 +19,7 @@ module RailsAiBridge
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(category: "all", server_context: nil)
-        gems = cached_context[:gems]
+        gems = cached_section(:gems)
         return text_response("Gem introspection not available. Add :gems to introspectors.") unless gems
         return text_response("Gem introspection failed: #{gems[:error]}") if gems[:error]
 

--- a/lib/rails_ai_bridge/tools/get_model_details.rb
+++ b/lib/rails_ai_bridge/tools/get_model_details.rb
@@ -23,7 +23,7 @@ module RailsAiBridge
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(model: nil, detail: "standard", server_context: nil)
-        models = cached_context[:models]
+        models = cached_section(:models)
         return text_response("Model introspection not available. Add :models to introspectors.") unless models
         return text_response("Model introspection failed: #{models[:error]}") if models[:error]
 

--- a/lib/rails_ai_bridge/tools/get_routes.rb
+++ b/lib/rails_ai_bridge/tools/get_routes.rb
@@ -31,7 +31,7 @@ module RailsAiBridge
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(controller: nil, detail: "standard", limit: nil, offset: 0, server_context: nil)
-        routes = cached_context[:routes]
+        routes = cached_section(:routes)
         return text_response("Route introspection not available. Add :routes to introspectors.") unless routes
         return text_response("Route introspection failed: #{routes[:error]}") if routes[:error]
 

--- a/lib/rails_ai_bridge/tools/get_schema.rb
+++ b/lib/rails_ai_bridge/tools/get_schema.rb
@@ -41,7 +41,7 @@ module RailsAiBridge
       )
 
       def self.call(table: nil, detail: "standard", limit: nil, offset: 0, format: "markdown", server_context: nil)
-        schema = cached_context[:schema]
+        schema = cached_section(:schema)
         return text_response("Schema introspection not available. Add :schema to introspectors.") unless schema
         return text_response("Schema introspection not available: #{schema[:error]}") if schema[:error]
 

--- a/lib/rails_ai_bridge/tools/get_test_info.rb
+++ b/lib/rails_ai_bridge/tools/get_test_info.rb
@@ -11,7 +11,7 @@ module RailsAiBridge
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
 
       def self.call(server_context: nil)
-        data = cached_context[:tests]
+        data = cached_section(:tests)
         return text_response("Test introspection not available. Add :tests to introspectors.") unless data
         return text_response("Test introspection failed: #{data[:error]}") if data[:error]
 

--- a/spec/lib/generators/rails_ai_bridge/install_generator_spec.rb
+++ b/spec/lib/generators/rails_ai_bridge/install_generator_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails/generators"
+require "generators/rails_ai_bridge/install/install_generator"
+
+RSpec.describe RailsAiBridge::Generators::InstallGenerator do
+  let(:destination_root) { Dir.mktmpdir }
+  let(:generator) { described_class.new([], {}, destination_root: destination_root) }
+
+  after do
+    FileUtils.remove_entry(destination_root)
+  end
+
+  describe "#create_initializer" do
+    it "documents the current preset sizes" do
+      generator.create_initializer
+
+      content = File.read(File.join(destination_root, "config/initializers/rails_ai_bridge.rb"))
+
+      expect(content).to include(":standard — 9 core introspectors")
+      expect(content).to include(":full     — all 26 introspectors")
+    end
+  end
+
+  describe "#generate_context_files" do
+    it "reports written and skipped files separately" do
+      allow(RailsAiBridge).to receive(:generate_context).and_return({
+        written: [ "CLAUDE.md" ],
+        skipped: [ ".cursorrules" ]
+      })
+      allow(generator).to receive(:say)
+
+      generator.generate_context_files
+
+      expect(generator).to have_received(:say).with("  Created CLAUDE.md", :green)
+      expect(generator).to have_received(:say).with("  Unchanged .cursorrules", :blue)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/README.md
+++ b/spec/lib/rails_ai_bridge/README.md
@@ -1,0 +1,33 @@
+# `spec/lib/rails_ai_bridge`
+
+This folder contains the main unit and integration coverage for the gem runtime.
+
+## What lives here
+
+- configuration specs
+- introspector and introspector-specific specs
+- MCP tool specs
+- resource specs
+- server and middleware specs
+- serializer specs
+- generator-facing behavior that is exercised close to the runtime code
+
+## Testing philosophy
+
+Prefer narrow behavioral specs over broad implementation coupling.
+
+Examples:
+
+- use tool specs to verify tool output contracts
+- use generator specs to prove install flow behavior
+- use integration specs when custom extension seams must work together
+
+## New seams introduced in this area
+
+The current architecture relies on tests around:
+
+- `ContextProvider` for snapshot and section caching
+- custom extension registration through configuration
+- shared HTTP transport behavior via `HttpTransportApp`
+
+If you change one of those boundaries, update the corresponding spec first.

--- a/spec/lib/rails_ai_bridge/configuration_spec.rb
+++ b/spec/lib/rails_ai_bridge/configuration_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe RailsAiBridge::Configuration do
     expect(config.assistant_overrides_path).to be_nil
     expect(config.copilot_compact_model_list_limit).to eq(5)
     expect(config.codex_compact_model_list_limit).to eq(3)
+    expect(config.additional_introspectors).to eq({})
+    expect(config.additional_tools).to eq([])
+    expect(config.additional_resources).to eq({})
   end
 
   it "defaults to standard preset" do
@@ -68,6 +71,32 @@ RSpec.describe RailsAiBridge::Configuration do
       config.introspectors += %i[views turbo]
       expect(config.introspectors).to include(:views, :turbo)
       expect(config.introspectors.size).to eq(11)
+    end
+  end
+
+  describe "extensibility registries" do
+    it "allows registering an additional introspector" do
+      config.additional_introspectors[:custom] = Class.new
+
+      expect(config.additional_introspectors.keys).to include(:custom)
+    end
+
+    it "allows registering additional MCP tools" do
+      tool_class = Class.new
+      config.additional_tools << tool_class
+
+      expect(config.additional_tools).to include(tool_class)
+    end
+
+    it "allows registering additional resources" do
+      config.additional_resources["rails://custom"] = {
+        name: "Custom",
+        description: "Custom resource",
+        mime_type: "application/json",
+        key: :custom
+      }
+
+      expect(config.additional_resources).to have_key("rails://custom")
     end
   end
 

--- a/spec/lib/rails_ai_bridge/context_provider_spec.rb
+++ b/spec/lib/rails_ai_bridge/context_provider_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::ContextProvider do
+  let(:app) { Rails.application }
+  let(:fingerprint) { "fingerprint-1" }
+  let(:context) { { schema: { tables: {} } } }
+
+  before do
+    described_class.reset!
+  end
+
+  after do
+    described_class.reset!
+  end
+
+  describe ".fetch" do
+    it "builds context on first request" do
+      allow(RailsAiBridge).to receive(:introspect).with(app).and_return(context)
+      allow(RailsAiBridge::Fingerprinter).to receive(:snapshot).with(app).and_return(fingerprint)
+
+      result = described_class.fetch(app)
+
+      expect(result).to eq(context)
+      expect(RailsAiBridge).to have_received(:introspect).with(app).once
+    end
+
+    it "reuses cached context while ttl is valid and fingerprint is unchanged" do
+      allow(RailsAiBridge).to receive(:introspect).with(app).and_return(context)
+      allow(RailsAiBridge::Fingerprinter).to receive(:snapshot).with(app).and_return(fingerprint)
+
+      first = described_class.fetch(app)
+      second = described_class.fetch(app)
+
+      expect(first).to eq(context)
+      expect(second).to eq(context)
+      expect(RailsAiBridge).to have_received(:introspect).with(app).once
+    end
+
+    it "rebuilds context when the fingerprint changes before ttl expiry" do
+      allow(RailsAiBridge).to receive(:introspect).with(app).and_return(context, { routes: { total_routes: 3 } })
+      allow(RailsAiBridge::Fingerprinter).to receive(:snapshot).with(app).and_return("fingerprint-1", "fingerprint-2")
+      allow(RailsAiBridge::Fingerprinter).to receive(:compute).with(app).and_call_original
+
+      first = described_class.fetch(app)
+      second = described_class.fetch(app)
+
+      expect(first).to eq(context)
+      expect(second).to eq({ routes: { total_routes: 3 } })
+      expect(RailsAiBridge).to have_received(:introspect).with(app).twice
+      expect(RailsAiBridge::Fingerprinter).to have_received(:snapshot).with(app).twice
+    end
+  end
+
+  describe ".fetch_section" do
+    it "builds only the requested section when it is not cached yet" do
+      schema_context = { app_name: "Demo", schema: { tables: { "users" => {} } } }
+
+      allow(RailsAiBridge).to receive(:introspect).and_call_original
+      allow_any_instance_of(RailsAiBridge::Introspector).to receive(:call).with(only: [ :schema ]).and_return(schema_context)
+      allow(RailsAiBridge::Fingerprinter).to receive(:snapshot).with(app).and_return(fingerprint)
+
+      result = described_class.fetch_section(:schema, app)
+
+      expect(result).to eq(schema_context[:schema])
+    end
+
+    it "reuses the cached section while ttl is valid and fingerprint is unchanged" do
+      schema_context = { app_name: "Demo", schema: { tables: { "users" => {} } } }
+
+      allow_any_instance_of(RailsAiBridge::Introspector).to receive(:call).with(only: [ :schema ]).and_return(schema_context)
+      allow(RailsAiBridge::Fingerprinter).to receive(:snapshot).with(app).and_return(fingerprint)
+
+      first = described_class.fetch_section(:schema, app)
+      second = described_class.fetch_section(:schema, app)
+
+      expect(first).to eq(schema_context[:schema])
+      expect(second).to eq(schema_context[:schema])
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/extensibility_integration_spec.rb
+++ b/spec/lib/rails_ai_bridge/extensibility_integration_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "RailsAiBridge extensibility integration" do
+  let(:custom_introspector) do
+    Class.new do
+      def initialize(_app); end
+
+      def call
+        {
+          enabled: true,
+          items: [ "alpha", "beta" ]
+        }
+      end
+    end
+  end
+
+  let(:custom_tool) do
+    Class.new(RailsAiBridge::Tools::BaseTool) do
+      tool_name "rails_get_custom_context"
+      description "Returns custom extension context for integration testing."
+      input_schema(properties: {})
+
+      def self.call(server_context: nil)
+        data = cached_section(:custom)
+        text_response(data[:items].join(", "))
+      end
+    end
+  end
+
+  around do |example|
+    original_introspectors = RailsAiBridge.configuration.introspectors.dup
+    original_additional_introspectors = RailsAiBridge.configuration.additional_introspectors.dup
+    original_additional_tools = RailsAiBridge.configuration.additional_tools.dup
+    original_additional_resources = RailsAiBridge.configuration.additional_resources.dup
+    RailsAiBridge::ContextProvider.reset!
+    example.run
+  ensure
+    RailsAiBridge.configuration.introspectors = original_introspectors
+    RailsAiBridge.configuration.additional_introspectors = original_additional_introspectors
+    RailsAiBridge.configuration.additional_tools = original_additional_tools
+    RailsAiBridge.configuration.additional_resources = original_additional_resources
+    RailsAiBridge::ContextProvider.reset!
+  end
+
+  it "supports a custom introspector, tool, and resource working together" do
+    RailsAiBridge.configuration.additional_introspectors[:custom] = custom_introspector
+    RailsAiBridge.configuration.additional_tools << custom_tool
+    RailsAiBridge.configuration.additional_resources["rails://custom"] = {
+      name: "Custom",
+      description: "Custom extension resource",
+      mime_type: "application/json",
+      key: :custom
+    }
+
+    server = RailsAiBridge::Server.new(Rails.application).build
+    tool_response = custom_tool.call
+    resource_rows = RailsAiBridge::Resources.send(:handle_read, { uri: "rails://custom" })
+    resource_json = JSON.parse(resource_rows.first[:text])
+
+    expect(server.tools).to have_key("rails_get_custom_context")
+    expect(server.resources.map(&:uri)).to include("rails://custom")
+    expect(tool_response.content.first[:text]).to include("alpha, beta")
+    expect(resource_json).to eq({ "enabled" => true, "items" => [ "alpha", "beta" ] })
+  end
+end

--- a/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
+++ b/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::HttpTransportApp do
+  let(:transport) { instance_double(MCP::Server::Transports::StreamableHTTPTransport) }
+
+  around do |example|
+    saved_token = RailsAiBridge.configuration.http_mcp_token
+    example.run
+  ensure
+    RailsAiBridge.configuration.http_mcp_token = saved_token
+  end
+
+  describe ".build" do
+    it "returns 404 for non-MCP paths" do
+      app = described_class.build(transport: transport, path: "/mcp")
+
+      status, headers, body = app.call(Rack::MockRequest.env_for("/users"))
+
+      expect(status).to eq(404)
+      expect(headers["Content-Type"]).to eq("application/json")
+      expect(body.first).to include("Not found")
+    end
+
+    it "returns 401 when auth is configured and Authorization is missing" do
+      RailsAiBridge.configuration.http_mcp_token = "secret"
+      app = described_class.build(transport: transport, path: "/mcp")
+
+      status, headers, = app.call(Rack::MockRequest.env_for("/mcp", method: "POST"))
+
+      expect(status).to eq(401)
+      expect(headers["WWW-Authenticate"]).to include("Bearer")
+    end
+
+    it "delegates to the transport for authorized requests" do
+      RailsAiBridge.configuration.http_mcp_token = "secret"
+      allow(transport).to receive(:handle_request).and_return([ 200, {}, [ "OK" ] ])
+      app = described_class.build(transport: transport, path: "/mcp")
+
+      env = Rack::MockRequest.env_for(
+        "/mcp",
+        method: "POST",
+        "HTTP_AUTHORIZATION" => "Bearer secret"
+      )
+
+      status, = app.call(env)
+
+      expect(status).to eq(200)
+      expect(transport).to have_received(:handle_request)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspector_spec.rb
@@ -5,6 +5,15 @@ require "spec_helper"
 RSpec.describe RailsAiBridge::Introspector do
   let(:introspector) { described_class.new(Rails.application) }
 
+  around do |example|
+    original_introspectors = RailsAiBridge.configuration.introspectors.dup
+    original_additional = RailsAiBridge.configuration.additional_introspectors.dup
+    example.run
+  ensure
+    RailsAiBridge.configuration.introspectors = original_introspectors
+    RailsAiBridge.configuration.additional_introspectors = original_additional
+  end
+
   describe "#call" do
     it "returns a complete context hash" do
       result = introspector.call
@@ -41,6 +50,23 @@ RSpec.describe RailsAiBridge::Introspector do
         expect(schema[:tables]).to have_key("users")
         expect(schema[:tables]).to have_key("posts")
       end
+    end
+
+    it "supports configured custom introspectors" do
+      custom_introspector = Class.new do
+        def initialize(_app); end
+
+        def call
+          { custom: true }
+        end
+      end
+
+      RailsAiBridge.configuration.additional_introspectors[:custom] = custom_introspector
+      RailsAiBridge.configuration.introspectors = [ :custom ]
+
+      result = introspector.call
+
+      expect(result[:custom]).to eq({ custom: true })
     end
   end
 end

--- a/spec/lib/rails_ai_bridge/resources_config_resource_spec.rb
+++ b/spec/lib/rails_ai_bridge/resources_config_resource_spec.rb
@@ -21,4 +21,29 @@ RSpec.describe RailsAiBridge::Resources do
       expect(json).not_to have_key("credentials_keys")
     end
   end
+
+  describe "additional resources" do
+    around do |example|
+      saved_resources = RailsAiBridge.configuration.additional_resources.dup
+      example.run
+    ensure
+      RailsAiBridge.configuration.additional_resources = saved_resources
+    end
+
+    it "reads configured custom resources through the shared context provider" do
+      RailsAiBridge.configuration.additional_resources["rails://custom"] = {
+        name: "Custom",
+        description: "Custom resource",
+        mime_type: "application/json",
+        key: :custom
+      }
+      allow(RailsAiBridge::ContextProvider).to receive(:fetch_section).with(:custom).and_return({ "value" => 7 })
+
+      rows = described_class.send(:handle_read, { uri: "rails://custom" })
+      json = JSON.parse(rows.first[:text])
+
+      expect(json).to eq({ "value" => 7 })
+      expect(RailsAiBridge::ContextProvider).to have_received(:fetch_section).with(:custom)
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/tools/get_controllers_detail_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_controllers_detail_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe RailsAiBridge::Tools::GetControllers do
           strong_params: %w[title body]
         }
       }
-      allow(described_class).to receive(:cached_context).and_return({
-        controllers: { controllers: controllers }
+      allow(described_class).to receive(:cached_section).with(:controllers).and_return({
+        controllers: controllers
       })
     end
 
@@ -61,7 +61,7 @@ RSpec.describe RailsAiBridge::Tools::GetControllers do
     end
 
     it "handles missing controllers gracefully" do
-      allow(described_class).to receive(:cached_context).and_return({})
+      allow(described_class).to receive(:cached_section).with(:controllers).and_return(nil)
       result = described_class.call(detail: "summary")
       text = result.content.first[:text]
       expect(text).to include("not available")

--- a/spec/lib/rails_ai_bridge/tools/get_model_details_detail_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_model_details_detail_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RailsAiBridge::Tools::GetModelDetails do
           validations: []
         }
       }
-      allow(described_class).to receive(:cached_context).and_return({ models: models })
+      allow(described_class).to receive(:cached_section).with(:models).and_return(models)
     end
 
     it "returns names only with detail:summary" do
@@ -60,7 +60,7 @@ RSpec.describe RailsAiBridge::Tools::GetModelDetails do
     end
 
     it "handles missing models gracefully" do
-      allow(described_class).to receive(:cached_context).and_return({})
+      allow(described_class).to receive(:cached_section).with(:models).and_return(nil)
       result = described_class.call(detail: "summary")
       text = result.content.first[:text]
       expect(text).to include("not available")

--- a/spec/lib/rails_ai_bridge/tools/get_routes_detail_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_routes_detail_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe RailsAiBridge::Tools::GetRoutes do
           { verb: "GET", path: "/api/v1/items", action: "index", name: "api_v1_items" }
         ]
       }
-      allow(described_class).to receive(:cached_context).and_return({
-        routes: { total_routes: 6, by_controller: by_controller, api_namespaces: [ "api/v1" ] }
-      })
+      allow(described_class).to receive(:cached_section).with(:routes).and_return(
+        { total_routes: 6, by_controller: by_controller, api_namespaces: [ "api/v1" ] }
+      )
     end
 
     it "returns summary with route counts per controller" do
@@ -71,7 +71,7 @@ RSpec.describe RailsAiBridge::Tools::GetRoutes do
     end
 
     it "handles missing routes gracefully" do
-      allow(described_class).to receive(:cached_context).and_return({})
+      allow(described_class).to receive(:cached_section).with(:routes).and_return(nil)
       result = described_class.call(detail: "summary")
       text = result.content.first[:text]
       expect(text).to include("not available")

--- a/spec/lib/rails_ai_bridge/tools/get_schema_detail_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_schema_detail_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe RailsAiBridge::Tools::GetSchema do
           foreign_keys: []
         }
       end
-      allow(described_class).to receive(:cached_context).and_return({
-        schema: { adapter: "postgresql", tables: tables, total_tables: 50 }
-      })
+      allow(described_class).to receive(:cached_section).with(:schema).and_return(
+        { adapter: "postgresql", tables: tables, total_tables: 50 }
+      )
     end
 
     it "returns compact summary with detail:summary" do
@@ -56,16 +56,14 @@ RSpec.describe RailsAiBridge::Tools::GetSchema do
     end
 
     it "handles missing schema gracefully" do
-      allow(described_class).to receive(:cached_context).and_return({})
+      allow(described_class).to receive(:cached_section).with(:schema).and_return(nil)
       result = described_class.call(detail: "summary")
       text = result.content.first[:text]
       expect(text).to include("not available")
     end
 
     it "handles schema error gracefully" do
-      allow(described_class).to receive(:cached_context).and_return({
-        schema: { error: "no database" }
-      })
+      allow(described_class).to receive(:cached_section).with(:schema).and_return({ error: "no database" })
       result = described_class.call(detail: "summary")
       text = result.content.first[:text]
       expect(text).to include("no database")

--- a/spec/lib/rails_ai_bridge/tools_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe "MCP Tool Integration" do
   describe "MCP::Server" do
     let(:server) { RailsAiBridge::Server.new(Rails.application).build }
 
+    around do |example|
+      original_tools = RailsAiBridge.configuration.additional_tools.dup
+      original_resources = RailsAiBridge.configuration.additional_resources.dup
+      example.run
+    ensure
+      RailsAiBridge.configuration.additional_tools = original_tools
+      RailsAiBridge.configuration.additional_resources = original_resources
+    end
+
     it "builds with all tools registered" do
       expect(server.tools.size).to eq(9)
       expect(server.tools.keys).to contain_exactly(
@@ -55,6 +64,38 @@ RSpec.describe "MCP Tool Integration" do
         "rails://migrations",
         "rails://engines"
       )
+    end
+
+    it "registers additional tools from configuration" do
+      extra_tool = Class.new(RailsAiBridge::Tools::BaseTool) do
+        tool_name "rails_extra_tool"
+        description "Extra tool for testing"
+        input_schema(type: "object", properties: {})
+
+        def self.call(**)
+          text_response("ok")
+        end
+      end
+
+      RailsAiBridge.configuration.additional_tools << extra_tool
+
+      built = RailsAiBridge::Server.new(Rails.application).build
+
+      expect(built.tools).to have_key("rails_extra_tool")
+    end
+
+    it "registers additional resources from configuration" do
+      RailsAiBridge.configuration.additional_resources["rails://custom"] = {
+        name: "Custom",
+        description: "Custom resource",
+        mime_type: "application/json",
+        key: :custom
+      }
+
+      built = RailsAiBridge::Server.new(Rails.application).build
+      uris = built.resources.map(&:uri)
+
+      expect(uris).to include("rails://custom")
     end
   end
 end


### PR DESCRIPTION
Add explicit extension registries, shared section-aware context caching, and folder-level docs so host apps can extend rails-ai-bridge without patching core internals and MCP reads stay aligned.

Made-with: Cursor