### PR TITLE
New process of installation and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Optional in-process MCP HTTP rate limit** — `config.mcp.rate_limit_max_requests` and `config.mcp.rate_limit_window_seconds` throttle requests per client IP (via `Rack::Request#ip`) before auth; JSON **429** with optional `Retry-After`. Per Ruby process only; `nil` / `0` max disables.
+- **`RailsAiBridge::Mcp` HTTP auth layer** — `Mcp::HttpAuth.authenticate`, `Mcp::AuthResult`, and `Mcp::Auth::Strategies::BearerToken` orchestrate static Bearer secrets (same digest-compare behavior as before). `McpHttpAuth.authorized_request?` delegates to `Mcp::HttpAuth`; successful static-token auth sets `env["rails_ai_bridge.mcp.context"]` to `:static_bearer`.
+- **`Mcp::Auth::Strategies::Jwt`** — `config.mcp.auth.jwt_decoder = ->(token) { ... }` with `strategy :jwt` or auto when decoder is set; no JWT gem dependency in the bridge (host supplies decode). Decoder exceptions → `:decode_error` (401), not 500.
+- **`config.mcp`** — `RailsAiBridge::Mcp::Settings` via `configuration.mcp`: `auth_configure` for `token_resolver` / `jwt_decoder` / `strategy`, optional `authorize` hook (HTTP 403 when falsey after auth), `require_auth_in_production` (boot check in production when no auth mechanism). `RailsAiBridge.mcp_auth_mechanism_configured?` includes static token, resolver, or JWT decoder for production HTTP / auto_mount guards.
+- **`McpHttpAuth.forbidden_rack_response`** — JSON 403 for failed authorization after successful authentication.
+- **`UPGRADING.md`** — starting notes for MCP config and `require_auth_in_production`.
 - **Install preferences** — `config/rails_ai_bridge/install.yml` controls which formats `rails ai:bridge` regenerates; `rails ai:bridge:all` writes every format including JSON.
 - **Presets and categories** — optional `:large_monolith` and `:regulated` presets plus `disabled_introspection_categories` for product-level introspector groups; `excluded_tables` (with glob `*`) aligns schema/model output for files and MCP.
 - **Copilot merge policy** — managed HTML-comment region in `.github/copilot-instructions.md` with `RAILS_AI_BRIDGE_COPILOT_MERGE` (`overwrite` / `skip`) documented in SECURITY.
@@ -22,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MCP HTTP rate limit** — Per-IP buckets with no timestamps left in the window are removed from the in-memory table to limit growth from idle clients; GUIDE / SECURITY clarify `request.ip` / trusted proxies, snapshot-at-`build` behavior, and many-IP abuse. `Retry-After` still uses a `60`s window when `rate_limit_window_seconds` is not positive.
+- **MCP docs** — GUIDE / SECURITY / UPGRADING cover Rack `env` PII risk, `nil` vs `false` from resolvers/decoders, and `:bearer_token` boot validation.
+- **CONTRIBUTING** — note to always use `bundle exec rspec` (bare `rspec` can hit `Combustion::Bundler` / wrong gem set).
 - **Documentation and install UX** — README / GUIDE emphasize `:development` install, HTTP `/mcp` risk, `install.yml`, and JSON workflow; `post_install_message` reinforces the same.
 - **Install generator** — `--assistants`, `--non-interactive`, HTTP security block in initializer, and initial `generate_context(format: :install)`.
 - **Install generator messages** — the install flow now reports created vs unchanged files correctly and the generated initializer comments reflect the current preset sizes.
@@ -29,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`strategy :bearer_token` misconfiguration** — Boot raises `ConfigurationError` when `:bearer_token` is set without `token_resolver` and without static `http_mcp_token` / env token, avoiding an accidentally open HTTP MCP endpoint.
+- **Resolver / JWT `false` return** — `token_resolver` or `jwt_decoder` returning `false` is treated as auth failure (`:unauthorized`), same as `nil`.
+- **`config.mcp.auth.token_resolver` errors** — Exceptions raised inside the resolver lambda are rescued; HTTP MCP auth returns a failed `AuthResult` with `:resolver_error` instead of bubbling a 500.
 - **Install generator output bug** — `generate_context` results are no longer iterated as raw hash pairs during install-time file generation.
 
 ## [1.1.0] - 2026-03-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Optional in-process MCP HTTP rate limit** — `config.mcp.rate_limit_max_requests` and `config.mcp.rate_limit_window_seconds` throttle requests per client IP (via `Rack::Request#ip`) before auth; JSON **429** with optional `Retry-After`. Per Ruby process only; `nil` / `0` max disables.
+- **`Mcp::HttpStructuredLog`** — opt-in `config.mcp.http_log_json`: one JSON line per MCP HTTP response (`event`, `http_status`, `path`, `client_ip`, optional `request_id`); no Bearer tokens logged.
+- **Optional in-process MCP HTTP rate limit** — per client IP (via `Rack::Request#ip`) before auth; JSON **429** with optional `Retry-After`. Per Ruby process. Explicit **`0`** disables; **`nil`** uses `security_profile` unless `mode` suppresses (`dev` off; `hybrid` only in `Rails.env.production?`; `production` always on). Profiles: `:strict` 60, `:balanced` 300, `:relaxed` 1200 per window (default window `60`s, `<= 0` → `60`).
 - **`RailsAiBridge::Mcp` HTTP auth layer** — `Mcp::HttpAuth.authenticate`, `Mcp::AuthResult`, and `Mcp::Auth::Strategies::BearerToken` orchestrate static Bearer secrets (same digest-compare behavior as before). `McpHttpAuth.authorized_request?` delegates to `Mcp::HttpAuth`; successful static-token auth sets `env["rails_ai_bridge.mcp.context"]` to `:static_bearer`.
 - **`Mcp::Auth::Strategies::Jwt`** — `config.mcp.auth.jwt_decoder = ->(token) { ... }` with `strategy :jwt` or auto when decoder is set; no JWT gem dependency in the bridge (host supplies decode). Decoder exceptions → `:decode_error` (401), not 500.
 - **`config.mcp`** — `RailsAiBridge::Mcp::Settings` via `configuration.mcp`: `auth_configure` for `token_resolver` / `jwt_decoder` / `strategy`, optional `authorize` hook (HTTP 403 when falsey after auth), `require_auth_in_production` (boot check in production when no auth mechanism). `RailsAiBridge.mcp_auth_mechanism_configured?` includes static token, resolver, or JWT decoder for production HTTP / auto_mount guards.
@@ -28,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **MCP HTTP rate limit** — Per-IP buckets with no timestamps left in the window are removed from the in-memory table to limit growth from idle clients; GUIDE / SECURITY clarify `request.ip` / trusted proxies, snapshot-at-`build` behavior, and many-IP abuse. `Retry-After` still uses a `60`s window when `rate_limit_window_seconds` is not positive.
+- **MCP HTTP rate limit** — Per-IP buckets with no timestamps left in the window are removed from the in-memory table to limit growth from idle clients; GUIDE / SECURITY / UPGRADING document `mode`, `security_profile`, implicit `nil` max, snapshot-at-`build` for the limiter vs live `http_log_json`. `Retry-After` still uses a `60`s window when `rate_limit_window_seconds` is not positive.
+- **MCP HTTP polish** — `mode` / `security_profile` nil-safe (default to `:hybrid` / `:balanced`); structured log `event` serialized as string; YARD clarifies limiter snapshot vs per-request `http_log_json`.
 - **MCP docs** — GUIDE / SECURITY / UPGRADING cover Rack `env` PII risk, `nil` vs `false` from resolvers/decoders, and `:bearer_token` boot validation.
 - **CONTRIBUTING** — note to always use `bundle exec rspec` (bare `rspec` can hit `Combustion::Bundler` / wrong gem set).
 - **Documentation and install UX** — README / GUIDE emphasize `:development` install, HTTP `/mcp` risk, `install.yml`, and JSON workflow; `post_install_message` reinforces the same.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Install preferences** — `config/rails_ai_bridge/install.yml` controls which formats `rails ai:bridge` regenerates; `rails ai:bridge:all` writes every format including JSON.
+- **Presets and categories** — optional `:large_monolith` and `:regulated` presets plus `disabled_introspection_categories` for product-level introspector groups; `excluded_tables` (with glob `*`) aligns schema/model output for files and MCP.
+- **Copilot merge policy** — managed HTML-comment region in `.github/copilot-instructions.md` with `RAILS_AI_BRIDGE_COPILOT_MERGE` (`overwrite` / `skip`) documented in SECURITY.
+- **Stub override warning** — visible warning when `overrides.md` still has the install `omit-merge` marker.
 - **Shared runtime context provider** — MCP tools and `rails://...` resources now read through `RailsAiBridge::ContextProvider`, keeping cache invalidation and snapshot semantics aligned across both entry points.
 - **Explicit extension registries** — `config.additional_introspectors`, `config.additional_tools`, and `config.additional_resources` allow host apps or companion gems to extend the built-ins without patching core constants.
 - **HTTP transport Rack builder** — `RailsAiBridge::HttpTransportApp` centralizes HTTP MCP request handling for both standalone server mode and middleware auto-mount.
@@ -18,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Documentation and install UX** — README / GUIDE emphasize `:development` install, HTTP `/mcp` risk, `install.yml`, and JSON workflow; `post_install_message` reinforces the same.
+- **Install generator** — `--assistants`, `--non-interactive`, HTTP security block in initializer, and initial `generate_context(format: :install)`.
 - **Install generator messages** — the install flow now reports created vs unchanged files correctly and the generated initializer comments reflect the current preset sizes.
 - **Fingerprint reuse on invalidation** — context refresh reuses a single fingerprint snapshot per fetch cycle instead of scanning twice when cached context becomes stale.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ bundle exec rubocop --parallel
 
 The test suite uses [Combustion](https://github.com/pat/combustion) to boot a minimal Rails app in `spec/internal/`. No external database required — tests run against an in-memory SQLite database.
 
+**Always run tests with `bundle exec rspec`.** Invoking plain `rspec` from your PATH can load the wrong gem set and fail at boot with errors such as `uninitialized constant Combustion::Bundler`.
+
 ## Project Structure
 
 ```
@@ -57,6 +59,8 @@ bundle exec rspec              # Full test suite
 bundle exec rspec spec/lib/    # Just lib specs
 bundle exec rubocop --parallel # Lint check
 ```
+
+Do not rely on bare `rspec`; see the note under Development Setup above.
 
 ## Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ flowchart LR
   app --> intro --> mcp --> clients
 ```
 
-1. **Up to 27 introspectors** scan schema, models, routes, controllers, jobs, gems, conventions, and more (preset `:standard` runs 9 core ones by default; `:full` runs all).
-2. **`rails ai:bridge`** writes bounded bridge files for Claude, Cursor, Copilot, Codex, Windsurf, and JSON.
+1. **Up to 27 introspectors** scan schema, models, routes, controllers, jobs, gems, conventions, and more (preset `:standard` runs 9 core ones by default; optional `:large_monolith` / `:regulated` tweak scope; `:full` runs all).
+2. **`rails ai:bridge`** writes bounded bridge files according to **`config/rails_ai_bridge/install.yml`** (from the generator). **`rails ai:bridge:all`** writes Claude, Codex, Cursor, Windsurf, Copilot, and **JSON** in one go.
 3. **`rails ai:serve`** exposes **9 MCP tools** so assistants pull detail on demand (`detail: "summary"` first, then drill down).
 
 ### Folder guides
@@ -50,10 +50,20 @@ For contributors, key folders now include local `README.md` guides:
 
 ## Quick start
 
+**Recommended:** put **rails-ai-bridge** in the **`development`** group so production images and `bundle install --without development` workflows do not ship the gem to production unless you want it there:
+
+```ruby
+group :development do
+  gem "rails-ai-bridge"
+end
+```
+
+A top-level `gem "rails-ai-bridge"` (outside `:development`) is installed for **all** groups, including production, when Bundler resolves the default set — fine if you deliberately need it in prod, but most apps should not.
+
 **From RubyGems** (once published):
 
 ```bash
-bundle add rails-ai-bridge
+bundle add rails-ai-bridge --group development
 rails generate rails_ai_bridge:install
 rails ai:bridge
 ```
@@ -61,27 +71,21 @@ rails ai:bridge
 **From GitHub** (before or alongside RubyGems):
 
 ```bash
-bundle add rails-ai-bridge --github=igmarin/rails-ai-bridge
+bundle add rails-ai-bridge --group development --github=igmarin/rails-ai-bridge
 rails generate rails_ai_bridge:install
 rails ai:bridge
 ```
 
-Or add to your `Gemfile`:
-
-```ruby
-gem "rails-ai-bridge", github: "igmarin/rails-ai-bridge"
-```
-
-Then `bundle install`, run the generator, and `rails ai:bridge` as above.
+Or add the `gem` line inside `:development` in your `Gemfile`, then `bundle install`, run the generator, and `rails ai:bridge`.
 
 Optional: `gem install rails-ai-bridge` installs the gem into your Ruby environment; you still add it to the app’s `Gemfile` for a Rails project.
 
-The install generator creates **`.mcp.json`** (MCP auto-discovery) and generates **`AGENTS.md`** (and other assistant files) when you run `rails ai:bridge`.
+The install generator creates **`.mcp.json`**, **`config/rails_ai_bridge/install.yml`** (which assistants `rails ai:bridge` regenerates by default), and runs an initial `rails ai:bridge`. Use **`rails ai:bridge:all`** to regenerate **every** format (including JSON), ignoring `install.yml`.
 
 ### Verify the integration in *your* Rails app
 
 1. **`bundle install` must finish cleanly** — until it does, `bundle exec rails -T` and `rails ai:serve` (from `.mcp.json`) cannot be verified. Merging this gem to `main` does not fix a broken or incomplete bundle on the host app.
-2. **Regenerate in one shot** — run `rails ai:bridge` (not only a single format) so route/controller summaries stay consistent across `CLAUDE.md`, `.cursor/rules/`, and `.github/instructions/`.
+2. **Regenerate the set you use** — run `rails ai:bridge` so files listed in `install.yml` stay consistent. Use `rails ai:bridge:all` when you need every format (including `.ai-context.json`) in one shot, e.g. CI or a full team refresh.
 3. **Keep team-specific rules** — generated files are snapshots. Use **`config/rails_ai_bridge/overrides.md`** for org-specific constraints (merged only after you **delete the first-line** `<!-- rails-ai-bridge:omit-merge -->` stub). Until then, the gem does not inject placeholder text into Copilot/Codex. See **`overrides.md.example`** for an outline. Alternatively re-merge into generated files after each `rails ai:bridge` (see `.codex/README.md`).
 4. **Tune list sizes** — `RailsAiBridge.configure { |c| c.copilot_compact_model_list_limit = 5 }` (and `codex_compact_model_list_limit`); set `0` to list no model names and point only to MCP.
 
@@ -301,13 +305,22 @@ Codex support is centered on **`AGENTS.md`** at the repository root.
 
 ---
 
+## JSON snapshot (`.ai-context.json`)
+
+`rails ai:bridge:json` writes structured context for scripts or CI. It is **not** part of the default `install.yml` selection unless you add `json` there. Use **`rails ai:bridge:all`** when you want JSON alongside every markdown artifact in one command.
+
+---
+
 ## Configuration
 
 ```ruby
 # config/initializers/rails_ai_bridge.rb
 RailsAiBridge.configure do |config|
-  # Presets: :standard (9 introspectors, default) or :full (all 27)
+  # Presets: :standard (default), :full (all 27), :large_monolith, :regulated
   config.preset = :standard
+
+  # Product-level groups to subtract from the preset (see GUIDE for mapping)
+  # config.disabled_introspection_categories += %i[domain_metadata]
 
   # Cherry-pick on top of a preset
   # config.introspectors += %i[views turbo auth api]
@@ -315,8 +328,9 @@ RailsAiBridge.configure do |config|
   # Context mode: :compact (≤150 lines, default) or :full (dump everything)
   # config.context_mode = :compact
 
-  # Exclude models from introspection
+  # Exclude models / tables from schema + model introspection (tables: exact or glob with *)
   config.excluded_models += %w[AdminUser InternalAuditLog]
+  # config.excluded_tables += %w[credit_cards raw_pii_*]
 
   # Exclude paths from code search
   config.excluded_paths += %w[vendor/bundle]
@@ -331,12 +345,14 @@ end
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `preset` | `:standard` | Introspector preset (`:standard` or `:full`) |
-| `introspectors` | 9 core | Array of introspector symbols |
+| `preset` | `:standard` | `:standard`, `:full`, `:large_monolith`, or `:regulated` |
+| `disabled_introspection_categories` | `[]` | Subtract introspector groups (`:domain_metadata`, `:persistence_surface`, `:api_surface`, `:ui_stack`) |
+| `introspectors` | from preset | Array of introspector symbols (`effective_introspectors` applies preset + categories) |
 | `context_mode` | `:compact` | `:compact` (≤150 lines) or `:full` (dump everything) |
 | `claude_max_lines` | `150` | Max lines for CLAUDE.md in compact mode |
 | `max_tool_response_chars` | `120_000` | Safety cap for MCP tool responses |
 | `excluded_models` | internal Rails models | Models to skip during introspection |
+| `excluded_tables` | `[]` | Table names to omit (glob with `*`) — applies to files **and** MCP schema/model tools |
 | `excluded_paths` | `node_modules tmp log vendor .git` | Paths excluded from code search |
 | `auto_mount` | `false` | Auto-mount HTTP MCP endpoint |
 | `allow_auto_mount_in_production` | `false` | Allow `auto_mount` in production (requires MCP token) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,7 @@ This fork is maintained by **Ismael Marin**. If you discover a security vulnerab
 - When **no** auth mechanism is configured, HTTP MCP is **unauthenticated** (backward compatible for local use); configure one of the above before exposing the port beyond localhost.
 - **Misconfiguration:** setting `strategy` to `:bearer_token` without a `token_resolver` and without a static MCP token causes **boot failure** (`ConfigurationError`) so the endpoint cannot start in an accidentally open state.
 - **Rate limiting:** optional `config.mcp.rate_limit_max_requests` is an **in-memory, per-process** sliding window keyed by client IP (as seen by `request.ip`). It is **not** shared across Puma workers or hosts. Empty per-IP buckets are dropped after timestamps expire to avoid unbounded growth from **idle** IPs; an attacker can still force **many distinct IPs within the window** (or spoof forwarded IPs if proxies are misconfigured), so treat this as a light guard—use a reverse proxy, WAF, or `rack-attack` for strict quotas.
+- **MCP HTTP JSON logs:** when `config.mcp.http_log_json` is enabled, log lines include **`client_ip`** and path; treat log sinks like any operational data store (retention, access control).
 
 ## Production
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,14 +33,17 @@ This fork is maintained by **Ismael Marin**. If you discover a security vulnerab
 
 ## HTTP MCP authentication
 
-- Set `config.http_mcp_token` and/or `ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]` (**ENV overrides** the config value when set).
-- When a token is configured, clients must send `Authorization: Bearer <token>` to the HTTP MCP endpoint (`auto_mount` or `rails ai:serve_http`).
-- When no token is configured, HTTP MCP is **unauthenticated** (backward compatible for local use); **set a token** before exposing the port beyond localhost.
+- **Shared secret:** set `config.http_mcp_token` and/or `ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]` (**ENV overrides** the config value when set). Clients send `Authorization: Bearer <token>`.
+- **Custom resolver / JWT:** you can instead configure `config.mcp.auth.token_resolver` or `config.mcp.auth.jwt_decoder` (see [docs/GUIDE.md](docs/GUIDE.md)); clients still use a Bearer header; the gem does not ship a JWT library—you verify and decode inside your lambda.
+- **Rack env context:** after a successful auth, `env["rails_ai_bridge.mcp.context"]` may contain **PII or claims** (e.g. JWT payload). Do not dump full Rack `env` to logs or APM; treat this key like session-derived data.
+- When **no** auth mechanism is configured, HTTP MCP is **unauthenticated** (backward compatible for local use); configure one of the above before exposing the port beyond localhost.
+- **Misconfiguration:** setting `strategy` to `:bearer_token` without a `token_resolver` and without a static MCP token causes **boot failure** (`ConfigurationError`) so the endpoint cannot start in an accidentally open state.
+- **Rate limiting:** optional `config.mcp.rate_limit_max_requests` is an **in-memory, per-process** sliding window keyed by client IP (as seen by `request.ip`). It is **not** shared across Puma workers or hosts. Empty per-IP buckets are dropped after timestamps expire to avoid unbounded growth from **idle** IPs; an attacker can still force **many distinct IPs within the window** (or spoof forwarded IPs if proxies are misconfigured), so treat this as a light guard—use a reverse proxy, WAF, or `rack-attack` for strict quotas.
 
 ## Production
 
-- `config.auto_mount = true` in **production** raises at boot unless **both** `config.allow_auto_mount_in_production = true` and a non-empty MCP token are set.
-- `rails ai:serve_http` in **production** requires a non-empty MCP token (config or ENV).
+- `config.auto_mount = true` in **production** raises at boot unless **both** `config.allow_auto_mount_in_production = true` and an MCP auth mechanism is configured (shared token, `token_resolver`, or `jwt_decoder`).
+- `rails ai:serve_http` in **production** requires the same class of auth configuration (not necessarily a static shared secret).
 
 ## Operational Security Guidance
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,3 +48,17 @@ This fork is maintained by **Ismael Marin**. If you discover a security vulnerab
 - If you enable HTTP transport, keep it bound to `127.0.0.1` unless you add your own network isolation and authentication controls.
 - Do **not** expose `auto_mount` on public or shared production surfaces without an explicit threat model review.
 - Treat generated files such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `.ai-context.json` as internal engineering documentation.
+
+## Copilot instructions file (`.github/copilot-instructions.md`)
+
+Regeneration wraps **gem-managed** content in HTML comment markers. Content **outside** those markers is left untouched when the markers already exist. If you have an **older** repo file **without** markers, `rails ai:bridge` **skips** overwriting that file by default so manual guidance is not destroyed. To replace the entire file from generated output, set:
+
+`RAILS_AI_BRIDGE_COPILOT_MERGE=overwrite`
+
+To skip writing Copilot instructions when you would otherwise overwrite:
+
+`RAILS_AI_BRIDGE_COPILOT_MERGE=skip`
+
+## Presets, exclusions, and MCP
+
+`rails_get_schema`, `rails_get_model_details`, and other tools build on the same introspection pipeline as `rails ai:bridge`. When you use **`config.excluded_tables`**, **`config.excluded_models`**, **`config.disabled_introspection_categories`**, or presets such as **`:regulated`**, treat the HTTP/stdio MCP surface with the **same data-classification assumptions** as your committed context files: the tools remain read-only but can still reveal structure you chose to omit from markdown.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,37 @@
+# Upgrading rails-ai-bridge
+
+This file will grow with major releases (especially 2.x). Early sections document new MCP configuration knobs.
+
+## `config.mcp.require_auth_in_production`
+
+When set to `true` in a **production** environment, Rails boot fails unless at least one MCP HTTP auth mechanism is configured:
+
+- `config.http_mcp_token`, or
+- `ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]`, or
+- `config.mcp.auth.token_resolver` (lambda that maps the raw Bearer string to a non-nil context), or
+- `config.mcp.auth.jwt_decoder` (lambda that returns a payload or `nil`; use your preferred JWT gem inside the lambda).
+
+Default is `false` (same effective behavior as before for apps that do not opt in).
+
+## `strategy :bearer_token`
+
+Rails **boot** raises `RailsAiBridge::ConfigurationError` if **all** of the following are true:
+
+- `config.mcp.auth.strategy == :bearer_token`
+- `config.mcp.auth.token_resolver` is blank
+- Neither `config.http_mcp_token` nor `ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]` is set
+
+That combination would leave HTTP MCP **unauthenticated**. Fix by adding a resolver or a static token.
+
+## Resolver / JWT return values
+
+Use **`nil`** (or let the gem treat **`false`** as failure) when a token is invalid. Returning `false` explicitly is treated the same as `nil` for auth failure (401).
+
+## `config.mcp` (overview)
+
+Inside `RailsAiBridge.configure`:
+
+- `config.mcp.auth_configure { |a| ... }` — set `a.strategy` (`:jwt`, `:bearer_token`, `:static_bearer`, or `nil` for auto), `a.token_resolver`, `a.jwt_decoder`, etc.
+- `config.mcp.authorize` — optional `->(context, request) { truthy }` after successful auth; returning falsey yields HTTP 403 on the MCP path.
+
+See [docs/GUIDE.md](docs/GUIDE.md) for full MCP HTTP documentation.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,3 +35,17 @@ Inside `RailsAiBridge.configure`:
 - `config.mcp.authorize` — optional `->(context, request) { truthy }` after successful auth; returning falsey yields HTTP 403 on the MCP path.
 
 See [docs/GUIDE.md](docs/GUIDE.md) for full MCP HTTP documentation.
+
+## MCP HTTP `mode`, `security_profile`, and rate limits
+
+When `config.mcp.rate_limit_max_requests` is **`nil`**, the gem may apply an **implicit** per-IP ceiling from `security_profile` (`:strict` / `:balanced` / `:relaxed`), unless `mode` suppresses it:
+
+- **`dev`** — no implicit limit.
+- **`hybrid`** (default) — implicit limit only when `Rails.env.production?` is true.
+- **`production`** — implicit limit in every Rails environment (useful to mimic prod throttling locally).
+
+Set **`config.mcp.rate_limit_max_requests = 0`** to **disable** limiting entirely (including implicit). A **positive integer** always overrides the profile.
+
+## MCP HTTP structured logging
+
+`config.mcp.http_log_json = true` emits **one JSON line per MCP HTTP response** (`msg` key `rails_ai_bridge.mcp.http`, plus `event`, `http_status`, `path`, `client_ip`, and `request_id` when present). Tokens and full Rack `env` are not logged. This flag is read **on each request** (unlike the rate-limit snapshot at `HttpTransportApp.build`).

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -678,18 +678,32 @@ RailsAiBridge.configure do |config|
   # Opt-in: in production, boot fails if no token / ENV / token_resolver / jwt_decoder (see UPGRADING.md)
   # config.mcp.require_auth_in_production = true
 
-  # Optional: per-IP sliding window inside this Ruby process (429 + Retry-After); nil/0 disables
+  # HTTP MCP mode (implicit rate limit when max is nil — see below)
+  # config.mcp.mode = :hybrid       # default: implicit limit only in Rails.env.production?
+  # config.mcp.mode = :dev          # never apply implicit limit from security_profile
+  # config.mcp.mode = :production   # always apply implicit limit from security_profile (even in dev)
+
+  # Implicit ceilings when rate_limit_max_requests is nil (requests per rate_limit_window_seconds, per IP)
+  # config.mcp.security_profile = :strict    # 60 per window (default window 60s)
+  # config.mcp.security_profile = :balanced  # 300 per window (default)
+  # config.mcp.security_profile = :relaxed   # 1200 per window
+
+  # Explicit override: positive integer = cap; 0 = off (disables implicit profile too)
   # config.mcp.rate_limit_max_requests = 300
-  # config.mcp.rate_limit_window_seconds = 60
+  # config.mcp.rate_limit_window_seconds = 60   # <= 0 falls back to 60
+
+  # One JSON log line per MCP HTTP response (path, client_ip, event, http_status); default off
+  # config.mcp.http_log_json = true
 end
 ```
 
 With `token_resolver` or JWT, successful auth sets `env["rails_ai_bridge.mcp.context"]` to the returned object or payload hash (not `:static_bearer`).
 
-**Rate limit:** When `rate_limit_max_requests` is a positive integer, the MCP HTTP Rack app counts requests per `request.ip` in a sliding window of `rate_limit_window_seconds` (default `60`; values `<= 0` fall back to `60`). Excess requests get **429** JSON (`Too Many Requests`) before Bearer auth runs. Limits are **not** shared across multiple processes or servers—see [SECURITY.md](../SECURITY.md).
+**Rate limit:** The effective cap is `config.mcp.effective_http_rate_limit_max_requests` (used by `HttpTransportApp`). A **positive** `rate_limit_max_requests` always wins. **`0`** turns limiting off. **`nil`** uses `security_profile` defaults **unless** `mode` suppresses them: **`dev`** never applies an implicit limit; **`hybrid`** applies them only when `Rails.env.production?` is true; **`production`** always applies them. Defaults: `:strict` → 60, `:balanced` → 300, `:relaxed` → 1200 requests per `rate_limit_window_seconds` (default `60`; values `<= 0` fall back to `60`). Excess requests get **429** before Bearer auth. Limits are **not** shared across processes or servers—see [SECURITY.md](../SECURITY.md).
 
 - **Client IP:** The limiter uses Rack’s `request.ip` (same rules as your app behind a reverse proxy). Configure **trusted proxies** in Rails (`config.action_dispatch.trusted_proxies` / `request.remote_ip`) so `X-Forwarded-For` is not spoofed from the public internet.
-- **When settings apply:** `HttpTransportApp.build` snapshots `rate_limit_*` when the Rack app is built (e.g. middleware memoizes that app). Changing `config.mcp.rate_limit_*` at runtime does not affect an already-built app until it is rebuilt (e.g. full restart).
+- **When rate-limit settings apply:** `HttpTransportApp.build` snapshots the **limiter** from `effective_http_rate_limit_max_requests` / `effective_http_rate_limit_window_seconds` at build time (e.g. middleware memoizes the app). Changing `rate_limit_*`, `mode`, or `security_profile` at runtime does not change an already-built app until restart/rebuild.
+- **Structured logging:** `http_log_json` is read **on each request** (no rebuild needed). Lines include `client_ip`; do not enable log forwarding to untrusted sinks without reviewing retention—see [SECURITY.md](../SECURITY.md).
 
 ### Options reference
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -648,6 +648,49 @@ RailsAiBridge.configure do |config|
 end
 ```
 
+Static Bearer validation is implemented by `RailsAiBridge::Mcp::HttpAuth`, which delegates to a small strategy layer. When `config.http_mcp_token` or `ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]` is set and the client sends a matching `Authorization: Bearer` token, Rack `env["rails_ai_bridge.mcp.context"]` is set to `:static_bearer` for that request.
+
+**Rack context and PII:** On success, `env["rails_ai_bridge.mcp.context"]` holds the object or JWT payload your resolver/decoder returned. Treat it as **potentially sensitive** (user ids, emails, roles). Do not log the whole `env` in production middleware; use targeted fields if you must log.
+
+**Invalid tokens:** `token_resolver` and `jwt_decoder` should return **`nil`** for invalid or unknown tokens. Returning **`false`** is also treated as failure (401). Avoid returning `false` to mean “invalid” when `nil` is clearer.
+
+**Boot validation:** If you set `a.strategy = :bearer_token`, you **must** also set `a.token_resolver` **or** configure `http_mcp_token` / `ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]`. Otherwise Rails raises `ConfigurationError` at boot—otherwise the HTTP MCP endpoint would be unauthenticated.
+
+**Extended configuration** (same initializer):
+
+```ruby
+RailsAiBridge.configure do |config|
+  config.mcp.auth_configure do |a|
+    # Pick one primary style (see resolution order in Mcp::HttpAuth):
+    # a.strategy = :static_bearer  # shared secret only (http_mcp_token / ENV)
+    # a.strategy = :bearer_token    # requires token_resolver OR static token (enforced at boot)
+    # a.strategy = :jwt             # jwt_decoder (any gem inside your lambda)
+    # a.strategy = nil              # auto: jwt_decoder if set, else token_resolver, else static token
+
+    a.token_resolver = ->(token) { User.find_by(api_token: token) } # StandardError → :resolver_error, not 500
+    # a.jwt_decoder = ->(token) { JWT.decode(token, key, true, { algorithm: "HS256" }).first rescue nil }
+    # StandardError from decoder → :decode_error (401), not 500
+  end
+
+  # Optional: avoid raising—return boolean; exceptions become 500
+  config.mcp.authorize = ->(context, request) { context.present? }
+
+  # Opt-in: in production, boot fails if no token / ENV / token_resolver / jwt_decoder (see UPGRADING.md)
+  # config.mcp.require_auth_in_production = true
+
+  # Optional: per-IP sliding window inside this Ruby process (429 + Retry-After); nil/0 disables
+  # config.mcp.rate_limit_max_requests = 300
+  # config.mcp.rate_limit_window_seconds = 60
+end
+```
+
+With `token_resolver` or JWT, successful auth sets `env["rails_ai_bridge.mcp.context"]` to the returned object or payload hash (not `:static_bearer`).
+
+**Rate limit:** When `rate_limit_max_requests` is a positive integer, the MCP HTTP Rack app counts requests per `request.ip` in a sliding window of `rate_limit_window_seconds` (default `60`; values `<= 0` fall back to `60`). Excess requests get **429** JSON (`Too Many Requests`) before Bearer auth runs. Limits are **not** shared across multiple processes or servers—see [SECURITY.md](../SECURITY.md).
+
+- **Client IP:** The limiter uses Rack’s `request.ip` (same rules as your app behind a reverse proxy). Configure **trusted proxies** in Rails (`config.action_dispatch.trusted_proxies` / `request.remote_ip`) so `X-Forwarded-For` is not spoofed from the public internet.
+- **When settings apply:** `HttpTransportApp.build` snapshots `rate_limit_*` when the Rack app is built (e.g. middleware memoizes that app). Changing `config.mcp.rate_limit_*` at runtime does not affect an already-built app until it is rebuilt (e.g. full restart).
+
 ### Options reference
 
 | Option | Type | Default | Description |

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -28,31 +28,46 @@
 
 ## Installation
 
+**Recommendation:** add **rails-ai-bridge** to the **`development`** group so production bundles do not include the gem unless you choose to:
+
+```ruby
+group :development do
+  gem "rails-ai-bridge"
+end
+```
+
+Top-level `gem "rails-ai-bridge"` is resolved for **all** groups (including production) under a normal `bundle install`.
+
 ### New project
 
 ```bash
-bundle add rails-ai-bridge
+bundle add rails-ai-bridge --group development
 rails generate rails_ai_bridge:install
 rails ai:bridge
 ```
 
 This creates:
-1. `config/initializers/rails_ai_bridge.rb` — configuration file
-2. `config/rails_ai_bridge/overrides.md` — stub (omit-merge line); `overrides.md.example` — outline (not merged)
-3. `.mcp.json` — MCP auto-discovery for MCP-capable clients
-4. Assistant-specific context files — including `AGENTS.md` for Codex
+1. `config/initializers/rails_ai_bridge.rb` — configuration file (see **HTTP SECURITY** comments for `/mcp`)
+2. `config/rails_ai_bridge/install.yml` — which assistant formats `rails ai:bridge` regenerates by default
+3. `config/rails_ai_bridge/overrides.md` — stub (omit-merge line); `overrides.md.example` — outline (not merged)
+4. `.mcp.json` — MCP auto-discovery for MCP-capable clients
+5. Assistant-specific context files — including `AGENTS.md` for Codex
 
 ### Existing project
 
-```bash
-# Add to Gemfile
-gem "rails-ai-bridge"
+```ruby
+# Gemfile — development group recommended
+group :development do
+  gem "rails-ai-bridge"
+end
+```
 
+```bash
 # Install
 bundle install
 rails generate rails_ai_bridge:install
 
-# Generate bridge files
+# Regenerate files listed in install.yml (default after install)
 rails ai:bridge
 
 # Verify everything works
@@ -62,10 +77,17 @@ rails ai:doctor
 ### What the install generator does
 
 1. Creates `.mcp.json` in project root (MCP auto-discovery)
-2. Creates `config/initializers/rails_ai_bridge.rb` with commented defaults
-3. Creates `config/rails_ai_bridge/overrides.md` (stub) and `overrides.md.example` when absent — remove the omit-merge line from `overrides.md` before real rules are merged
-4. Adds `.ai-context.json` to `.gitignore` (JSON cache — markdown files should be committed)
-5. Generates all bridge files
+2. Creates `config/initializers/rails_ai_bridge.rb` with commented defaults and a prominent HTTP `/mcp` security block
+3. Creates `config/rails_ai_bridge/install.yml` listing assistant formats (from `--assistants` or interactive prompt; `--non-interactive` uses a safe default set)
+4. Creates `config/rails_ai_bridge/overrides.md` (stub) and `overrides.md.example` when absent — remove the omit-merge line from `overrides.md` before real rules are merged
+5. Adds `.ai-context.json` to `.gitignore` (JSON cache — markdown files should be committed)
+6. Runs `rails ai:bridge` once using the `install.yml` selection
+
+### `install.yml` vs `rails ai:bridge:all`
+
+- **`rails ai:bridge`** — regenerates only the formats listed under `config/rails_ai_bridge/install.yml` (fast day-to-day workflow).
+- **`rails ai:bridge:all`** — regenerates **every** format in one run, including **JSON** (`.ai-context.json`), regardless of `install.yml`. Use for CI, onboarding, or when you temporarily need every artifact.
+- **`rails ai:bridge:json`** — writes `.ai-context.json` only; add `json` to `install.yml` if you want it on every `rails ai:bridge`.
 
 ---
 
@@ -78,6 +100,8 @@ The gem has two context modes that control how much data goes into the generated
 ```bash
 rails ai:bridge
 ```
+
+- Respects `config/rails_ai_bridge/install.yml` for which assistant files to touch (see [Installation](#installation)).
 
 - CLAUDE.md ≤150 lines
 - .windsurfrules ≤5,800 characters
@@ -127,7 +151,7 @@ end
 
 ## Generated Files
 
-`rails ai:bridge` generates **18+ files** across all AI assistants (counts include Codex and split rules).
+With **`rails ai:bridge:all`**, the gem can produce **18+ files** across assistants (counts include Codex and split rules). A normal **`rails ai:bridge`** only touches the subset configured in `config/rails_ai_bridge/install.yml`.
 
 ### Claude Code (4 files)
 
@@ -161,7 +185,7 @@ end
 
 | File | Purpose | Notes |
 |------|---------|-------|
-| `.github/copilot-instructions.md` | Repo-wide instructions | ≤500 lines in compact mode. Order: engineering rules → stack → optional `overrides.md` → performance + Rails patterns → short model list → MCP. |
+| `.github/copilot-instructions.md` | Repo-wide instructions | ≤500 lines in compact mode. Gem-managed content is wrapped in HTML comment markers so human text outside the block survives regeneration (see [SECURITY.md](../SECURITY.md)). |
 | `.github/instructions/rails-models.instructions.md` | Model context | `applyTo: app/models/**/*.rb` — loaded when editing models. |
 | `.github/instructions/rails-controllers.instructions.md` | Controller context | `applyTo: app/controllers/**/*.rb` — loaded when editing controllers. |
 | `.github/instructions/rails-mcp-tools.instructions.md` | MCP tool reference | `applyTo: **/*` — loaded everywhere. |
@@ -178,7 +202,9 @@ Commit **all files except `.ai-context.json`** (which is gitignored). This gives
 
 ### Repo-specific guidance (`config/rails_ai_bridge/overrides.md`)
 
-Optional markdown **merged verbatim** into compact `.github/copilot-instructions.md` and `AGENTS.md` under **Repo-specific guidance** when you run `rails ai:bridge` — **only after** you remove the install stub’s first line: `<!-- rails-ai-bridge:omit-merge -->`. While that line is the first non-empty line in the file, the gem treats overrides as inactive (no placeholder noise in generated files).
+Optional markdown **merged verbatim** into compact `.github/copilot-instructions.md` and `AGENTS.md` under **Repo-specific guidance** when you run `rails ai:bridge` — **only after** you remove the install stub’s first line: `<!-- rails-ai-bridge:omit-merge -->`. While that line is the first non-empty line in the file, the gem treats overrides as inactive (no placeholder noise in generated files), and generation may **warn** that the stub is still active.
+
+For Copilot, if `.github/copilot-instructions.md` exists **without** gem markers, `rails ai:bridge` **skips** overwriting it unless you set `RAILS_AI_BRIDGE_COPILOT_MERGE=overwrite` (or `skip` to never write that file). See [SECURITY.md](../SECURITY.md).
 
 - Use **`overrides.md.example`** as a starting outline (that file is never merged).
 - Override path: `config.assistant_overrides_path` (relative to `Rails.root` or absolute).
@@ -194,8 +220,9 @@ The same engineering baseline intentionally appears in Copilot, Codex, and Curso
 
 | Command | Mode | Format | Description |
 |---------|------|--------|-------------|
-| `rails ai:bridge` | compact | all | Generate all bridge files |
-| `rails ai:bridge:full` | full | all | Generate all files in full mode |
+| `rails ai:bridge` | compact | `install.yml` | Regenerate formats listed in `config/rails_ai_bridge/install.yml` |
+| `rails ai:bridge:all` | compact | all | Regenerate every assistant format + JSON (ignores `install.yml`) |
+| `rails ai:bridge:full` | full | all | Full context mode — writes **every** format (including JSON), same as compact `ai:bridge:all` but with `context_mode: :full` |
 | `rails ai:bridge:claude` | compact | Claude | CLAUDE.md + .claude/rules/ |
 | `rails ai:bridge:codex` | compact | Codex | AGENTS.md + .codex/README.md |
 | `rails ai:bridge:cursor` | compact | Cursor | .cursorrules + .cursor/rules/ |
@@ -567,8 +594,11 @@ Both transports are **read-only** — they expose the same 9 tools and never mod
 RailsAiBridge.configure do |config|
   # --- Introspectors ---
 
-  # Presets: :standard (9 core, default) or :full (all 27)
+  # Presets: :standard (9 core, default), :full (27), :large_monolith (MCP-first tuning), :regulated (minimal domain on disk)
   config.preset = :standard
+
+  # Subtract product-level groups from whatever the preset enables (see "Introspection categories" below)
+  # config.disabled_introspection_categories += %i[domain_metadata persistence_surface]
 
   # Cherry-pick on top of a preset
   config.introspectors += %i[views turbo auth api]
@@ -601,8 +631,9 @@ RailsAiBridge.configure do |config|
 
   # --- Exclusions ---
 
-  # Models to skip during introspection
+  # Models / tables to skip during introspection (tables: string name or glob with *)
   config.excluded_models += %w[AdminUser InternalAuditLog]
+  # config.excluded_tables += %w[user_secrets sensitive_*]
 
   # Paths to exclude from code search
   config.excluded_paths += %w[vendor/bundle]
@@ -621,13 +652,15 @@ end
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `preset` | Symbol | `:standard` | Introspector preset (`:standard` or `:full`) |
-| `introspectors` | Array | 9 core symbols | Which introspectors to run |
+| `preset` | Symbol | `:standard` | `:standard`, `:full`, `:large_monolith`, `:regulated` |
+| `disabled_introspection_categories` | Array | `[]` | Keys such as `:domain_metadata` that remove groups of introspectors (see below) |
+| `introspectors` | Array | from preset | Which introspectors to run (after preset + categories); use for advanced cherry-pick |
 | `context_mode` | Symbol | `:compact` | `:compact` or `:full` |
 | `claude_max_lines` | Integer | `150` | Max lines for CLAUDE.md in compact mode |
 | `max_tool_response_chars` | Integer | `120_000` | Safety cap for MCP tool responses |
 | `cache_ttl` | Integer | `30` | Cache TTL in seconds for introspection results |
 | `excluded_models` | Array | internal Rails models | Models to skip |
+| `excluded_tables` | Array | `[]` | Tables omitted from schema/model introspection (generated files **and** MCP tools) |
 | `excluded_paths` | Array | `node_modules tmp log vendor .git` | Paths excluded from code search |
 | `output_dir` | String | `nil` (Rails.root) | Where to write context files |
 | `auto_mount` | Boolean | `false` | Auto-mount HTTP MCP endpoint |
@@ -689,6 +722,33 @@ Includes all standard introspectors plus:
 ```ruby
 config.preset = :full
 ```
+
+### Optional presets: `:large_monolith` and `:regulated`
+
+- **`:large_monolith`** — same introspector *set* as `:standard`; intended for big apps that pair compact static files with MCP-first detail (tune `copilot_compact_model_list_limit` / `codex_compact_model_list_limit` in the initializer).
+- **`:regulated`** — runs a **smaller** introspector list (no `schema`, `models`, or `migrations` in the preset definition). Disk output and MCP tools share the same **`effective_introspectors`**; configuring this preset reduces both.
+
+Names are reflected in compact “intro snapshot” lines so assistants can tell which profile is active.
+
+### Introspection categories (`disabled_introspection_categories`)
+
+Instead of memorizing raw introspector symbols, you can disable **product-level** groups. Each key removes the listed introspectors from the active preset at runtime (union of all selected categories):
+
+| Category | Introspectors removed |
+|----------|------------------------|
+| `:domain_metadata` | `schema`, `models`, `migrations` |
+| `:persistence_surface` | `schema`, `models` |
+| `:api_surface` | `api` |
+| `:ui_stack` | `views`, `stimulus`, `turbo`, `i18n` |
+
+Example:
+
+```ruby
+config.preset = :standard
+config.disabled_introspection_categories << :domain_metadata
+```
+
+Advanced users can still use `config.introspectors +=` / `config.preset = :full` as before.
 
 ### Cherry-picking introspectors
 

--- a/docs/roadmap-context-assistants.md
+++ b/docs/roadmap-context-assistants.md
@@ -1,0 +1,20 @@
+# Roadmap: context files & assistant UX (pre–major release)
+
+This track is **separate** from [roadmap-mcp-v2.md](roadmap-mcp-v2.md) (MCP HTTP auth, rate limits, logging). It covers **improving the static context** the gem generates (CLAUDE.md, Cursor rules, Copilot instructions, etc.) so IDEs and AI clients get **clearer, more actionable** help from the same introspection data.
+
+**Progress summary:** [roadmaps.md](roadmaps.md).
+
+## Goals (high level)
+
+- Sharpen per-assistant formats (structure, length, cross-links) based on real usage feedback.
+- Reduce duplication and noise while keeping “always-on” rules discoverable.
+- Align tool references and workflow hints across Claude, Cursor, Copilot, Windsurf, Codex, etc.
+
+## Relation to versioning
+
+**No semver bump is implied by this doc alone.** A future **major release** (e.g. 2.0.0) should follow **after** this work (and MCP HTTP hardening) when the maintainers are ready to communicate breaking or wide-ranging changes to generated files and defaults—not as a fixed milestone on the MCP roadmap.
+
+## References
+
+- [docs/GUIDE.md](GUIDE.md) — install, formats, MCP setup
+- [CHANGELOG.md](../CHANGELOG.md) — user-visible changes

--- a/docs/roadmap-mcp-v2.md
+++ b/docs/roadmap-mcp-v2.md
@@ -21,13 +21,17 @@ These are **priorities** for code that lands under `lib/rails_ai_bridge/mcp/` an
 
 ## Done vs upcoming (snapshot)
 
-Already in tree (check `CHANGELOG.md`): `Mcp::HttpAuth`, `BearerToken`, `Jwt`, `config.mcp`, `authorize`, production validations, resolver/JWT error handling, `:bearer_token` boot guard, optional **in-process IP rate limit** on the MCP HTTP path (`Mcp::HttpRateLimiter`, `HttpTransportApp`).
+Already in tree (check `CHANGELOG.md`): `Mcp::HttpAuth`, `BearerToken`, `Jwt`, `config.mcp`, `authorize`, production validations, resolver/JWT error handling, `:bearer_token` boot guard, **in-process IP rate limit** (`Mcp::HttpRateLimiter`), **`mode` / `security_profile` implicit limits**, optional **JSON HTTP access lines** (`Mcp::HttpStructuredLog`, `config.mcp.http_log_json`).
 
-**Typical next slices:** structured logging, `security_profile` presets, release **2.0.0** consolidation (README upgrading, version bump, generator template).
+**Next (this track):** any follow-ups to MCP HTTP (e.g. log sampling, metrics hooks) as needed.
+
+**Separate plan (before a major release):** improve **generated context & assistant UX** — see [roadmap-context-assistants.md](roadmap-context-assistants.md). A **2.0.0** (or similar) release is **deferred** until after that work and maintainer-ready communication; it is not a current milestone on this MCP roadmap.
 
 ## References
 
+- [docs/roadmaps.md](roadmaps.md) — quick progress tables for both tracks (contributor-facing)
 - [docs/GUIDE.md](GUIDE.md) — MCP HTTP configuration
+- [docs/roadmap-context-assistants.md](roadmap-context-assistants.md) — IDE / context file improvements (pre–major release)
 - [SECURITY.md](../SECURITY.md) — threat model and production notes
 - [UPGRADING.md](../UPGRADING.md) — breaking / new config knobs
 - Contributor skills (Cursor / team): **`rails-principles-and-boundaries`**, **`yard-documentation`** — use both for MCP/auth work; they are intentionally paired in section 2 above.

--- a/docs/roadmap-mcp-v2.md
+++ b/docs/roadmap-mcp-v2.md
@@ -1,0 +1,33 @@
+# Roadmap: MCP HTTP auth (v2 track)
+
+High-level direction for the `RailsAiBridge::Mcp` HTTP authentication layer, rate limiting, and related docs. The detailed task list may live in your issue tracker or in Cursor plans; this file is the **human-readable** anchor for contributors.
+
+## Engineering principles (this track)
+
+These are **priorities** for code that lands under `lib/rails_ai_bridge/mcp/` and related Rack paths—not optional polish at the end.
+
+1. **Tests gate implementation** — Write or extend a failing spec for the behavior, run it, then implement (`rspec-best-practices`, `rails-agent-skills`). No “implement first, test later” for new behavior.
+
+2. **Principles and YARD go together** — Treat **`rails-principles-and-boundaries`** and **`yard-documentation`** as one bar for each slice that touches library code:
+   - **Behavior & structure:** **KISS**; **DRY** only when duplication has a real maintenance cost; **style** from the repo linter (e.g. RuboCop omakase)—do not restate linter rules in prose.
+   - **API documentation (same PR / same slice):** Any new or changed **public** Ruby surface (classes, public methods) needs **English** YARD: summary line plus `@param`, `@return`, and `@raise` when applicable—**before** the change is considered done, not in a follow-up ticket. Use `@example` when usage is non-obvious.
+   - **Private helpers:** Document when behavior is non-obvious (e.g. lambdas that must not raise, digest-normalized comparison for timing safety).
+
+3. **Clear method boundaries** — Keep Rack/guard logic separate from “run host lambda safely” (e.g. private `decode_token` / `resolve_token_context`) so strategies stay easy to read, review, and extend with new strategies without growing god methods.
+
+4. **Self-review before merge** — Run through `rails-code-review` (and security/architecture skills when touching auth or production boot). Confirm YARD on touched public API matches the **yard-documentation** gate.
+
+5. **User-facing documentation per slice** — Update `CHANGELOG` `[Unreleased]`, and touch `GUIDE` / `SECURITY` / `UPGRADING` when user-visible behavior changes.
+
+## Done vs upcoming (snapshot)
+
+Already in tree (check `CHANGELOG.md`): `Mcp::HttpAuth`, `BearerToken`, `Jwt`, `config.mcp`, `authorize`, production validations, resolver/JWT error handling, `:bearer_token` boot guard, optional **in-process IP rate limit** on the MCP HTTP path (`Mcp::HttpRateLimiter`, `HttpTransportApp`).
+
+**Typical next slices:** structured logging, `security_profile` presets, release **2.0.0** consolidation (README upgrading, version bump, generator template).
+
+## References
+
+- [docs/GUIDE.md](GUIDE.md) — MCP HTTP configuration
+- [SECURITY.md](../SECURITY.md) — threat model and production notes
+- [UPGRADING.md](../UPGRADING.md) — breaking / new config knobs
+- Contributor skills (Cursor / team): **`rails-principles-and-boundaries`**, **`yard-documentation`** — use both for MCP/auth work; they are intentionally paired in section 2 above.

--- a/docs/roadmaps.md
+++ b/docs/roadmaps.md
@@ -1,0 +1,45 @@
+# Roadmaps — progress index
+
+Entry point to see **which tracks exist** and **what is left**. Details live in each linked file; update the tables here when you close slices (or track work in GitHub Issues / Projects instead).
+
+**Audience:** These documents are mainly for **maintainers and contributors**. Gem users usually rely on [GUIDE.md](GUIDE.md), [CHANGELOG.md](../CHANGELOG.md), and the README. Keeping roadmaps **in git** is normal for open-source gems (transparency, onboarding); they are not required to *use* the gem.
+
+## MCP HTTP track (`RailsAiBridge::Mcp`)
+
+**Primary doc:** [roadmap-mcp-v2.md](roadmap-mcp-v2.md) (engineering principles + narrative snapshot).
+
+| Area | Status |
+|------|--------|
+| Auth (`HttpAuth`, Bearer, JWT, resolver, boot guards) | Done |
+| `authorize` + 403 | Done |
+| In-process rate limit + bucket prune | Done |
+| `mode` / `security_profile` + effective limits | Done |
+| JSON HTTP (`http_log_json`, `HttpStructuredLog`) | Done |
+| Docs (GUIDE / SECURITY / UPGRADING / CHANGELOG) for the above | Done |
+
+**Optional / follow-up (non-blocking):** log sampling, metrics hooks, heavier load testing, community-driven tweaks.
+
+---
+
+## Context files & assistants (pre–major release)
+
+**Primary doc:** [roadmap-context-assistants.md](roadmap-context-assistants.md).
+
+| Area | Status |
+|------|--------|
+| Goals (per-assistant formats, less noise, alignment) | Documented |
+| Concrete tasks per assistant / format | **TBD** (next step: break down into issues or subsections here) |
+| Major release (e.g. 2.0.0) | **Deferred** until this track + communication plan |
+
+---
+
+## Where to look in the repo
+
+| Need | File |
+|------|------|
+| Implementation rules (tests, YARD, docs per slice) | [roadmap-mcp-v2.md](roadmap-mcp-v2.md) § Engineering principles |
+| What the MCP stack already includes (narrative) | [roadmap-mcp-v2.md](roadmap-mcp-v2.md) § Done vs upcoming |
+| Plan for generated context (CLAUDE.md, rules, etc.) | [roadmap-context-assistants.md](roadmap-context-assistants.md) |
+| User-facing shipped / upcoming changes | [CHANGELOG.md](../CHANGELOG.md) `[Unreleased]` and version sections |
+
+If you use a **GitHub Project**, link it here in one line to avoid duplicating status in two places.

--- a/exe/rails-ai-bridge
+++ b/exe/rails-ai-bridge
@@ -21,7 +21,8 @@ module RailsAiBridge
     end
 
     desc "bridge", "Generate AI bridge files"
-    option :format, type: :string, default: "all", desc: "Format: claude, cursor, windsurf, copilot, json, all"
+    option :format, type: :string, default: "install",
+                     desc: "install (default, respects install.yml), all, claude, cursor, windsurf, copilot, json, codex"
     def bridge
       boot_rails!
       require "rails_ai_bridge"

--- a/lib/generators/rails_ai_bridge/install/install_generator.rb
+++ b/lib/generators/rails_ai_bridge/install/install_generator.rb
@@ -7,7 +7,11 @@ module RailsAiBridge
     class InstallGenerator < Rails::Generators::Base
       source_root File.expand_path("templates", __dir__)
 
-      desc "Install rails-ai-bridge: creates initializer, MCP config, and generates initial bridge files."
+      class_option :assistants, type: :string, default: nil,
+                                desc: "Comma-separated formats: claude,codex,cursor,windsurf,copilot,json (non-interactive)"
+      class_option :non_interactive, type: :boolean, default: false, desc: "Skip interactive prompts (default: all formats)"
+
+      desc "Install rails-ai-bridge: creates initializer, MCP config, install.yml, and generates initial bridge files."
 
       def create_mcp_config
         create_file ".mcp.json", JSON.pretty_generate({
@@ -25,52 +29,64 @@ module RailsAiBridge
       def create_initializer
         standard_count = RailsAiBridge::Configuration::PRESETS[:standard].size
         full_count = RailsAiBridge::Configuration::PRESETS[:full].size
+        regulated_count = RailsAiBridge::Configuration::PRESETS[:regulated].size
 
         create_file "config/initializers/rails_ai_bridge.rb", <<~RUBY
           # frozen_string_literal: true
 
           RailsAiBridge.configure do |config|
-            # Introspector preset:
-            #   :standard — #{standard_count} core introspectors (schema, models, routes, jobs, gems, conventions, controllers, tests, migrations)
-            #   :full     — all #{full_count} introspectors (adds views, turbo, auth, API, config, assets, devops, etc.)
+            # --- Introspector presets (optional; default is :standard / :compact) ---
+            # :standard — #{standard_count} core introspectors (schema, models, routes, jobs, gems, conventions, controllers, tests, migrations)
+            # :full     — all #{full_count} introspectors (views, turbo, auth, API, config, assets, devops, ...)
+            # :large_monolith — same slices as :standard; pair with codex/copilot compact model limits = 0 for MCP-first workflows
+            # :regulated — #{regulated_count} introspectors (no :schema, :models, :migrations) for less domain metadata on disk/MCP
             # config.preset = :standard
 
-            # Or cherry-pick individual introspectors:
+            # Or cherry-pick introspectors:
             # config.introspectors += %i[views turbo auth api]
 
-            # Models to exclude from introspection
-            # config.excluded_models += %w[AdminUser InternalThing]
+            # Optional: remove introspector groups via product categories (see INTROSPECTION_CATEGORY_INTROSPECTORS in the gem).
+            # config.disabled_introspection_categories << :domain_metadata
 
-            # Paths to exclude from code search
+            # Models / tables to exclude from introspection (tables support globs, e.g. "pii_*")
+            # config.excluded_models += %w[AdminUser InternalThing]
+            # config.excluded_tables += %w[legacy_import_raw]
+
+            # Paths excluded from rails_search_code
             # config.excluded_paths += %w[vendor/bundle]
 
-            # Context mode for generated files (CLAUDE.md, .cursorrules, etc.)
-            # :compact — smart, ≤150 lines, references MCP tools for details (default)
-            # :full    — dumps everything into context files (good for small apps <30 models)
+            # Context mode: :compact (default) or :full
             # config.context_mode = :compact
-
-            # Max lines for CLAUDE.md in compact mode
             # config.claude_max_lines = 150
-
-            # Max response size for MCP tool results (chars). Safety net for large apps.
             # config.max_tool_response_chars = 120_000
 
-            # Optional: path to markdown merged into compact Copilot + Codex (default: config/rails_ai_bridge/overrides.md).
-            # The install stub uses <!-- rails-ai-bridge:omit-merge --> on line 1 — delete it when adding real rules
-            # (until then nothing is merged). See config/rails_ai_bridge/overrides.md.example for an outline.
+            # Team rules merged into compact Copilot/Codex (remove omit-merge line when ready)
             # config.assistant_overrides_path = "config/rails_ai_bridge/overrides.md"
 
-            # Compact file model name caps (0 = MCP pointer only, no names listed)
+            # Compact model lists (0 = MCP pointer only)
             # config.copilot_compact_model_list_limit = 5
             # config.codex_compact_model_list_limit = 3
 
-            # Auto-mount HTTP MCP endpoint at /mcp (see SECURITY.md — production needs token + explicit opt-in)
+            # =============================================================================
+            # HTTP MCP / auto_mount — SECURITY CRITICAL
+            # =============================================================================
+            # auto_mount exposes read-only MCP tools over HTTP. They still reveal routes, schema,
+            # controllers, and code layout — treat as sensitive. Prefer stdio (`rails ai:serve`) for local AI clients.
+            #
+            # REQUIREMENTS:
+            # - Bind to 127.0.0.1 in development unless you add network + auth controls.
+            # - Production: set http_mcp_token (or ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]), allow_auto_mount_in_production = true,
+            #   and review SECURITY.md before enabling.
+            #
+            # Skimming this block is dangerous; read docs/GUIDE.md and SECURITY.md before turning auto_mount on.
+            # =============================================================================
             # config.auto_mount = false
             # config.allow_auto_mount_in_production = false
             # config.http_mcp_token = "generate-a-long-random-secret"
             # ENV["RAILS_AI_BRIDGE_MCP_TOKEN"] overrides http_mcp_token when set
             # config.http_path  = "/mcp"
-            # config.http_port  = 6029
+            # config.http_bind   = "127.0.0.1"
+            # config.http_port   = 6029
           end
         RUBY
 
@@ -97,6 +113,14 @@ module RailsAiBridge
         end
       end
 
+      def create_install_preferences
+        require "rails_ai_bridge"
+
+        formats = resolve_assistant_format_selection
+        AssistantFormatsPreference.write!(formats: formats)
+        say "Created #{AssistantFormatsPreference::RELATIVE_PATH} — `rails ai:bridge` targets: #{formats.join(", ")}", :green
+      end
+
       def add_to_gitignore
         gitignore = Rails.root.join(".gitignore")
         return unless File.exist?(gitignore)
@@ -121,7 +145,7 @@ module RailsAiBridge
 
         if Rails.application
           require "rails_ai_bridge"
-          result = RailsAiBridge.generate_context(format: :all)
+          result = RailsAiBridge.generate_context(format: :install)
           result[:written].each { |file| say "  Created #{file}", :green }
           result[:skipped].each { |file| say "  Unchanged #{file}", :blue }
         else
@@ -136,12 +160,13 @@ module RailsAiBridge
         say "=" * 50, :cyan
         say ""
         say "Quick start:", :yellow
-        say "  rails ai:bridge         # Generate all bridge files"
-        say "  rails ai:bridge:claude   # Generate CLAUDE.md only"
-        say "  rails ai:bridge:codex    # Generate AGENTS.md only"
-        say "  rails ai:bridge:cursor   # Generate .cursorrules only"
-        say "  rails ai:serve           # Start MCP server (stdio)"
-        say "  rails ai:inspect         # Print introspection summary"
+        say "  rails ai:bridge              # Generate files from config/rails_ai_bridge/install.yml"
+        say "  rails ai:bridge:all          # Every format (including JSON), ignores install.yml"
+        say "  rails ai:bridge:claude       # CLAUDE.md only"
+        say "  rails ai:bridge:codex        # AGENTS.md only"
+        say "  rails ai:bridge:json         # .ai-context.json only (machine-readable bundle)"
+        say "  rails ai:serve               # MCP server (stdio)"
+        say "  rails ai:inspect             # Introspection summary"
         say ""
         say "Generated files per AI tool:", :yellow
         say "  Claude Code    → CLAUDE.md + .claude/rules/*.md"
@@ -150,19 +175,47 @@ module RailsAiBridge
         say "  Windsurf       → .windsurfrules + .windsurf/rules/*.md"
         say "  GitHub Copilot → .github/copilot-instructions.md + .github/instructions/*.instructions.md"
         say ""
+        say "Copilot merges:", :yellow
+        say "  Managed content is wrapped in HTML comments in copilot-instructions.md."
+        say "  Existing files without markers are skipped unless RAILS_AI_BRIDGE_COPILOT_MERGE=overwrite."
+        say ""
         say "MCP auto-discovery:", :yellow
         say "  .mcp.json is auto-detected by Claude Code and Cursor."
-        say "  No manual MCP config needed — just open your project."
         say ""
         say "Bridge modes:", :yellow
-        say "  rails ai:bridge         # compact mode (default, smart for any app size)"
-        say "  rails ai:bridge:full    # full dump (good for small apps)"
+        say "  rails ai:bridge:full    # full dump into context files (good for small apps)"
         say ""
-        say "Repo-specific Copilot/Codex rules:", :yellow
+        say "Repo-specific rules:", :yellow
         say "  Edit config/rails_ai_bridge/overrides.md — remove the first-line omit-merge comment to enable merge."
         say "  See overrides.md.example for a suggested outline."
         say ""
         say "Commit bridge files and .mcp.json so your team benefits!", :green
+      end
+
+      private
+
+      def resolve_assistant_format_selection
+        if options[:assistants].present?
+          list = parse_assistant_list(options[:assistants])
+          return AssistantFormatsPreference::FORMAT_KEYS if list.empty?
+
+          return list
+        end
+
+        return AssistantFormatsPreference::FORMAT_KEYS if options[:non_interactive] || !$stdin.tty?
+
+        say ""
+        say "Which assistant outputs should `rails ai:bridge` generate?", :yellow
+        say "  claude, codex, cursor, windsurf, copilot, json — or 'all' (default)."
+        ans = ask("formats [all]:", default: "all")
+        return AssistantFormatsPreference::FORMAT_KEYS if ans.strip.empty? || ans.strip.casecmp("all").zero?
+
+        list = parse_assistant_list(ans)
+        list.empty? ? AssistantFormatsPreference::FORMAT_KEYS : list
+      end
+
+      def parse_assistant_list(str)
+        str.to_s.split(",").map(&:strip).map(&:downcase).map(&:to_sym) & AssistantFormatsPreference::FORMAT_KEYS
       end
     end
   end

--- a/lib/rails_ai_bridge.rb
+++ b/lib/rails_ai_bridge.rb
@@ -46,12 +46,33 @@ module RailsAiBridge
     # Generate context files (CLAUDE.md, .cursorrules, etc.)
     #
     # @param app [Rails::Application, nil] app to introspect, defaults to Rails.application
-    # @param format [Symbol] output format (:all, :claude, :cursor, :windsurf, :copilot, :json, :codex)
+    # @param format [Symbol, Array<Symbol>] output format (+:all+, +:install+, +:claude+, …, or an array from install.yml)
     # @return [Hash{Symbol => Array<String>}] files grouped under +:written+ and +:skipped+
     def generate_context(app = nil, format: :all)
       app ||= Rails.application
+      warn_stubbed_assistant_overrides
       context = introspect(app)
-      Serializers::ContextFileSerializer.new(context, format: format).call
+      Serializers::ContextFileSerializer.new(context, format: resolve_generate_format(format)).call
+    end
+
+    # @param format [Object]
+    # @return [Symbol, Array<Symbol>]
+    def resolve_generate_format(format)
+      case format
+      when :install
+        prefs = AssistantFormatsPreference.formats_for_default_bridge_task
+        prefs.nil? ? :all : prefs
+      else
+        format
+      end
+    end
+
+    # @return [void]
+    def warn_stubbed_assistant_overrides
+      return unless Serializers::SharedAssistantGuidance.overrides_stub_active?
+
+      warn "[rails-ai-bridge] config/rails_ai_bridge/overrides.md is still the install stub (remove the first-line " \
+           "<!-- rails-ai-bridge:omit-merge --> marker so team rules merge into Copilot/Codex output)."
     end
 
     # Start the MCP server programmatically

--- a/lib/rails_ai_bridge.rb
+++ b/lib/rails_ai_bridge.rb
@@ -100,10 +100,11 @@ module RailsAiBridge
               "rails_ai_bridge: auto_mount is disabled in production unless you set allow_auto_mount_in_production = true"
       end
 
-      return if McpHttpAuth.effective_http_mcp_token.present?
+      return if mcp_auth_mechanism_configured?
 
       raise ConfigurationError,
-            "rails_ai_bridge: auto_mount in production requires http_mcp_token or ENV['#{McpHttpAuth::TOKEN_ENV_KEY}']"
+            "rails_ai_bridge: auto_mount in production requires http_mcp_token or ENV['#{McpHttpAuth::TOKEN_ENV_KEY}'], " \
+            "config.mcp.auth.token_resolver, or config.mcp.auth.jwt_decoder"
     end
 
     # Raises {ConfigurationError} when starting the standalone HTTP MCP server in production without a token.
@@ -112,10 +113,50 @@ module RailsAiBridge
     # @raise [RailsAiBridge::ConfigurationError] when production HTTP MCP starts without a token
     def validate_http_mcp_server_in_production!
       return unless Rails.env.production?
-      return if McpHttpAuth.effective_http_mcp_token.present?
+      return if mcp_auth_mechanism_configured?
 
       raise ConfigurationError,
-            "rails_ai_bridge: HTTP MCP in production requires http_mcp_token or ENV['#{McpHttpAuth::TOKEN_ENV_KEY}']"
+            "rails_ai_bridge: HTTP MCP in production requires http_mcp_token or ENV['#{McpHttpAuth::TOKEN_ENV_KEY}'], " \
+            "config.mcp.auth.token_resolver, or config.mcp.auth.jwt_decoder"
+    end
+
+    # True when static MCP token, +token_resolver+, or +jwt_decoder+ is configured.
+    #
+    # @return [Boolean]
+    def mcp_auth_mechanism_configured?
+      McpHttpAuth.http_mcp_auth_configured? ||
+        configuration.mcp.auth.token_resolver.present? ||
+        configuration.mcp.auth.jwt_decoder.present?
+    end
+
+    # Raises when +strategy == :bearer_token+ but neither +token_resolver+ nor static MCP token is configured.
+    #
+    # @return [void]
+    # @raise [RailsAiBridge::ConfigurationError]
+    def validate_mcp_strategy_configuration!
+      a = configuration.mcp.auth
+      return unless a.strategy == :bearer_token
+      return if a.token_resolver.present?
+      return if McpHttpAuth.http_mcp_auth_configured?
+
+      raise ConfigurationError,
+            "rails_ai_bridge: strategy :bearer_token requires config.mcp.auth.token_resolver or " \
+            "http_mcp_token / ENV['#{McpHttpAuth::TOKEN_ENV_KEY}']. Otherwise HTTP MCP would be unauthenticated. See UPGRADING.md."
+    end
+
+    # Raises when +config.mcp.require_auth_in_production+ is +true+ in production and no MCP auth mechanism exists.
+    #
+    # @return [void]
+    # @raise [RailsAiBridge::ConfigurationError]
+    def validate_mcp_require_auth_in_production!
+      return unless Rails.env.production?
+      return unless configuration.mcp.require_auth_in_production
+      return if mcp_auth_mechanism_configured?
+
+      raise ConfigurationError,
+            "rails_ai_bridge: MCP auth cannot be disabled in production (require_auth_in_production is true). " \
+            "Set http_mcp_token, ENV['#{McpHttpAuth::TOKEN_ENV_KEY}'], config.mcp.auth.token_resolver, or " \
+            "config.mcp.auth.jwt_decoder. See UPGRADING.md."
     end
   end
 end

--- a/lib/rails_ai_bridge/assistant_formats_preference.rb
+++ b/lib/rails_ai_bridge/assistant_formats_preference.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module RailsAiBridge
+  # Reads and writes which assistant formats +rails ai:bridge+ regenerates by default.
+  #
+  # The install generator creates {RELATIVE_PATH} with a YAML +formats+ list (subset of {FORMAT_KEYS}).
+  # When the file is missing or invalid, callers treat that as “all formats”. Omitting +json+ skips +.ai-context.json+
+  # unless the user runs +rails ai:bridge:json+ or +rails ai:bridge:all+.
+  #
+  # @see ContextFileSerializer
+  class AssistantFormatsPreference
+    # Path relative to +Rails.root+ for the persisted preference file.
+    RELATIVE_PATH = "config/rails_ai_bridge/install.yml"
+
+    # Allowed keys for the +formats+ array in YAML (order not significant).
+    FORMAT_KEYS = %i[claude codex cursor windsurf copilot json].freeze
+
+    class << self
+      # Absolute path to the preference file when a Rails application is loaded.
+      #
+      # @return [Pathname, nil] +nil+ when +Rails.application+ is not available
+      def config_path
+        return nil unless defined?(Rails) && Rails.application
+
+        Rails.root.join(RELATIVE_PATH)
+      end
+
+      # Normalized format list for the default +rails ai:bridge+ task.
+      #
+      # @return [Array<Symbol>, nil] subset of {FORMAT_KEYS}, or +nil+ when the file is missing / invalid /
+      #   when +formats+ should fall back to “all outputs”
+      def formats_for_default_bridge_task
+        path = config_path
+        return nil unless path&.file?
+
+        data = load_yaml(path)
+        return nil if data.nil? || !data.is_a?(Hash)
+
+        raw = data["formats"] || data[:formats]
+        return nil if raw.nil?
+
+        fmts = Array(raw).map { |f| f.to_s.downcase.to_sym } & FORMAT_KEYS
+        fmts.empty? ? nil : fmts.uniq
+      end
+
+      # Writes +install.yml+ with a normalized +formats+ list.
+      #
+      # @param formats [Array<Symbol, String>] values intersected with {FORMAT_KEYS}
+      # @raise [RailsAiBridge::Error] when +Rails.application+ is unavailable (+config_path+ is +nil+)
+      # @return [void]
+      def write!(formats:)
+        path = config_path
+        raise Error, "Rails app not available" unless path
+
+        path.dirname.mkpath
+        list = Array(formats).map { |f| f.to_s.downcase }.uniq & FORMAT_KEYS.map(&:to_s)
+        File.write(path.to_s, YAML.dump({ "formats" => list }))
+      end
+
+      private
+
+      # @param path [Pathname]
+      # @return [Object, nil] parsed Hash or +nil+ on syntax error / missing file
+      def load_yaml(path)
+        YAML.safe_load(File.read(path), permitted_classes: [ Symbol ], permitted_symbols: [], aliases: true)
+      rescue Psych::SyntaxError, Errno::ENOENT
+        nil
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/configuration.rb
+++ b/lib/rails_ai_bridge/configuration.rb
@@ -110,6 +110,13 @@ module RailsAiBridge
     # Optional custom MCP resources merged with built-in resources.
     attr_accessor :additional_resources
 
+    # Nested MCP HTTP auth / policy settings ({RailsAiBridge::Mcp::Settings}).
+    #
+    # @return [RailsAiBridge::Mcp::Settings]
+    def mcp
+      @mcp ||= Mcp::Settings.new
+    end
+
     # Initializes defaults (standard preset, compact mode, common +excluded_models+, empty exclusions).
     #
     # @return [void]

--- a/lib/rails_ai_bridge/configuration.rb
+++ b/lib/rails_ai_bridge/configuration.rb
@@ -1,13 +1,42 @@
 # frozen_string_literal: true
 
 module RailsAiBridge
+  # Holds user-facing options for introspection presets, exclusions, MCP HTTP, and context generation.
+  #
+  # Presets ({PRESETS}) set the base +introspectors+ list; {#disabled_introspection_categories} and
+  # {#preset=} refine what runs. {#effective_introspectors} is what the introspector and MCP layer use.
+  #
+  # @see Introspector
+  # @see RailsAiBridge.configuration
   class Configuration
+    # Named introspector lists for {#preset=}.
+    #
+    # @return [Hash<Symbol, Array<Symbol>>]
     PRESETS = {
       standard: %i[schema models routes jobs gems conventions controllers tests migrations],
       full: %i[schema models routes jobs gems conventions stimulus controllers views turbo
                i18n config active_storage action_text auth api tests rake_tasks assets
-               devops action_mailbox migrations seeds middleware engines multi_database]
+               devops action_mailbox migrations seeds middleware engines multi_database],
+      # Same introspector set as :standard; use for large apps that want MCP-first model/schema detail (tune list limits in the initializer).
+      large_monolith: %i[schema models routes jobs gems conventions controllers tests migrations],
+      # Minimal disk/MCP surface: no schema, models, or migrations introspection (add them back if you need domain tools).
+      regulated: %i[routes jobs gems conventions controllers tests]
     }.freeze
+
+    # Product-level categories that subtract introspectors from the active preset (see +#effective_introspectors+).
+    #
+    # @return [Hash<Symbol, Array<Symbol>>]
+    INTROSPECTION_CATEGORY_INTROSPECTORS = {
+      domain_metadata: %i[schema models migrations],
+      persistence_surface: %i[schema models],
+      api_surface: %i[api],
+      ui_stack: %i[views stimulus turbo i18n]
+    }.freeze
+
+    # Order for {#inferred_preset_name}: more specific presets before subsets (e.g. :large_monolith vs :standard).
+    #
+    # @return [Array<Symbol>]
+    PRESET_INFERENCE_ORDER = %i[regulated large_monolith full standard].freeze
 
     # MCP server settings
     attr_accessor :server_name, :server_version
@@ -36,6 +65,12 @@ module RailsAiBridge
 
     # Models/tables to exclude from introspection
     attr_accessor :excluded_models
+
+    # Table names to skip in schema/model introspection (exact match or glob with +*+, e.g. +"secrets_*"+).
+    attr_accessor :excluded_tables
+
+    # Category keys from {INTROSPECTION_CATEGORY_INTROSPECTORS} to remove from the active preset at runtime.
+    attr_accessor :disabled_introspection_categories
 
     # TTL in seconds for cached introspection (default: 30)
     attr_accessor :cache_ttl
@@ -75,6 +110,9 @@ module RailsAiBridge
     # Optional custom MCP resources merged with built-in resources.
     attr_accessor :additional_resources
 
+    # Initializes defaults (standard preset, compact mode, common +excluded_models+, empty exclusions).
+    #
+    # @return [void]
     def initialize
       @server_name         = "rails-ai-bridge"
       @server_version      = RailsAiBridge::VERSION
@@ -93,6 +131,8 @@ module RailsAiBridge
         ActionText::RichText ActionText::EncryptedRichText
         ActionMailbox::InboundEmail ActionMailbox::Record
       ]
+      @excluded_tables                    = []
+      @disabled_introspection_categories  = []
       @cache_ttl                = 30
       @context_mode             = :compact
       @claude_max_lines         = 150
@@ -107,12 +147,53 @@ module RailsAiBridge
       @additional_resources             = {}
     end
 
+    # Replaces +introspectors+ with the list for the given preset name.
+    #
+    # @param name [Symbol, String] one of {PRESETS} keys
+    # @raise [ArgumentError] when the preset is unknown
+    # @return [void]
     def preset=(name)
       name = name.to_sym
       raise ArgumentError, "Unknown preset: #{name}. Valid presets: #{PRESETS.keys.join(", ")}" unless PRESETS.key?(name)
       @introspectors = PRESETS[name].dup
     end
 
+    # Introspectors after removing any disabled by {#disabled_introspection_categories}.
+    #
+    # @return [Array<Symbol>]
+    def effective_introspectors
+      disabled = @disabled_introspection_categories.flat_map do |c|
+        INTROSPECTION_CATEGORY_INTROSPECTORS[c.to_sym] || []
+      end.uniq
+      @introspectors.reject { |i| disabled.include?(i) }
+    end
+
+    # Whether a logical table name matches any +excluded_tables+ pattern (exact or glob).
+    #
+    # @param table_name [String, nil]
+    # @return [Boolean]
+    def excluded_table?(table_name)
+      return false if table_name.nil? || table_name.to_s.empty?
+
+      @excluded_tables.any? { |pat| ExclusionHelper.table_pattern_match?(pat.to_s, table_name.to_s) }
+    end
+
+    # Best-effort preset label when +introspectors+ exactly match a known preset; otherwise +:custom+.
+    #
+    # @return [Symbol] a key from {PRESETS} if the sorted list matches, else +:custom+
+    def inferred_preset_name
+      sorted = introspectors.sort
+      self.class::PRESET_INFERENCE_ORDER.each do |key|
+        list = self.class::PRESETS[key]
+        return key if list && sorted == list.sort
+      end
+      :custom
+    end
+
+    # Root-relative or absolute output directory for generated files.
+    #
+    # @param app [Rails::Application]
+    # @return [String] filesystem path
     def output_dir_for(app)
       @output_dir || app.root.to_s
     end

--- a/lib/rails_ai_bridge/engine.rb
+++ b/lib/rails_ai_bridge/engine.rb
@@ -8,6 +8,14 @@ module RailsAiBridge
       Rails.application.config.rails_ai_bridge = RailsAiBridge.configuration
     end
 
+    initializer "rails_ai_bridge.mcp_strategy", after: "rails_ai_bridge.setup" do
+      RailsAiBridge.validate_mcp_strategy_configuration!
+    end
+
+    initializer "rails_ai_bridge.mcp_require_auth", after: "rails_ai_bridge.mcp_strategy" do
+      RailsAiBridge.validate_mcp_require_auth_in_production!
+    end
+
     # Auto-mount MCP HTTP middleware when configured
     initializer "rails_ai_bridge.middleware" do |app|
       RailsAiBridge.validate_auto_mount_configuration!

--- a/lib/rails_ai_bridge/exclusion_helper.rb
+++ b/lib/rails_ai_bridge/exclusion_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  # Table name matching for +config.excluded_tables+ (exact names or +*+ globs).
+  module ExclusionHelper
+    module_function
+
+    # @param pattern [String] e.g. +"users"+ or +"audit_*"+
+    # @param table_name [String]
+    # @return [Boolean]
+    def table_pattern_match?(pattern, table_name)
+      return false if pattern.to_s.empty? || table_name.to_s.empty?
+
+      p = pattern.to_s
+      return p == table_name unless p.include?("*")
+
+      File.fnmatch(p, table_name, File::FNM_EXTGLOB | File::FNM_CASEFOLD)
+    end
+  end
+end

--- a/lib/rails_ai_bridge/http_transport_app.rb
+++ b/lib/rails_ai_bridge/http_transport_app.rb
@@ -5,22 +5,56 @@ module RailsAiBridge
   # middleware auto-mount path so request handling stays in one place.
   class HttpTransportApp
     class << self
+      # Returns a Rack app for the MCP HTTP path: optional per-IP rate limit, Bearer auth,
+      # optional +authorize+, then the streamable transport. Limit values are read from
+      # {RailsAiBridge::Configuration#mcp} at call time of +build+ (not on each request).
+      #
       # @param transport [MCP::Server::Transports::StreamableHTTPTransport] transport to delegate to
       # @param path [String] configured MCP endpoint path
       # @return [Proc] rack-compatible app
       def build(transport:, path:)
+        mcp = RailsAiBridge.configuration.mcp
+        limiter, retry_after = build_rate_limit(mcp)
+
         lambda do |env|
           unless env["PATH_INFO"] == path || env["PATH_INFO"] == "#{path}/"
             return [ 404, { "Content-Type" => "application/json" }, [ '{"error":"Not found"}' ] ]
           end
 
           request = Rack::Request.new(env)
+          if limiter && !limiter.allow?(request.ip)
+            return McpHttpAuth.rate_limited_rack_response(retry_after: retry_after)
+          end
+
           unless McpHttpAuth.authorized_request?(request)
             return McpHttpAuth.unauthorized_rack_response
           end
 
+          authz = RailsAiBridge.configuration.mcp.authorize
+          if authz
+            ctx = request.env[Mcp::HttpAuth::ENV_CONTEXT_KEY]
+            unless authz.call(ctx, request)
+              return McpHttpAuth.forbidden_rack_response
+            end
+          end
+
           transport.handle_request(request)
         end
+      end
+
+      private
+
+      # @param mcp [RailsAiBridge::Mcp::Settings]
+      # @return [Array(RailsAiBridge::Mcp::HttpRateLimiter, Integer, nil), Array(nil, nil)]
+      def build_rate_limit(mcp)
+        max = mcp.rate_limit_max_requests.to_i
+        return [ nil, nil ] if max <= 0
+
+        window = mcp.rate_limit_window_seconds.to_i
+        window = 60 if window <= 0
+
+        limiter = Mcp::HttpRateLimiter.new(max_requests: max, window_seconds: window)
+        [ limiter, window ]
       end
     end
   end

--- a/lib/rails_ai_bridge/http_transport_app.rb
+++ b/lib/rails_ai_bridge/http_transport_app.rb
@@ -6,8 +6,10 @@ module RailsAiBridge
   class HttpTransportApp
     class << self
       # Returns a Rack app for the MCP HTTP path: optional per-IP rate limit, Bearer auth,
-      # optional +authorize+, then the streamable transport. Limit values are read from
-      # {RailsAiBridge::Configuration#mcp} at call time of +build+ (not on each request).
+      # optional +authorize+, then the streamable transport. Rate-limit ceilings and window
+      # are fixed at +build+ from {RailsAiBridge::Mcp::Settings#effective_http_rate_limit_max_requests}
+      # and {#effective_http_rate_limit_window_seconds}. JSON access logging (+http_log_json+) is
+      # evaluated on each request inside {Mcp::HttpStructuredLog.emit}.
       #
       # @param transport [MCP::Server::Transports::StreamableHTTPTransport] transport to delegate to
       # @param path [String] configured MCP endpoint path
@@ -23,10 +25,12 @@ module RailsAiBridge
 
           request = Rack::Request.new(env)
           if limiter && !limiter.allow?(request.ip)
+            Mcp::HttpStructuredLog.emit(request: request, event: :rate_limited, http_status: 429)
             return McpHttpAuth.rate_limited_rack_response(retry_after: retry_after)
           end
 
           unless McpHttpAuth.authorized_request?(request)
+            Mcp::HttpStructuredLog.emit(request: request, event: :unauthorized, http_status: 401)
             return McpHttpAuth.unauthorized_rack_response
           end
 
@@ -34,11 +38,14 @@ module RailsAiBridge
           if authz
             ctx = request.env[Mcp::HttpAuth::ENV_CONTEXT_KEY]
             unless authz.call(ctx, request)
+              Mcp::HttpStructuredLog.emit(request: request, event: :forbidden, http_status: 403)
               return McpHttpAuth.forbidden_rack_response
             end
           end
 
-          transport.handle_request(request)
+          status, headers, body = transport.handle_request(request)
+          Mcp::HttpStructuredLog.emit(request: request, event: :handled, http_status: status)
+          [ status, headers, body ]
         end
       end
 
@@ -47,12 +54,10 @@ module RailsAiBridge
       # @param mcp [RailsAiBridge::Mcp::Settings]
       # @return [Array(RailsAiBridge::Mcp::HttpRateLimiter, Integer, nil), Array(nil, nil)]
       def build_rate_limit(mcp)
-        max = mcp.rate_limit_max_requests.to_i
+        max = mcp.effective_http_rate_limit_max_requests
         return [ nil, nil ] if max <= 0
 
-        window = mcp.rate_limit_window_seconds.to_i
-        window = 60 if window <= 0
-
+        window = mcp.effective_http_rate_limit_window_seconds
         limiter = Mcp::HttpRateLimiter.new(max_requests: max, window_seconds: window)
         [ limiter, window ]
       end

--- a/lib/rails_ai_bridge/introspector.rb
+++ b/lib/rails_ai_bridge/introspector.rb
@@ -78,7 +78,7 @@ module RailsAiBridge
 
     def selected_introspectors(only)
       names = Array(only).compact
-      return config.introspectors if names.empty?
+      return config.effective_introspectors if names.empty?
 
       names
     end

--- a/lib/rails_ai_bridge/introspectors/model_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/model_introspector.rb
@@ -35,13 +35,21 @@ module RailsAiBridge
         nil
       end
 
+      def model_table_excluded?(model)
+        tn = model.table_name
+        return false if tn.nil? || tn.to_s.empty?
+
+        config.excluded_table?(tn)
+      end
+
       def discover_models
         return [] unless defined?(ActiveRecord::Base)
 
         ActiveRecord::Base.descendants.reject do |model|
           model.abstract_class? ||
             model.name.nil? ||
-            config.excluded_models.include?(model.name)
+            config.excluded_models.include?(model.name) ||
+            model_table_excluded?(model)
         end.sort_by(&:name)
       end
 

--- a/lib/rails_ai_bridge/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/schema_introspector.rb
@@ -5,10 +5,11 @@ module RailsAiBridge
     # Extracts database schema information including tables, columns,
     # indexes, and foreign keys from the Rails application.
     class SchemaIntrospector
-      attr_reader :app
+      attr_reader :app, :config
 
       def initialize(app)
-        @app = app
+        @app    = app
+        @config = RailsAiBridge.configuration
       end
 
       # @return [Hash] database schema context
@@ -42,7 +43,10 @@ module RailsAiBridge
       end
 
       def table_names
-        @table_names ||= connection.tables.reject { |t| t.start_with?("ar_internal_metadata", "schema_migrations") }
+        @table_names ||= begin
+          names = connection.tables.reject { |t| t.start_with?("ar_internal_metadata", "schema_migrations") }
+          names.reject { |t| config.excluded_table?(t) }
+        end
       end
 
       def extract_tables

--- a/lib/rails_ai_bridge/mcp.rb
+++ b/lib/rails_ai_bridge/mcp.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  # Namespace for HTTP MCP authentication strategies and orchestration.
+  module Mcp
+  end
+end

--- a/lib/rails_ai_bridge/mcp/auth/base_strategy.rb
+++ b/lib/rails_ai_bridge/mcp/auth/base_strategy.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Mcp
+    module Auth
+      # Shared helpers for Bearer-based strategies.
+      class BaseStrategy
+        # @param request [Rack::Request]
+        # @return [String, nil] raw token without "Bearer " prefix
+        def extract_bearer(request)
+          auth = request.get_header("HTTP_AUTHORIZATION")
+          return nil if auth.blank?
+
+          match = auth.match(/\ABearer\s+(.+)\z/i)
+          match ? match[1].to_s.strip : nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp/auth/strategies/bearer_token.rb
+++ b/lib/rails_ai_bridge/mcp/auth/strategies/bearer_token.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module RailsAiBridge
+  module Mcp
+    module Auth
+      module Strategies
+        # Compares +Authorization: Bearer+ to a shared secret and/or resolves a token via +token_resolver+.
+        class BearerToken < BaseStrategy
+          # Builds a strategy from a static secret provider and/or a host token resolver.
+          # @param static_token_provider [Proc] callable returning +String+ secret or +nil+ (optional if +token_resolver+ is set)
+          # @param token_resolver [Proc, nil] +->(token) { context_or_nil }+; return +nil+ or +false+ to deny
+          # @return [void]
+          def initialize(static_token_provider:, token_resolver: nil)
+            @static_token_provider = static_token_provider
+            @token_resolver = token_resolver
+          end
+
+          # Authenticates using +token_resolver+ when configured; otherwise compares Bearer to the static secret.
+          # @param request [Rack::Request]
+          # @return [AuthResult]
+          def authenticate(request)
+            return authenticate_via_resolver(request) if @token_resolver
+
+            authenticate_via_static_secret(request)
+          end
+
+          private
+
+          def authenticate_via_resolver(request)
+            token = extract_bearer(request)
+            return AuthResult.fail(:missing_token) if token.blank?
+
+            ctx, resolve_error = resolve_token_context(token)
+            return AuthResult.fail(resolve_error) if resolve_error
+            return AuthResult.fail(:unauthorized) if ctx.nil? || ctx == false
+
+            AuthResult.ok(ctx)
+          end
+
+          # Invokes +token_resolver+ and maps failures to a tuple (no uncaught exceptions).
+          # @param token [String] raw Bearer credential (no +Bearer + prefix)
+          # @return [Array] +[context, nil]+ on success; +[nil, :resolver_error]+ if the resolver raised
+          def resolve_token_context(token)
+            [ @token_resolver.call(token), nil ]
+          rescue StandardError
+            [ nil, :resolver_error ]
+          end
+
+          def authenticate_via_static_secret(request)
+            expected = @static_token_provider.call.to_s
+            return AuthResult.ok(nil) if expected.blank?
+
+            token = extract_bearer(request)
+            return AuthResult.fail(:missing_token) if token.blank?
+
+            return AuthResult.fail(:wrong_token) unless secure_compare_tokens(token, expected)
+
+            AuthResult.ok(:static_bearer)
+          end
+
+          # Timing-safe equality on SHA256 digests so comparison does not leak raw token length.
+          # @param received [String]
+          # @param expected [String]
+          # @return [Boolean]
+          def secure_compare_tokens(received, expected)
+            ActiveSupport::SecurityUtils.secure_compare(
+              Digest::SHA256.hexdigest(received),
+              Digest::SHA256.hexdigest(expected)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp/auth/strategies/jwt.rb
+++ b/lib/rails_ai_bridge/mcp/auth/strategies/jwt.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Mcp
+    module Auth
+      module Strategies
+        # Decodes a Bearer token via a host-provided lambda (no JWT gem required).
+        #
+        # Example: +->(token) { JWT.decode(token, key, true, algorithm: "HS256").first rescue nil }+
+        class Jwt < BaseStrategy
+          # @param decoder [Proc, nil] +->(raw_bearer_string) { payload_or_nil }+
+          def initialize(decoder:)
+            @decoder = decoder
+          end
+
+          # @param request [Rack::Request]
+          # @return [AuthResult]
+          def authenticate(request)
+            token = extract_bearer(request)
+            return AuthResult.fail(:missing_token) if token.blank?
+            return AuthResult.fail(:misconfigured) if @decoder.nil?
+
+            payload, decode_error = decode_token(token)
+            return AuthResult.fail(decode_error) if decode_error
+            return AuthResult.fail(:unauthorized) if payload.nil? || payload == false
+
+            AuthResult.ok(payload)
+          end
+
+          private
+
+          # Runs the host decoder; never raises.
+          #
+          # @return [Array(Object, Symbol, nil)] +[payload, nil]+ on success path, or +[nil, :decode_error]+ if the decoder raised
+          def decode_token(token)
+            [ @decoder.call(token), nil ]
+          rescue StandardError
+            [ nil, :decode_error ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp/auth_config.rb
+++ b/lib/rails_ai_bridge/mcp/auth_config.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Mcp
+    # Nested auth options under {Settings#auth} / {#auth_configure}.
+    class AuthConfig
+      # @return [Symbol, nil] +:bearer_token+, +:static_bearer+, or +nil+ (auto)
+      attr_accessor :strategy
+
+      # @return [Proc, nil] +->(raw_bearer_token) { context_or_nil }+
+      attr_accessor :token_resolver
+
+      # @return [Proc, nil] +->(raw_bearer_string) { payload_or_nil }+ when using {Strategies::Jwt}
+      attr_accessor :jwt_decoder
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp/auth_result.rb
+++ b/lib/rails_ai_bridge/mcp/auth_result.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Mcp
+    # Result of {HttpAuth} / strategy authentication (strategies do not raise for expected failures).
+    AuthResult = Data.define(:success, :context, :error) do
+      # @return [Boolean]
+      def success? = success
+
+      # @return [Boolean]
+      def failure? = !success
+
+      # @param context [Object, nil]
+      # @return [AuthResult]
+      def self.ok(context = nil)
+        new(success: true, context: context, error: nil)
+      end
+
+      # @param error [Symbol, String, nil]
+      # @return [AuthResult]
+      def self.fail(error = :unauthorized)
+        new(success: false, context: nil, error: error)
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp/http_auth.rb
+++ b/lib/rails_ai_bridge/mcp/http_auth.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Mcp
+    # Orchestrates HTTP MCP authentication using a resolved strategy (JWT, Bearer resolver, or static secret).
+    module HttpAuth
+      ENV_CONTEXT_KEY = "rails_ai_bridge.mcp.context"
+
+      module_function
+
+      # @param request [Rack::Request]
+      # @return [AuthResult]
+      def authenticate(request)
+        env = request.env
+        env.delete(ENV_CONTEXT_KEY)
+
+        strategy = resolve_strategy
+        if strategy.nil?
+          return AuthResult.ok(nil)
+        end
+
+        result = strategy.authenticate(request)
+        env[ENV_CONTEXT_KEY] = result.context if result.success?
+        result
+      end
+
+      # @return [RailsAiBridge::Mcp::Auth::Strategies::BearerToken, RailsAiBridge::Mcp::Auth::Strategies::Jwt, nil]
+      def resolve_strategy
+        a = RailsAiBridge.configuration.mcp.auth
+
+        if a.strategy != :static_bearer
+          if a.strategy == :jwt || (a.strategy.nil? && a.jwt_decoder.present?)
+            return Auth::Strategies::Jwt.new(decoder: a.jwt_decoder)
+          end
+
+          if a.token_resolver.present? && [ :bearer_token, nil ].include?(a.strategy)
+            return Auth::Strategies::BearerToken.new(
+              static_token_provider: -> { nil },
+              token_resolver: a.token_resolver
+            )
+          end
+        end
+
+        return nil unless McpHttpAuth.http_mcp_auth_configured?
+
+        Auth::Strategies::BearerToken.new(
+          static_token_provider: -> { McpHttpAuth.effective_http_mcp_token },
+          token_resolver: nil
+        )
+      end
+      private_class_method :resolve_strategy
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp/http_rate_limiter.rb
+++ b/lib/rails_ai_bridge/mcp/http_rate_limiter.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Mcp
+    # Sliding-window request counter per client key (typically +request.ip+), in-memory per process.
+    class HttpRateLimiter
+      # @param max_requests [Integer] allowed hits per window (must be positive)
+      # @param window_seconds [Integer] window length in seconds
+      # @param clock [Proc, nil] +-> { Float }+ seconds timestamp; defaults to monotonic clock
+      def initialize(max_requests:, window_seconds:, clock: nil)
+        @max_requests = max_requests
+        @window_seconds = window_seconds.to_f
+        @clock = clock || -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+        @mutex = Mutex.new
+        @hits = Hash.new { |h, k| h[k] = [] }
+      end
+
+      # @param ip [String, nil] client identifier (blank values share the +unknown+ bucket)
+      # @return [Boolean] +true+ if the request may proceed
+      def allow?(ip)
+        key = ip.to_s.presence || "unknown"
+        now = @clock.call
+        window_start = now - @window_seconds
+
+        @mutex.synchronize do
+          times = @hits[key]
+          times.reject! { |t| t < window_start }
+          # Drop stale keys so unique IPs that stop requesting do not grow @hits forever.
+          @hits.delete(key) if times.empty?
+
+          times = @hits[key]
+          return false if times.size >= @max_requests
+
+          times << now
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp/http_structured_log.rb
+++ b/lib/rails_ai_bridge/mcp/http_structured_log.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "logger"
+
+module RailsAiBridge
+  module Mcp
+    # One-line JSON logs for the MCP HTTP Rack path when {Settings#http_log_json} is enabled.
+    # Does not log tokens or Rack +env+ bodies.
+    module HttpStructuredLog
+      MESSAGE_KEY = "rails_ai_bridge.mcp.http"
+
+      class << self
+        # Emits a single JSON line via +Rails.logger+ (or +$stdout+) when logging is on.
+        #
+        # @param request [Rack::Request]
+        # @param event [Symbol, String] logical outcome; stored in JSON as a string (+rate_limited+, +handled+, …).
+        # @param http_status [Integer]
+        # @param extra [Hash] optional extra scalar fields merged into the payload (+nil+ values omitted)
+        # @return [void]
+        def emit(request:, event:, http_status:, **extra)
+          return unless RailsAiBridge.configuration.mcp.http_log_json
+
+          payload = {
+            msg: MESSAGE_KEY,
+            event: event.to_s,
+            http_status: http_status,
+            path: request.path,
+            client_ip: request.ip.to_s
+          }
+          rid = request.env["action_dispatch.request_id"]
+          payload[:request_id] = rid if rid.present?
+          extra.each { |k, v| payload[k] = v unless v.nil? }
+
+          target_logger.info(payload.to_json)
+        end
+
+        private
+
+        def target_logger
+          if defined?(Rails) && Rails.logger
+            Rails.logger
+          else
+            @fallback_logger ||= Logger.new($stdout)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp/settings.rb
+++ b/lib/rails_ai_bridge/mcp/settings.rb
@@ -4,18 +4,24 @@ module RailsAiBridge
   module Mcp
     # MCP HTTP settings under {RailsAiBridge::Configuration#mcp}.
     class Settings
-      # @return [Symbol] +:dev+, +:production+, +:hybrid+ (documentational)
+      # Controls when implicit HTTP rate limits apply (see {#effective_http_rate_limit_max_requests}).
+      # +:dev+ — no implicit limit (+nil+ max). +:production+ — implicit limit from {#security_profile}.
+      # +:hybrid+ — implicit limit only when +Rails.env.production?+.
+      # @return [Symbol]
       attr_accessor :mode
 
-      # @return [Symbol] +:strict+, +:balanced+, +:relaxed+
+      # Default MCP HTTP rate ceiling per IP when +rate_limit_max_requests+ is +nil+ (see {#effective_http_rate_limit_max_requests}).
+      # +:strict+ 60, +:balanced+ 300, +:relaxed+ 1200 requests per +rate_limit_window_seconds+ sliding window (default +60+ seconds).
+      # @return [Symbol]
       attr_accessor :security_profile
 
       # When +true+ in production, boot fails unless {RailsAiBridge.mcp_auth_mechanism_configured?}.
       # @return [Boolean]
       attr_accessor :require_auth_in_production
 
-      # Max MCP HTTP requests per +rate_limit_window_seconds+ per client IP, in-process (+nil+ or +0+ disables).
-      # @return [Integer, nil]
+      # Explicit MCP HTTP requests allowed per {#rate_limit_window_seconds} per client IP (+Integer+ or numeric string).
+      # +nil+ uses {#security_profile} defaults unless {#http_rate_limit_implicitly_suppressed?}; +0+ disables limiting.
+      # @return [Integer, nil, String]
       attr_accessor :rate_limit_max_requests
 
       # Sliding window for {rate_limit_max_requests} (seconds).
@@ -24,6 +30,10 @@ module RailsAiBridge
 
       # @return [Proc, nil] +->(context, request) { truthy }+ after successful authentication
       attr_accessor :authorize
+
+      # When +true+, MCP HTTP decisions emit one JSON line per response (+msg+ +rails_ai_bridge.mcp.http+).
+      # @return [Boolean]
+      attr_accessor :http_log_json
 
       # @return [AuthConfig]
       attr_reader :auth
@@ -36,6 +46,58 @@ module RailsAiBridge
         @rate_limit_max_requests = nil
         @rate_limit_window_seconds = 60
         @authorize = nil
+        @http_log_json = false
+      end
+
+      # Effective rate-limit ceiling for {HttpTransportApp} (+0+ means disabled).
+      #
+      # * Positive +rate_limit_max_requests+ — use that value (+Integer+ or numeric string).
+      # * +0+ — disable (even if {#security_profile} would suggest a limit).
+      # * +nil+ — use {#security_profile} unless {#http_rate_limit_implicitly_suppressed?}.
+      #
+      # @return [Integer]
+      def effective_http_rate_limit_max_requests
+        raw = @rate_limit_max_requests
+
+        case raw
+        when Integer
+          return 0 if raw <= 0
+
+          raw
+        when nil
+          return 0 if http_rate_limit_implicitly_suppressed?
+
+          security_profile_rate_limit_max
+        else
+          n = raw.to_i
+          return 0 if n <= 0
+
+          n
+        end
+      end
+
+      # Window length passed to {HttpRateLimiter} (+<= 0+ normalizes to +60+).
+      #
+      # @return [Integer]
+      def effective_http_rate_limit_window_seconds
+        w = @rate_limit_window_seconds.to_i
+        w = 60 if w <= 0
+
+        w
+      end
+
+      # @return [Boolean] +true+ when +nil+ max should not inherit {#security_profile} defaults
+      def http_rate_limit_implicitly_suppressed?
+        case (@mode || :hybrid).to_sym
+        when :dev
+          true
+        when :hybrid
+          !Rails.env.production?
+        when :production
+          false
+        else
+          false
+        end
       end
 
       # @yieldparam auth [AuthConfig]
@@ -43,6 +105,18 @@ module RailsAiBridge
       def auth_configure
         yield @auth if block_given?
         @auth
+      end
+
+      private
+
+      def security_profile_rate_limit_max
+        case (@security_profile || :balanced).to_sym
+        when :strict then 60
+        when :balanced then 300
+        when :relaxed then 1_200
+        else
+          300
+        end
       end
     end
   end

--- a/lib/rails_ai_bridge/mcp/settings.rb
+++ b/lib/rails_ai_bridge/mcp/settings.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Mcp
+    # MCP HTTP settings under {RailsAiBridge::Configuration#mcp}.
+    class Settings
+      # @return [Symbol] +:dev+, +:production+, +:hybrid+ (documentational)
+      attr_accessor :mode
+
+      # @return [Symbol] +:strict+, +:balanced+, +:relaxed+
+      attr_accessor :security_profile
+
+      # When +true+ in production, boot fails unless {RailsAiBridge.mcp_auth_mechanism_configured?}.
+      # @return [Boolean]
+      attr_accessor :require_auth_in_production
+
+      # Max MCP HTTP requests per +rate_limit_window_seconds+ per client IP, in-process (+nil+ or +0+ disables).
+      # @return [Integer, nil]
+      attr_accessor :rate_limit_max_requests
+
+      # Sliding window for {rate_limit_max_requests} (seconds).
+      # @return [Integer]
+      attr_accessor :rate_limit_window_seconds
+
+      # @return [Proc, nil] +->(context, request) { truthy }+ after successful authentication
+      attr_accessor :authorize
+
+      # @return [AuthConfig]
+      attr_reader :auth
+
+      def initialize
+        @auth = AuthConfig.new
+        @mode = :hybrid
+        @security_profile = :balanced
+        @require_auth_in_production = false
+        @rate_limit_max_requests = nil
+        @rate_limit_window_seconds = 60
+        @authorize = nil
+      end
+
+      # @yieldparam auth [AuthConfig]
+      # @return [AuthConfig]
+      def auth_configure
+        yield @auth if block_given?
+        @auth
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp_http_auth.rb
+++ b/lib/rails_ai_bridge/mcp_http_auth.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "digest"
-
 module RailsAiBridge
   # Shared HTTP MCP authentication for {Middleware} and {Server} Rack apps.
   # When +http_mcp_token+ or +ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]+ is set, requests must send
@@ -34,22 +32,7 @@ module RailsAiBridge
     # @param request [Rack::Request] request to validate
     # @return [Boolean] true when auth is not configured or the Bearer token matches
     def authorized_request?(request)
-      return true unless http_mcp_auth_configured?
-
-      auth = request.get_header("HTTP_AUTHORIZATION")
-      return false if auth.blank?
-
-      match = auth.match(/\ABearer\s+(.+)\z/i)
-      return false unless match
-
-      received = match[1].to_s.strip
-      expected = effective_http_mcp_token.to_s
-      return false if received.blank? || expected.blank?
-
-      ActiveSupport::SecurityUtils.secure_compare(
-        Digest::SHA256.hexdigest(received),
-        Digest::SHA256.hexdigest(expected)
-      )
+      Mcp::HttpAuth.authenticate(request).success?
     end
 
     # Builds a Rack-compatible unauthorized response for HTTP MCP endpoints.
@@ -63,6 +46,32 @@ module RailsAiBridge
           "WWW-Authenticate" => 'Bearer realm="rails-ai-bridge-mcp"'
         },
         [ '{"error":"Unauthorized"}' ]
+      ]
+    end
+
+    # Rack 403 after authentication succeeded but {RailsAiBridge::Configuration#mcp} +authorize+ rejected.
+    #
+    # @return [Array<(Integer, Hash{String => String}, Array<String>)>]
+    def forbidden_rack_response
+      [
+        403,
+        { "Content-Type" => "application/json" },
+        [ '{"error":"Forbidden"}' ]
+      ]
+    end
+
+    # JSON 429 when the MCP HTTP rate limiter rejects a request.
+    #
+    # @param retry_after [Integer, nil] optional +Retry-After+ header value in seconds
+    # @return [Array<(Integer, Hash{String => String}, Array<String>)>]
+    def rate_limited_rack_response(retry_after: nil)
+      headers = { "Content-Type" => "application/json" }
+      headers["Retry-After"] = retry_after.to_s if retry_after&.positive?
+
+      [
+        429,
+        headers,
+        [ '{"error":"Too Many Requests"}' ]
       ]
     end
   end

--- a/lib/rails_ai_bridge/serializers/codex_serializer.rb
+++ b/lib/rails_ai_bridge/serializers/codex_serializer.rb
@@ -33,26 +33,9 @@ module RailsAiBridge
         lines << ""
         lines << "Codex reads this file before starting work in this repository."
         lines << ""
+        lines.concat(SharedAssistantGuidance.intro_snapshot_lines(context))
         lines.concat(SharedAssistantGuidance.compact_engineering_rules_lines)
 
-        lines << "## Project overview"
-        lines << "- App: #{context[:app_name]}"
-        lines << "- Stack: Rails #{context[:rails_version]} | Ruby #{context[:ruby_version]}"
-
-        schema = context[:schema]
-        if schema && !schema[:error]
-          lines << "- Database: #{schema[:adapter]} (#{schema[:total_tables]} tables)"
-        end
-
-        models = context[:models]
-        if models.is_a?(Hash) && !models[:error]
-          lines << "- Models: #{models.size}"
-        end
-
-        line = ContextSummary.routes_stack_line(context)
-        lines << line if line
-
-        lines << ""
         lines << "## Working agreements"
         lines << "- Prefer the MCP tools over guessing the Rails structure."
         lines << "- Start with `detail:\"summary\"`, then drill into specifics."
@@ -64,7 +47,7 @@ module RailsAiBridge
         SharedAssistantGuidance.performance_security_and_rails_examples_lines.each { |l| lines << l }
         lines << ""
 
-        append_compact_codex_models_section(lines, models)
+        append_compact_codex_models_section(lines, context[:models])
 
         conv = context[:conventions]
         if conv.is_a?(Hash) && !conv[:error]

--- a/lib/rails_ai_bridge/serializers/context_file_serializer.rb
+++ b/lib/rails_ai_bridge/serializers/context_file_serializer.rb
@@ -2,12 +2,17 @@
 
 module RailsAiBridge
   module Serializers
-    # Orchestrates writing context files to disk in various formats.
-    # Supports: CLAUDE.md, .cursorrules, .windsurfrules, .github/copilot-instructions.md, JSON
-    # Also generates split rule files for AI tools that support them.
+    # Writes compact (or full) assistant context files under {Rails.root} or +config.output_dir+.
+    #
+    # Dispatches to format-specific serializers and, for Copilot, merges into a managed HTML comment region
+    # so host edits outside that block are preserved. Also emits “split” rule files (.claude/rules/, etc.)
+    # when the primary format for that assistant is included in the run.
+    #
+    # @see AssistantFormatsPreference
     class ContextFileSerializer
       attr_reader :context, :format
 
+      # Maps logical format keys to a single top-level filename under the output directory.
       FORMAT_MAP = {
         claude:    "CLAUDE.md",
         codex:     "AGENTS.md",
@@ -17,15 +22,25 @@ module RailsAiBridge
         json:      ".ai-context.json"
       }.freeze
 
+      # Start marker for gem-managed Copilot markdown (see {#write_copilot_with_merge}).
+      COPILOT_MANAGED_BEGIN = "<!-- rails-ai-bridge:begin managed -->"
+      # End marker for gem-managed Copilot markdown.
+      COPILOT_MANAGED_END = "<!-- rails-ai-bridge:end managed -->"
+      # Matches one managed block for replacement.
+      COPILOT_MANAGED_BLOCK = /#{Regexp.escape(COPILOT_MANAGED_BEGIN)}.*?#{Regexp.escape(COPILOT_MANAGED_END)}/m
+
+      # @param context [Hash] introspection snapshot passed to format serializers
+      # @param format [Symbol, Array<Symbol>] +:all+, a single key from {FORMAT_MAP}, or an array of keys
       def initialize(context, format: :all)
         @context = context
         @format  = format
       end
 
-      # Write context files, skipping unchanged ones.
-      # @return [Hash] { written: [paths], skipped: [paths] }
+      # Writes requested files and split rules, skipping byte-identical paths.
+      #
+      # @return [Hash{Symbol => Array<String>}] +:written+ and +:skipped+ file paths
       def call
-        formats = format == :all ? FORMAT_MAP.keys : Array(format)
+        formats = normalize_format_list(@format)
         output_dir = RailsAiBridge.configuration.output_dir_for(Rails.application)
         written = []
         skipped = []
@@ -38,13 +53,13 @@ module RailsAiBridge
           end
 
           filepath = File.join(output_dir, filename)
-
-          # Ensure subdirectory exists (e.g. .github/)
           FileUtils.mkdir_p(File.dirname(filepath))
 
           content = serialize(fmt)
 
-          if File.exist?(filepath) && File.read(filepath) == content
+          if fmt == :copilot
+            write_copilot_with_merge(filepath, content, written, skipped)
+          elsif File.exist?(filepath) && File.read(filepath) == content
             skipped << filepath
           else
             File.write(filepath, content)
@@ -52,7 +67,6 @@ module RailsAiBridge
           end
         end
 
-        # Generate split rule files for all AI tools that support them
         generate_split_rules(formats, output_dir, written, skipped)
 
         { written: written, skipped: skipped }
@@ -60,6 +74,71 @@ module RailsAiBridge
 
       private
 
+      # @param format [Object]
+      # @raise [ArgumentError] when an unknown format key appears in an array
+      # @return [Array<Symbol>]
+      def normalize_format_list(format)
+        case format
+        when :all
+          FORMAT_MAP.keys
+        when Array
+          list = format.map(&:to_sym).uniq
+          unknown = list - FORMAT_MAP.keys
+          raise ArgumentError, "Unknown format(s): #{unknown.join(", ")}" if unknown.any?
+
+          list
+        else
+          [ format ].flatten.map(&:to_sym)
+        end
+      end
+
+      # @param inner_markdown [String]
+      # @return [String]
+      def wrap_copilot_managed(inner_markdown)
+        "#{COPILOT_MANAGED_BEGIN}\n#{inner_markdown.to_s.strip}\n#{COPILOT_MANAGED_END}\n"
+      end
+
+      # Updates +copilot-instructions.md+ by replacing the managed block, or skips/warns per +RAILS_AI_BRIDGE_COPILOT_MERGE+.
+      #
+      # @param filepath [String]
+      # @param inner_content [String] serialized Copilot body (without managed markers)
+      # @param written [Array<String>] mutated with path if written
+      # @param skipped [Array<String>] mutated with path if skipped
+      # @return [void]
+      def write_copilot_with_merge(filepath, inner_content, written, skipped)
+        wrapped = wrap_copilot_managed(inner_content)
+        mode = ENV.fetch("RAILS_AI_BRIDGE_COPILOT_MERGE", "").to_s.downcase
+
+        if File.exist?(filepath)
+          existing = File.read(filepath)
+          if existing.match?(COPILOT_MANAGED_BLOCK)
+            updated = existing.sub(COPILOT_MANAGED_BLOCK, wrapped.strip)
+          elsif mode == "overwrite"
+            updated = wrapped
+          elsif mode == "skip"
+            warn "[rails-ai-bridge] Skipping #{filepath} (no managed markers; RAILS_AI_BRIDGE_COPILOT_MERGE=skip)."
+            skipped << filepath
+            return
+          else
+            warn "[rails-ai-bridge] Skipping #{filepath}: existing file has no #{COPILOT_MANAGED_BEGIN}/END managed block. " \
+                 "Set RAILS_AI_BRIDGE_COPILOT_MERGE=overwrite to replace, or wrap your file manually."
+            skipped << filepath
+            return
+          end
+        else
+          updated = wrapped
+        end
+
+        if File.exist?(filepath) && File.read(filepath) == updated
+          skipped << filepath
+        else
+          File.write(filepath, updated)
+          written << filepath
+        end
+      end
+
+      # @param fmt [Symbol]
+      # @return [String]
       def serialize(fmt)
         case fmt
         when :json     then JsonSerializer.new(context).call
@@ -72,6 +151,11 @@ module RailsAiBridge
         end
       end
 
+      # @param formats [Array<Symbol>]
+      # @param output_dir [String]
+      # @param written [Array<String>]
+      # @param skipped [Array<String>]
+      # @return [void]
       def generate_split_rules(formats, output_dir, written, skipped)
         if formats.include?(:claude)
           result = ClaudeRulesSerializer.new(context).call(output_dir)

--- a/lib/rails_ai_bridge/serializers/copilot_serializer.rb
+++ b/lib/rails_ai_bridge/serializers/copilot_serializer.rb
@@ -26,8 +26,7 @@ module RailsAiBridge
         lines = []
         lines << "# #{context[:app_name]} — Copilot Context"
         lines << ""
-        lines << "Rails #{context[:rails_version]} | Ruby #{context[:ruby_version]}"
-        lines << ""
+        lines.concat(SharedAssistantGuidance.intro_snapshot_lines(context))
         lines.concat(SharedAssistantGuidance.compact_engineering_rules_lines)
         # Stack overview
         lines << "## Stack"
@@ -70,48 +69,7 @@ module RailsAiBridge
 
         append_compact_copilot_models_section(lines, models)
 
-
-        # MCP tools
-        lines << "## MCP Tool Reference"
-        lines << ""
-        lines << "This project has MCP tools for live introspection."
-        lines << "**Always start with `detail:\"summary\"`, then drill into specifics.**"
-        lines << ""
-        lines << "### Detail levels (schema, routes, models, controllers)"
-        lines << "- `summary` — names + counts (default limit: 50)"
-        lines << "- `standard` — names + key details (default limit: 15, this is the default)"
-        lines << "- `full` — everything including indexes, FKs (default limit: 5)"
-        lines << ""
-        lines << "### rails_get_schema"
-        lines << "Params: `table`, `detail`, `limit`, `offset`, `format`"
-        lines << "- `rails_get_schema(detail:\"summary\")` — all tables with column counts"
-        lines << "- `rails_get_schema(table:\"users\")` — full detail for one table"
-        lines << "- `rails_get_schema(detail:\"summary\", limit:20, offset:40)` — paginate"
-        lines << ""
-        lines << "### rails_get_model_details"
-        lines << "Params: `model`, `detail`"
-        lines << "- `rails_get_model_details(detail:\"summary\")` — list all model names"
-        lines << "- `rails_get_model_details(model:\"User\")` — associations, validations, scopes, enums"
-        lines << ""
-        lines << "### rails_get_routes"
-        lines << "Params: `controller`, `detail`, `limit`, `offset`"
-        lines << "- `rails_get_routes(detail:\"summary\")` — route counts per controller"
-        lines << "- `rails_get_routes(controller:\"users\")` — routes for one controller"
-        lines << ""
-        lines << "### rails_get_controllers"
-        lines << "Params: `controller`, `detail`"
-        lines << "- `rails_get_controllers(detail:\"summary\")` — names + action counts"
-        lines << "- `rails_get_controllers(controller:\"UsersController\")` — actions, filters, params"
-        lines << ""
-        lines << "### Other tools"
-        lines << "- `rails_get_config` — cache store, session, timezone, middleware"
-        lines << "- `rails_get_test_info` — test framework, factories/fixtures, CI config"
-        lines << "- `rails_get_gems` — notable gems categorized by function"
-        lines << "- `rails_get_conventions` — architecture patterns, directory structure"
-        lines << "- `rails_search_code(pattern:\"regex\", file_type:\"rb\", max_results:20)` — codebase search"
-        lines << ""
-        lines << "_The same MCP reference also appears under `.github/instructions/rails-mcp-tools.instructions.md` and `.cursor/rules/rails-mcp-tools.mdc` for path-scoped clients._"
-        lines << ""
+        lines.concat(SharedAssistantGuidance.compact_copilot_mcp_tool_reference_lines)
 
         # Conventions
         lines << "## Conventions"

--- a/lib/rails_ai_bridge/serializers/shared_assistant_guidance.rb
+++ b/lib/rails_ai_bridge/serializers/shared_assistant_guidance.rb
@@ -13,12 +13,83 @@ module RailsAiBridge
       # First line of +overrides.md+ while in stub mode — file is not merged until removed.
       OMIT_MERGE_FIRST_LINE = /\A<!--\s*rails-ai-bridge:omit-merge\s*-->\z/i
 
+      # Snapshot block for compact AGENTS.md / Copilot: high-level facts from the last introspection run.
+      #
+      # Composes a fixed heading plus one line per stack, preset, schema/models (when present), routes, and MCP hint.
+      #
+      # @param context [Hash] introspection snapshot (+:environment+, +:rails_version+, +:schema+, +:models+, …)
+      # @return [Array<String>] markdown lines ending with a trailing blank line
+      def intro_snapshot_lines(context)
+        intro_snapshot_heading_lines + intro_snapshot_metric_lines(context) + [ "" ]
+      end
+
+      # Markdown lines for the compact Copilot primary document: full MCP tool cheat sheet (+##+ / +###+ headings).
+      #
+      # Kept here so +CopilotSerializer+ stays orchestration-only; wording matches split Copilot instruction files.
+      #
+      # @return [Array<String>]
+      def compact_copilot_mcp_tool_reference_lines
+        [
+          "## MCP Tool Reference",
+          "",
+          "This project has MCP tools for live introspection.",
+          "**Always start with `detail:\"summary\"`, then drill into specifics.**",
+          "",
+          "### Detail levels (schema, routes, models, controllers)",
+          "- `summary` — names + counts (default limit: 50)",
+          "- `standard` — names + key details (default limit: 15, this is the default)",
+          "- `full` — everything including indexes, FKs (default limit: 5)",
+          "",
+          "### rails_get_schema",
+          "Params: `table`, `detail`, `limit`, `offset`, `format`",
+          "- `rails_get_schema(detail:\"summary\")` — all tables with column counts",
+          "- `rails_get_schema(table:\"users\")` — full detail for one table",
+          "- `rails_get_schema(detail:\"summary\", limit:20, offset:40)` — paginate",
+          "",
+          "### rails_get_model_details",
+          "Params: `model`, `detail`",
+          "- `rails_get_model_details(detail:\"summary\")` — list all model names",
+          "- `rails_get_model_details(model:\"User\")` — associations, validations, scopes, enums",
+          "",
+          "### rails_get_routes",
+          "Params: `controller`, `detail`, `limit`, `offset`",
+          "- `rails_get_routes(detail:\"summary\")` — route counts per controller",
+          "- `rails_get_routes(controller:\"users\")` — routes for one controller",
+          "",
+          "### rails_get_controllers",
+          "Params: `controller`, `detail`",
+          "- `rails_get_controllers(detail:\"summary\")` — names + action counts",
+          "- `rails_get_controllers(controller:\"UsersController\")` — actions, filters, params",
+          "",
+          "### Other tools",
+          "- `rails_get_config` — cache store, session, timezone, middleware",
+          "- `rails_get_test_info` — test framework, factories/fixtures, CI config",
+          "- `rails_get_gems` — notable gems categorized by function",
+          "- `rails_get_conventions` — architecture patterns, directory structure",
+          "- `rails_search_code(pattern:\"regex\", file_type:\"rb\", max_results:20)` — codebase search",
+          "",
+          "_The same MCP reference also appears under `.github/instructions/rails-mcp-tools.instructions.md` and `.cursor/rules/rails-mcp-tools.mdc` for path-scoped clients._",
+          ""
+        ]
+      end
+
+      # @return [Boolean] +true+ when +overrides.md+ exists but is not mergeable (install stub).
+      def overrides_stub_active?
+        path = resolved_assistant_overrides_path
+        return false unless path && File.file?(path)
+
+        body = File.read(path)
+        return false if body.strip.empty?
+
+        !mergeable_override_content?(body)
+      end
+
       # @return [Array<String>] markdown lines including heading and trailing blank line
       def compact_engineering_rules_lines
         [
-          "## Engineering rules (read first)",
+          "## General engineering guidance (rails-ai-bridge baseline)",
           "",
-          "Defaults for this codebase unless existing files clearly show a different pattern.",
+          "_Baseline Rails practices for any app. Team-specific hot tables, auth boundaries, and compliance belong in `config/rails_ai_bridge/overrides.md`._",
           "",
           "### Controllers & strong parameters",
           "- Permit attributes explicitly; never pass raw `params` into `Model.new`, `update`, or `assign_attributes`.",
@@ -134,17 +205,38 @@ module RailsAiBridge
         end
       end
 
-      # @return [Array<String>] section to splice after stack; empty if no overrides
+      # @return [Array<String>] merged team rules, stub notice, or optional pointer
       def repo_specific_guidance_section_lines
         body = read_assistant_overrides
-        return [] unless body
+        if body
+          return [
+            "## Repo-specific guidance",
+            "",
+            body,
+            ""
+          ]
+        end
 
-        [
-          "## Repo-specific guidance",
-          "",
-          body,
-          ""
-        ]
+        if overrides_stub_active?
+          return [
+            "## Repo-specific guidance",
+            "",
+            "_Inactive: `config/rails_ai_bridge/overrides.md` still has the `<!-- rails-ai-bridge:omit-merge -->` marker as the first non-empty line. Remove it to merge team rules here._",
+            ""
+          ]
+        end
+
+        path = resolved_assistant_overrides_path
+        if path && !File.file?(path)
+          return [
+            "## Repo-specific guidance",
+            "",
+            "_Optional: add `config/rails_ai_bridge/overrides.md` for internal constraints (use `overrides.md.example` as a template)._",
+            ""
+          ]
+        end
+
+        []
       end
 
       # Baseline bullets plus concrete Rails patterns for large data.
@@ -153,6 +245,59 @@ module RailsAiBridge
       def performance_security_and_rails_examples_lines
         ContextSummary.compact_performance_security_section + rails_performance_examples_lines
       end
+
+      def intro_snapshot_heading_lines
+        [
+          "## This repository (from introspection)",
+          "_Generated by rails-ai-bridge. This is not your team policy file — see **Repo-specific guidance** below._",
+          ""
+        ]
+      end
+      private_class_method :intro_snapshot_heading_lines
+
+      def intro_snapshot_metric_lines(context)
+        cfg = RailsAiBridge.configuration
+        lines = []
+        lines << intro_snapshot_stack_bullet(context)
+        lines << intro_snapshot_preset_bullet(cfg)
+        lines.concat(intro_snapshot_schema_model_bullets(context))
+        rline = ContextSummary.routes_stack_line(context)
+        lines << rline if rline
+        lines << intro_snapshot_mcp_hint_bullet
+        lines
+      end
+      private_class_method :intro_snapshot_metric_lines
+
+      def intro_snapshot_stack_bullet(context)
+        env = context[:environment].to_s
+        env = "unknown" if env.empty?
+        "- **Stack:** Rails #{context[:rails_version]} | Ruby #{context[:ruby_version]} | #{env}"
+      end
+      private_class_method :intro_snapshot_stack_bullet
+
+      def intro_snapshot_preset_bullet(cfg)
+        "- **Preset:** `#{cfg.inferred_preset_name}` (#{cfg.effective_introspectors.size} introspectors; category exclusions applied)"
+      end
+      private_class_method :intro_snapshot_preset_bullet
+
+      def intro_snapshot_schema_model_bullets(context)
+        out = []
+        schema = context[:schema]
+        if schema.is_a?(Hash) && !schema[:error]
+          out << "- **Database:** #{schema[:adapter]} — #{schema[:total_tables]} tables (after `excluded_tables`)"
+        end
+        models = context[:models]
+        if models.is_a?(Hash) && !models[:error]
+          out << "- **Models:** #{models.size} (after exclusions)"
+        end
+        out
+      end
+      private_class_method :intro_snapshot_schema_model_bullets
+
+      def intro_snapshot_mcp_hint_bullet
+        "- **MCP:** start with `rails_get_routes` + `detail:\"summary\"`, then `rails_get_schema` / `rails_get_model_details`."
+      end
+      private_class_method :intro_snapshot_mcp_hint_bullet
     end
   end
 end

--- a/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
+++ b/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
@@ -25,7 +25,7 @@ def apply_context_mode_override
 end
 
 namespace :ai do
-  desc "Generate AI bridge files (CLAUDE.md, .cursorrules, .windsurfrules, .github/copilot-instructions.md)"
+  desc "Generate AI bridge files (respects config/rails_ai_bridge/install.yml when present; otherwise all formats)"
   task bridge: :environment do
     require "rails_ai_bridge"
 
@@ -33,13 +33,14 @@ namespace :ai do
 
     puts "🔍 Introspecting #{Rails.application.class.module_parent_name}..."
 
-    puts "📝 Writing bridge files..."
-    result = RailsAiBridge.generate_context(format: :all)
+    puts "📝 Writing bridge files (selection from install.yml if configured)..."
+    result = RailsAiBridge.generate_context(format: :install)
 
     print_result(result)
     puts ""
     puts "Done! Your AI assistants now understand your Rails app."
     puts "Commit these files so your whole team benefits."
+    puts "Run `rails ai:bridge:all` to regenerate every format including JSON (ignores install.yml)."
     puts ""
     puts ASSISTANT_TABLE
   end
@@ -60,6 +61,21 @@ namespace :ai do
   end
 
   namespace :bridge do
+    desc "Generate every bridge format (including JSON), ignoring install.yml"
+    task all: :environment do
+      require "rails_ai_bridge"
+
+      apply_context_mode_override
+
+      puts "🔍 Introspecting #{Rails.application.class.module_parent_name}..."
+      puts "📝 Writing all bridge files..."
+      result = RailsAiBridge.generate_context(format: :all)
+
+      print_result(result)
+      puts ""
+      puts "Done! All formats written."
+    end
+
     { claude: "CLAUDE.md", codex: "AGENTS.md", cursor: ".cursorrules", windsurf: ".windsurfrules",
       copilot: ".github/copilot-instructions.md", json: ".ai-context.json" }.each do |fmt, file|
       desc "Generate #{file} bridge file"
@@ -74,7 +90,7 @@ namespace :ai do
 
         print_result(result)
         puts ""
-        puts "Tip: Run `rails ai:bridge` to generate all formats at once."
+        puts "Tip: Run `rails ai:bridge` for your install.yml selection, or `rails ai:bridge:all` for every format."
       end
     end
 

--- a/lib/rails_ai_bridge/watcher.rb
+++ b/lib/rails_ai_bridge/watcher.rb
@@ -1,10 +1,24 @@
 # frozen_string_literal: true
 
 module RailsAiBridge
-  # File system watcher that regenerates bridge files when key files change.
-  # Requires the `listen` gem (optional dependency).
+  # Watches a fixed set of project directories and regenerates bridge files when the
+  # {Fingerprinter} detects a meaningful change.
+  #
+  # Depends on the +listen+ gem, which is **not** a runtime dependency of rails-ai-bridge: add
+  # +gem "listen", group: :development+ to the **host application** (or rely on Rails’ default
+  # development group, which often includes it). The gem declares +listen+ only as a
+  # development dependency for maintainers and CI.
+  #
+  # @see Fingerprinter
+  # @see RailsAiBridge.generate_context
   class Watcher
+    # Reserved interval (seconds) for future debouncing; regeneration is currently gated by
+    # fingerprint comparison in {#handle_change}.
     DEBOUNCE_SECONDS = 2
+
+    # Subpaths under +Rails.root+ passed to +Listen+. Only existing directories are watched.
+    #
+    # @return [Array<String>]
     WATCH_PATTERNS = %w[
       app/models
       app/controllers
@@ -15,13 +29,22 @@ module RailsAiBridge
       db
     ].freeze
 
+    # @return [Rails::Application]
     attr_reader :app
 
+    # @param app [Rails::Application, nil] defaults to +Rails.application+
     def initialize(app = nil)
       @app = app || Rails.application
       @last_fingerprint = Fingerprinter.compute(@app)
     end
 
+    # Starts +Listen+ on {WATCH_PATTERNS}, then blocks in a sleep loop until SIGINT (+Interrupt+).
+    #
+    # Calls {RailsAiBridge.generate_context} with +format: :install+ when the fingerprint changes.
+    #
+    # @return [void] may return early when no watchable directories exist
+    # @note On missing +listen+, prints to stderr and calls +exit(1)+.
+    # @note This method does not return normally unless no directories are watchable.
     def start
       require "listen"
 
@@ -59,13 +82,16 @@ module RailsAiBridge
 
     private
 
+    # Regenerates context when {Fingerprinter.changed?} is true; updates the cached fingerprint.
+    #
+    # @return [void]
     def handle_change
       return unless Fingerprinter.changed?(app, @last_fingerprint)
 
       @last_fingerprint = Fingerprinter.compute(app)
 
       $stderr.puts "[rails-ai-bridge] Changes detected, regenerating bridge files..."
-      result = RailsAiBridge.generate_context(format: :all)
+      result = RailsAiBridge.generate_context(format: :install)
       result[:written].each { |f| $stderr.puts "  Updated: #{f}" }
       result[:skipped].each { |f| $stderr.puts "  Unchanged: #{f}" }
     rescue => e

--- a/rails-ai-bridge.gemspec
+++ b/rails-ai-bridge.gemspec
@@ -5,7 +5,7 @@ require_relative "lib/rails_ai_bridge/version"
 Gem::Specification.new do |spec|
   spec.name          = "rails-ai-bridge"
   spec.version       = RailsAiBridge::VERSION
-  spec.authors       = [ "Ismael Marin" ]
+  spec.authors       = [ "Ismael G Marin Cabrera" ]
   spec.email         = [ "ismael.marin@gmail.com" ]
 
   spec.summary       = "Give AI assistants deep, live knowledge of your Rails app via MCP."
@@ -30,11 +30,22 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.post_install_message = <<~MSG
-    rails-ai-bridge installed! Quick start:
+    rails-ai-bridge installed!
+
+    Recommended: keep the gem in :development so production bundles stay lean:
+      group :development do
+        gem "rails-ai-bridge"
+      end
+    Without :development, Bundler also installs it for production unless you exclude the group.
+
+    Quick start:
       rails generate rails_ai_bridge:install
-      rails ai:bridge          # generate bridge files (compact mode)
-      rails ai:bridge:full     # full dump (good for small apps)
-      rails ai:serve           # start MCP server for Claude Code / Cursor
+      rails ai:bridge              # respects config/rails_ai_bridge/install.yml
+      rails ai:bridge:all          # every format, including JSON
+      rails ai:bridge:full         # full context dump (small apps)
+      rails ai:serve               # MCP server (stdio) for Claude / Cursor
+
+    HTTP auto_mount is off by default — read SECURITY.md before exposing /mcp.
   MSG
 
   spec.files = Dir.chdir(__dir__) do
@@ -62,4 +73,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", "~> 0.9"
   spec.add_development_dependency "combustion", "~> 1.4" # Test Rails engines in isolation
   spec.add_development_dependency "simplecov", "~> 0.22"
+  # Optional at runtime: host apps need `gem "listen"` for `rails ai:watch` (see Watcher).
+  spec.add_development_dependency "listen", "~> 3.9"
 end

--- a/spec/internal/config/rails_ai_bridge/install.yml
+++ b/spec/internal/config/rails_ai_bridge/install.yml
@@ -1,0 +1,5 @@
+---
+formats:
+- cursor
+- claude
+- json

--- a/spec/lib/generators/rails_ai_bridge/install_generator_spec.rb
+++ b/spec/lib/generators/rails_ai_bridge/install_generator_spec.rb
@@ -20,12 +20,15 @@ RSpec.describe RailsAiBridge::Generators::InstallGenerator do
 
       expect(content).to include(":standard — 9 core introspectors")
       expect(content).to include(":full     — all 26 introspectors")
+      expect(content).to include(":regulated")
+      expect(content).to include("SECURITY CRITICAL")
+      expect(content).to include("RAILS_AI_BRIDGE_MCP_TOKEN")
     end
   end
 
   describe "#generate_context_files" do
     it "reports written and skipped files separately" do
-      allow(RailsAiBridge).to receive(:generate_context).and_return({
+      allow(RailsAiBridge).to receive(:generate_context).with(format: :install).and_return({
         written: [ "CLAUDE.md" ],
         skipped: [ ".cursorrules" ]
       })

--- a/spec/lib/rails_ai_bridge/assistant_formats_preference_spec.rb
+++ b/spec/lib/rails_ai_bridge/assistant_formats_preference_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::AssistantFormatsPreference do
+  describe ".formats_for_default_bridge_task" do
+    it "returns nil when install.yml is missing" do
+      allow(described_class).to receive(:config_path).and_return(Pathname.new("/__no_such__/install.yml"))
+      expect(described_class.formats_for_default_bridge_task).to be_nil
+    end
+
+    it "returns nil when YAML is not a Hash" do
+      Dir.mktmpdir do |dir|
+        path = Pathname.new(dir).join("config/rails_ai_bridge/install.yml")
+        path.dirname.mkpath
+        File.write(path, "--- []\n")
+        allow(described_class).to receive(:config_path).and_return(path)
+        expect(described_class.formats_for_default_bridge_task).to be_nil
+      end
+    end
+
+    it "returns nil when formats list is empty after filtering" do
+      Dir.mktmpdir do |dir|
+        path = Pathname.new(dir).join("config/rails_ai_bridge/install.yml")
+        path.dirname.mkpath
+        File.write(path, YAML.dump({ "formats" => %w[unknown_fmt] }))
+        allow(described_class).to receive(:config_path).and_return(path)
+        expect(described_class.formats_for_default_bridge_task).to be_nil
+      end
+    end
+
+    it "returns nil for invalid YAML" do
+      Dir.mktmpdir do |dir|
+        path = Pathname.new(dir).join("config/rails_ai_bridge/install.yml")
+        path.dirname.mkpath
+        File.write(path, "{ not: valid: yaml :")
+        allow(described_class).to receive(:config_path).and_return(path)
+        expect(described_class.formats_for_default_bridge_task).to be_nil
+      end
+    end
+  end
+
+  describe ".write!" do
+    it "persists normalized format keys" do
+      Dir.mktmpdir do |dir|
+        path = Pathname.new(dir).join("config/rails_ai_bridge/install.yml")
+        allow(described_class).to receive(:config_path).and_return(path)
+        described_class.write!(formats: %i[cursor claude json])
+        data = YAML.load_file(path)
+        expect(data["formats"]).to eq(%w[cursor claude json])
+      end
+    end
+
+    it "raises when Rails app path is unavailable" do
+      allow(described_class).to receive(:config_path).and_return(nil)
+      expect { described_class.write!(formats: [ :claude ]) }.to raise_error(RailsAiBridge::Error, /Rails app not available/)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/configuration_spec.rb
+++ b/spec/lib/rails_ai_bridge/configuration_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe RailsAiBridge::Configuration do
     expect(config.additional_resources).to eq({})
   end
 
+  it "memoizes mcp settings" do
+    expect(config.mcp).to be(config.mcp)
+    expect(config.mcp).to be_a(RailsAiBridge::Mcp::Settings)
+  end
+
   it "defaults to standard preset" do
     expect(config.introspectors).to eq(described_class::PRESETS[:standard])
   end

--- a/spec/lib/rails_ai_bridge/configuration_spec.rb
+++ b/spec/lib/rails_ai_bridge/configuration_spec.rb
@@ -66,6 +66,29 @@ RSpec.describe RailsAiBridge::Configuration do
       expect { config.preset = :unknown }.to raise_error(ArgumentError, /Unknown preset/)
     end
 
+    it "sets large_monolith preset to standard-shaped introspector list" do
+      config.preset = :large_monolith
+      expect(config.introspectors).to eq(described_class::PRESETS[:standard])
+    end
+
+    it "sets regulated preset without schema, models, or migrations" do
+      config.preset = :regulated
+      expect(config.introspectors).not_to include(:schema, :models, :migrations)
+      expect(config.introspectors).to include(:routes, :controllers)
+    end
+
+    it "effective_introspectors subtracts disabled categories" do
+      config.preset = :standard
+      config.disabled_introspection_categories << :domain_metadata
+      expect(config.effective_introspectors).not_to include(:schema, :models, :migrations)
+    end
+
+    it "excluded_table? matches globs" do
+      config.excluded_tables << "secrets_*"
+      expect(config.excluded_table?("secrets_raw")).to be true
+      expect(config.excluded_table?("users")).to be false
+    end
+
     it "allows adding introspectors after preset" do
       config.preset = :standard
       config.introspectors += %i[views turbo]

--- a/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
+++ b/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
@@ -7,9 +7,15 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
 
   around do |example|
     saved_token = RailsAiBridge.configuration.http_mcp_token
+    saved_authz = RailsAiBridge.configuration.mcp.authorize
+    saved_rl_max = RailsAiBridge.configuration.mcp.rate_limit_max_requests
+    saved_rl_win = RailsAiBridge.configuration.mcp.rate_limit_window_seconds
     example.run
   ensure
     RailsAiBridge.configuration.http_mcp_token = saved_token
+    RailsAiBridge.configuration.mcp.authorize = saved_authz
+    RailsAiBridge.configuration.mcp.rate_limit_max_requests = saved_rl_max
+    RailsAiBridge.configuration.mcp.rate_limit_window_seconds = saved_rl_win
   end
 
   describe ".build" do
@@ -33,6 +39,50 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
       expect(headers["WWW-Authenticate"]).to include("Bearer")
     end
 
+    it "returns 429 when rate limit is exceeded before auth" do
+      RailsAiBridge.configuration.http_mcp_token = "secret"
+      RailsAiBridge.configuration.mcp.rate_limit_max_requests = 2
+      RailsAiBridge.configuration.mcp.rate_limit_window_seconds = 60
+      allow(transport).to receive(:handle_request).and_return([ 200, {}, [ "OK" ] ])
+      app = described_class.build(transport: transport, path: "/mcp")
+
+      base_env = {
+        "REMOTE_ADDR" => "203.0.113.9",
+        method: "POST",
+        "HTTP_AUTHORIZATION" => "Bearer secret"
+      }
+
+      expect(app.call(Rack::MockRequest.env_for("/mcp", **base_env)).first).to eq(200)
+      expect(app.call(Rack::MockRequest.env_for("/mcp", **base_env)).first).to eq(200)
+
+      status, headers, body = app.call(Rack::MockRequest.env_for("/mcp", **base_env))
+
+      expect(status).to eq(429)
+      expect(headers["Content-Type"]).to eq("application/json")
+      expect(headers["Retry-After"]).to eq("60")
+      expect(body.first).to include("Too Many Requests")
+      expect(transport).to have_received(:handle_request).twice
+    end
+
+    it "uses a 60s Retry-After when rate_limit_window_seconds is not positive" do
+      RailsAiBridge.configuration.http_mcp_token = "secret"
+      RailsAiBridge.configuration.mcp.rate_limit_max_requests = 1
+      RailsAiBridge.configuration.mcp.rate_limit_window_seconds = 0
+      allow(transport).to receive(:handle_request).and_return([ 200, {}, [ "OK" ] ])
+      app = described_class.build(transport: transport, path: "/mcp")
+
+      env = {
+        "REMOTE_ADDR" => "198.51.100.2",
+        method: "POST",
+        "HTTP_AUTHORIZATION" => "Bearer secret"
+      }
+      expect(app.call(Rack::MockRequest.env_for("/mcp", **env)).first).to eq(200)
+
+      _status, headers, = app.call(Rack::MockRequest.env_for("/mcp", **env))
+
+      expect(headers["Retry-After"]).to eq("60")
+    end
+
     it "delegates to the transport for authorized requests" do
       RailsAiBridge.configuration.http_mcp_token = "secret"
       allow(transport).to receive(:handle_request).and_return([ 200, {}, [ "OK" ] ])
@@ -48,6 +98,46 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
 
       expect(status).to eq(200)
       expect(transport).to have_received(:handle_request)
+    end
+
+    context "when config.mcp.authorize is set" do
+      before do
+        RailsAiBridge.configuration.http_mcp_token = "secret"
+      end
+
+      it "returns 403 when authorize rejects the context" do
+        RailsAiBridge.configuration.mcp.authorize = ->(_ctx, _req) { false }
+        allow(transport).to receive(:handle_request).and_return([ 200, {}, [ "OK" ] ])
+        app = described_class.build(transport: transport, path: "/mcp")
+
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          method: "POST",
+          "HTTP_AUTHORIZATION" => "Bearer secret"
+        )
+        status, headers, body = app.call(env)
+
+        expect(status).to eq(403)
+        expect(headers["Content-Type"]).to eq("application/json")
+        expect(body.first).to include("Forbidden")
+        expect(transport).not_to have_received(:handle_request)
+      end
+
+      it "delegates when authorize accepts" do
+        RailsAiBridge.configuration.mcp.authorize = ->(ctx, _req) { ctx == :static_bearer }
+        allow(transport).to receive(:handle_request).and_return([ 200, {}, [ "OK" ] ])
+        app = described_class.build(transport: transport, path: "/mcp")
+
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          method: "POST",
+          "HTTP_AUTHORIZATION" => "Bearer secret"
+        )
+        status, = app.call(env)
+
+        expect(status).to eq(200)
+        expect(transport).to have_received(:handle_request)
+      end
     end
   end
 end

--- a/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
+++ b/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
@@ -10,12 +10,18 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
     saved_authz = RailsAiBridge.configuration.mcp.authorize
     saved_rl_max = RailsAiBridge.configuration.mcp.rate_limit_max_requests
     saved_rl_win = RailsAiBridge.configuration.mcp.rate_limit_window_seconds
+    saved_mode = RailsAiBridge.configuration.mcp.mode
+    saved_profile = RailsAiBridge.configuration.mcp.security_profile
+    saved_log = RailsAiBridge.configuration.mcp.http_log_json
     example.run
   ensure
     RailsAiBridge.configuration.http_mcp_token = saved_token
     RailsAiBridge.configuration.mcp.authorize = saved_authz
     RailsAiBridge.configuration.mcp.rate_limit_max_requests = saved_rl_max
     RailsAiBridge.configuration.mcp.rate_limit_window_seconds = saved_rl_win
+    RailsAiBridge.configuration.mcp.mode = saved_mode
+    RailsAiBridge.configuration.mcp.security_profile = saved_profile
+    RailsAiBridge.configuration.mcp.http_log_json = saved_log
   end
 
   describe ".build" do
@@ -37,6 +43,17 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
 
       expect(status).to eq(401)
       expect(headers["WWW-Authenticate"]).to include("Bearer")
+    end
+
+    it "emits structured JSON log on 401 when http_log_json is enabled" do
+      RailsAiBridge.configuration.http_mcp_token = "secret"
+      RailsAiBridge.configuration.mcp.http_log_json = true
+      expect(Rails.logger).to receive(:info) do |line|
+        expect(JSON.parse(line)["event"]).to eq("unauthorized")
+      end
+      app = described_class.build(transport: transport, path: "/mcp")
+
+      app.call(Rack::MockRequest.env_for("/mcp", method: "POST"))
     end
 
     it "returns 429 when rate limit is exceeded before auth" do

--- a/spec/lib/rails_ai_bridge/mcp/auth/strategies/jwt_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/auth/strategies/jwt_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::Mcp::Auth::Strategies::Jwt do
+  describe "#authenticate" do
+    let(:decoder) { ->(token) { token == "good.jwt" ? { "sub" => "1" } : nil } }
+
+    it "returns failure when Authorization is missing" do
+      env = Rack::MockRequest.env_for("/mcp")
+      request = Rack::Request.new(env)
+      result = described_class.new(decoder: decoder).authenticate(request)
+      expect(result).to be_failure
+      expect(result.error).to eq(:missing_token)
+    end
+
+    it "returns failure when decoder is nil" do
+      env = Rack::MockRequest.env_for("/mcp", "HTTP_AUTHORIZATION" => "Bearer x")
+      request = Rack::Request.new(env)
+      result = described_class.new(decoder: nil).authenticate(request)
+      expect(result).to be_failure
+      expect(result.error).to eq(:misconfigured)
+    end
+
+    it "returns success with payload as context when decoder returns a value" do
+      env = Rack::MockRequest.env_for("/mcp", "HTTP_AUTHORIZATION" => "Bearer good.jwt")
+      request = Rack::Request.new(env)
+      result = described_class.new(decoder: decoder).authenticate(request)
+      expect(result).to be_success
+      expect(result.context).to eq({ "sub" => "1" })
+    end
+
+    it "returns failure when decoder returns nil" do
+      env = Rack::MockRequest.env_for("/mcp", "HTTP_AUTHORIZATION" => "Bearer bad.jwt")
+      request = Rack::Request.new(env)
+      result = described_class.new(decoder: decoder).authenticate(request)
+      expect(result).to be_failure
+      expect(result.error).to eq(:unauthorized)
+    end
+
+    it "returns failure when decoder returns false" do
+      false_decoder = ->(_t) { false }
+      env = Rack::MockRequest.env_for("/mcp", "HTTP_AUTHORIZATION" => "Bearer x")
+      request = Rack::Request.new(env)
+      result = described_class.new(decoder: false_decoder).authenticate(request)
+      expect(result).to be_failure
+      expect(result.error).to eq(:unauthorized)
+    end
+
+    it "returns decode_error when decoder raises StandardError" do
+      bad_decoder = ->(_t) { raise StandardError, "bad sig" }
+      env = Rack::MockRequest.env_for("/mcp", "HTTP_AUTHORIZATION" => "Bearer x")
+      request = Rack::Request.new(env)
+      result = described_class.new(decoder: bad_decoder).authenticate(request)
+      expect(result).to be_failure
+      expect(result.error).to eq(:decode_error)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/auth_result_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/auth_result_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::Mcp::AuthResult do
+  describe ".ok" do
+    it "marks success with optional context" do
+      r = described_class.ok(:ctx)
+      expect(r).to be_success
+      expect(r).not_to be_failure
+      expect(r.context).to eq(:ctx)
+      expect(r.error).to be_nil
+    end
+  end
+
+  describe ".fail" do
+    it "marks failure with error key" do
+      r = described_class.fail(:missing_token)
+      expect(r).not_to be_success
+      expect(r).to be_failure
+      expect(r.context).to be_nil
+      expect(r.error).to eq(:missing_token)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/http_auth_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/http_auth_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::Mcp::HttpAuth do
+  around do |example|
+    saved_env = ENV["RAILS_AI_BRIDGE_MCP_TOKEN"]
+    saved_cfg_token = RailsAiBridge.configuration.http_mcp_token
+    saved_resolver = RailsAiBridge.configuration.mcp.auth.token_resolver
+    saved_strategy = RailsAiBridge.configuration.mcp.auth.strategy
+    saved_jwt = RailsAiBridge.configuration.mcp.auth.jwt_decoder
+    ENV.delete("RAILS_AI_BRIDGE_MCP_TOKEN")
+    example.run
+  ensure
+    if saved_env
+      ENV["RAILS_AI_BRIDGE_MCP_TOKEN"] = saved_env
+    else
+      ENV.delete("RAILS_AI_BRIDGE_MCP_TOKEN")
+    end
+    RailsAiBridge.configuration.http_mcp_token = saved_cfg_token
+    RailsAiBridge.configuration.mcp.auth.token_resolver = saved_resolver
+    RailsAiBridge.configuration.mcp.auth.strategy = saved_strategy
+    RailsAiBridge.configuration.mcp.auth.jwt_decoder = saved_jwt
+  end
+
+  describe ".authenticate" do
+    let(:key) { described_class::ENV_CONTEXT_KEY }
+
+    context "when no HTTP MCP token is configured" do
+      before { RailsAiBridge.configuration.http_mcp_token = nil }
+
+      it "returns success without requiring Authorization" do
+        env = Rack::MockRequest.env_for("/mcp")
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_success
+        expect(result.context).to be_nil
+        expect(env[key]).to be_nil
+      end
+    end
+
+    context "when token is configured" do
+      before { RailsAiBridge.configuration.http_mcp_token = "correct-token" }
+
+      it "returns failure when Authorization is missing" do
+        env = Rack::MockRequest.env_for("/mcp")
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_failure
+        expect(env[key]).to be_nil
+      end
+
+      it "returns failure for wrong Bearer token" do
+        env = Rack::MockRequest.env_for("/mcp", "HTTP_AUTHORIZATION" => "Bearer wrong")
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_failure
+        expect(env[key]).to be_nil
+      end
+
+      it "returns success and sets rack env context when Bearer matches" do
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          "HTTP_AUTHORIZATION" => "Bearer correct-token"
+        )
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_success
+        expect(result.context).to eq(:static_bearer)
+        expect(env[key]).to eq(:static_bearer)
+      end
+    end
+
+    context "when token_resolver is configured without static token" do
+      before do
+        RailsAiBridge.configuration.http_mcp_token = nil
+        RailsAiBridge.configuration.mcp.auth.strategy = :bearer_token
+        RailsAiBridge.configuration.mcp.auth.token_resolver = lambda do |token|
+          token == "api-ok" ? :resolved_user : nil
+        end
+      end
+
+      it "returns success with resolver context when token maps" do
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          "HTTP_AUTHORIZATION" => "Bearer api-ok"
+        )
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_success
+        expect(result.context).to eq(:resolved_user)
+        expect(env[key]).to eq(:resolved_user)
+      end
+
+      it "returns failure when resolver returns nil" do
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          "HTTP_AUTHORIZATION" => "Bearer unknown"
+        )
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_failure
+        expect(env[key]).to be_nil
+      end
+
+      it "returns failure when resolver returns false" do
+        RailsAiBridge.configuration.mcp.auth.token_resolver = ->(_t) { false }
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          "HTTP_AUTHORIZATION" => "Bearer any"
+        )
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_failure
+        expect(result.error).to eq(:unauthorized)
+        expect(env[key]).to be_nil
+      end
+
+      it "returns failure when resolver raises (no exception propagates)" do
+        RailsAiBridge.configuration.mcp.auth.token_resolver = ->(_t) { raise StandardError, "simulated resolver failure" }
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          "HTTP_AUTHORIZATION" => "Bearer any-token"
+        )
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_failure
+        expect(result.error).to eq(:resolver_error)
+        expect(env[key]).to be_nil
+      end
+    end
+
+    context "when jwt_decoder is configured (strategy :jwt)" do
+      before do
+        RailsAiBridge.configuration.http_mcp_token = nil
+        RailsAiBridge.configuration.mcp.auth.token_resolver = nil
+        RailsAiBridge.configuration.mcp.auth.strategy = :jwt
+        RailsAiBridge.configuration.mcp.auth.jwt_decoder = lambda do |token|
+          token == "valid" ? { "sub" => "user-1" } : nil
+        end
+      end
+
+      it "returns success and sets context to decoded payload" do
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          "HTTP_AUTHORIZATION" => "Bearer valid"
+        )
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_success
+        expect(result.context).to eq({ "sub" => "user-1" })
+        expect(env[key]).to eq({ "sub" => "user-1" })
+      end
+
+      it "returns failure when decode yields nil" do
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          "HTTP_AUTHORIZATION" => "Bearer other"
+        )
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_failure
+        expect(env[key]).to be_nil
+      end
+    end
+
+    context "when jwt_decoder is set with strategy nil (auto)" do
+      before do
+        RailsAiBridge.configuration.http_mcp_token = nil
+        RailsAiBridge.configuration.mcp.auth.strategy = nil
+        RailsAiBridge.configuration.mcp.auth.token_resolver = nil
+        RailsAiBridge.configuration.mcp.auth.jwt_decoder = ->(t) { t == "auto" ? { "ok" => true } : nil }
+      end
+
+      it "uses JWT strategy before static or resolver" do
+        env = Rack::MockRequest.env_for(
+          "/mcp",
+          "HTTP_AUTHORIZATION" => "Bearer auto"
+        )
+        request = Rack::Request.new(env)
+        result = described_class.authenticate(request)
+        expect(result).to be_success
+        expect(result.context).to eq({ "ok" => true })
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/http_rate_limiter_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/http_rate_limiter_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::Mcp::HttpRateLimiter do
+  describe "#allow?" do
+    it "allows requests under the limit" do
+      limiter = described_class.new(max_requests: 3, window_seconds: 60)
+
+      expect(limiter.allow?("1.2.3.4")).to be true
+      expect(limiter.allow?("1.2.3.4")).to be true
+      expect(limiter.allow?("1.2.3.4")).to be true
+    end
+
+    it "denies when the limit is reached within the window" do
+      limiter = described_class.new(max_requests: 2, window_seconds: 60)
+
+      expect(limiter.allow?("1.2.3.4")).to be true
+      expect(limiter.allow?("1.2.3.4")).to be true
+      expect(limiter.allow?("1.2.3.4")).to be false
+    end
+
+    it "tracks keys independently per IP" do
+      limiter = described_class.new(max_requests: 1, window_seconds: 60)
+
+      expect(limiter.allow?("10.0.0.1")).to be true
+      expect(limiter.allow?("10.0.0.2")).to be true
+    end
+
+    it "resets the window after time advances" do
+      tick = [ 1_000.0 ]
+      clock = -> { tick.first }
+      limiter = described_class.new(max_requests: 1, window_seconds: 10, clock: clock)
+
+      expect(limiter.allow?("1.2.3.4")).to be true
+      expect(limiter.allow?("1.2.3.4")).to be false
+
+      tick[0] = 1_020.0
+
+      expect(limiter.allow?("1.2.3.4")).to be true
+    end
+
+    it "uses unknown bucket for blank IP" do
+      limiter = described_class.new(max_requests: 1, window_seconds: 60)
+
+      expect(limiter.allow?("")).to be true
+      expect(limiter.allow?(nil)).to be false
+    end
+
+    it "drops the per-client hash entry when all hits fall outside the window" do
+      tick = [ 100.0 ]
+      clock = -> { tick.first }
+      limiter = described_class.new(max_requests: 5, window_seconds: 10, clock: clock)
+
+      limiter.allow?("192.0.2.1")
+      expect(limiter.instance_variable_get(:@hits)).to have_key("192.0.2.1")
+
+      tick[0] = 200.0
+      limiter.allow?("192.0.2.1")
+
+      hits = limiter.instance_variable_get(:@hits)
+      expect(hits["192.0.2.1"]).to eq([ 200.0 ])
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/http_structured_log_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/http_structured_log_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::Mcp::HttpStructuredLog do
+  let(:request) do
+    Rack::Request.new(
+      Rack::MockRequest.env_for(
+        "/mcp",
+        "REMOTE_ADDR" => "203.0.113.1",
+        "action_dispatch.request_id" => "abc-123"
+      )
+    )
+  end
+
+  around do |example|
+    saved = RailsAiBridge.configuration.mcp.http_log_json
+    example.run
+  ensure
+    RailsAiBridge.configuration.mcp.http_log_json = saved
+  end
+
+  describe ".emit" do
+    it "does not call the logger when http_log_json is false" do
+      RailsAiBridge.configuration.mcp.http_log_json = false
+      expect(Rails.logger).not_to receive(:info)
+
+      described_class.emit(request: request, event: :handled, http_status: 200)
+    end
+
+    it "logs one JSON line with msg, event, status, path, client_ip, and request_id when enabled" do
+      RailsAiBridge.configuration.mcp.http_log_json = true
+      expect(Rails.logger).to receive(:info) do |line|
+        h = JSON.parse(line)
+        expect(h["msg"]).to eq("rails_ai_bridge.mcp.http")
+        expect(h["event"]).to eq("handled")
+        expect(h["http_status"]).to eq(200)
+        expect(h["path"]).to eq("/mcp")
+        expect(h["client_ip"]).to eq("203.0.113.1")
+        expect(h["request_id"]).to eq("abc-123")
+      end
+
+      described_class.emit(request: request, event: :handled, http_status: 200)
+    end
+
+    it "merges extra keyword fields and omits nil values" do
+      RailsAiBridge.configuration.mcp.http_log_json = true
+      expect(Rails.logger).to receive(:info) do |line|
+        h = JSON.parse(line)
+        expect(h["event"]).to eq("handled")
+        expect(h["http_status"]).to eq(201)
+        expect(h["mcp_session"]).to eq("abc")
+        expect(h).not_to have_key("skipped")
+      end
+
+      described_class.emit(
+        request: request,
+        event: :handled,
+        http_status: 201,
+        mcp_session: "abc",
+        skipped: nil
+      )
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/settings_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/settings_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::Mcp::Settings do
+  describe "defaults" do
+    subject(:settings) { described_class.new }
+
+    it "uses hybrid mode and balanced profile" do
+      expect(settings.mode).to eq(:hybrid)
+      expect(settings.security_profile).to eq(:balanced)
+    end
+
+    it "does not require auth in production by default" do
+      expect(settings.require_auth_in_production).to eq(false)
+    end
+
+    it "disables MCP HTTP rate limiting by default" do
+      expect(settings.rate_limit_max_requests).to be_nil
+      expect(settings.rate_limit_window_seconds).to eq(60)
+    end
+
+    it "exposes nested auth config" do
+      expect(settings.auth).to be_a(RailsAiBridge::Mcp::AuthConfig)
+      expect(settings.auth.strategy).to be_nil
+      expect(settings.auth.token_resolver).to be_nil
+    end
+  end
+
+  describe "#auth_configure" do
+    it "yields auth for DSL-style setup" do
+      settings = described_class.new
+      settings.auth_configure do |a|
+        a.strategy = :bearer_token
+        a.token_resolver = ->(t) { t == "x" ? :user : nil }
+      end
+      expect(settings.auth.strategy).to eq(:bearer_token)
+      expect(settings.auth.token_resolver.call("x")).to eq(:user)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/settings_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/settings_spec.rb
@@ -18,12 +18,112 @@ RSpec.describe RailsAiBridge::Mcp::Settings do
     it "disables MCP HTTP rate limiting by default" do
       expect(settings.rate_limit_max_requests).to be_nil
       expect(settings.rate_limit_window_seconds).to eq(60)
+      expect(settings.effective_http_rate_limit_max_requests).to eq(0)
+    end
+
+    it "defaults http_log_json to false" do
+      expect(settings.http_log_json).to eq(false)
     end
 
     it "exposes nested auth config" do
       expect(settings.auth).to be_a(RailsAiBridge::Mcp::AuthConfig)
       expect(settings.auth.strategy).to be_nil
       expect(settings.auth.token_resolver).to be_nil
+    end
+  end
+
+  describe "effective HTTP rate limits" do
+    it "returns 0 for nil max in hybrid mode when not in production" do
+      allow(Rails.env).to receive(:production?).and_return(false)
+      m = described_class.new
+      m.mode = :hybrid
+      m.security_profile = :balanced
+      m.rate_limit_max_requests = nil
+
+      expect(m.effective_http_rate_limit_max_requests).to eq(0)
+    end
+
+    it "returns profile default for nil max in hybrid mode in production" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      m = described_class.new
+      m.mode = :hybrid
+      m.security_profile = :strict
+      m.rate_limit_max_requests = nil
+
+      expect(m.effective_http_rate_limit_max_requests).to eq(60)
+    end
+
+    it "returns profile default for nil max in production mode regardless of Rails.env" do
+      allow(Rails.env).to receive(:production?).and_return(false)
+      m = described_class.new
+      m.mode = :production
+      m.security_profile = :relaxed
+      m.rate_limit_max_requests = nil
+
+      expect(m.effective_http_rate_limit_max_requests).to eq(1_200)
+    end
+
+    it "returns 0 for nil max in dev mode" do
+      m = described_class.new
+      m.mode = :dev
+      m.security_profile = :strict
+      m.rate_limit_max_requests = nil
+
+      expect(m.effective_http_rate_limit_max_requests).to eq(0)
+    end
+
+    it "honors explicit positive integer over profile" do
+      m = described_class.new
+      m.mode = :production
+      m.security_profile = :strict
+      m.rate_limit_max_requests = 500
+
+      expect(m.effective_http_rate_limit_max_requests).to eq(500)
+    end
+
+    it "disables when explicit zero" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      m = described_class.new
+      m.mode = :hybrid
+      m.security_profile = :strict
+      m.rate_limit_max_requests = 0
+
+      expect(m.effective_http_rate_limit_max_requests).to eq(0)
+    end
+
+    it "normalizes non-positive rate_limit_window_seconds to 60" do
+      m = described_class.new
+      m.rate_limit_window_seconds = 0
+
+      expect(m.effective_http_rate_limit_window_seconds).to eq(60)
+    end
+
+    it "treats nil mode like hybrid for implicit suppression" do
+      allow(Rails.env).to receive(:production?).and_return(false)
+      m = described_class.new
+      m.mode = nil
+      m.rate_limit_max_requests = nil
+
+      expect(m.http_rate_limit_implicitly_suppressed?).to be true
+      expect(m.effective_http_rate_limit_max_requests).to eq(0)
+    end
+
+    it "treats nil security_profile like balanced for profile defaults" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      m = described_class.new
+      m.mode = :hybrid
+      m.security_profile = nil
+      m.rate_limit_max_requests = nil
+
+      expect(m.effective_http_rate_limit_max_requests).to eq(300)
+    end
+
+    it "accepts a numeric string for rate_limit_max_requests" do
+      m = described_class.new
+      m.mode = :production
+      m.rate_limit_max_requests = "150"
+
+      expect(m.effective_http_rate_limit_max_requests).to eq(150)
     end
   end
 

--- a/spec/lib/rails_ai_bridge/rails_ai_bridge_mcp_validation_spec.rb
+++ b/spec/lib/rails_ai_bridge/rails_ai_bridge_mcp_validation_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "RailsAiBridge MCP production validation" do
+  around do |example|
+    saved_token = RailsAiBridge.configuration.http_mcp_token
+    saved_req = RailsAiBridge.configuration.mcp.require_auth_in_production
+    saved_resolver = RailsAiBridge.configuration.mcp.auth.token_resolver
+    saved_jwt = RailsAiBridge.configuration.mcp.auth.jwt_decoder
+    saved_strategy = RailsAiBridge.configuration.mcp.auth.strategy
+    example.run
+  ensure
+    RailsAiBridge.configuration.http_mcp_token = saved_token
+    RailsAiBridge.configuration.mcp.require_auth_in_production = saved_req
+    RailsAiBridge.configuration.mcp.auth.token_resolver = saved_resolver
+    RailsAiBridge.configuration.mcp.auth.jwt_decoder = saved_jwt
+    RailsAiBridge.configuration.mcp.auth.strategy = saved_strategy
+  end
+
+  describe ".validate_mcp_require_auth_in_production!" do
+    it "does nothing in non-production" do
+      allow(Rails.env).to receive(:production?).and_return(false)
+      RailsAiBridge.configuration.mcp.require_auth_in_production = true
+      RailsAiBridge.configuration.http_mcp_token = nil
+      expect { RailsAiBridge.validate_mcp_require_auth_in_production! }.not_to raise_error
+    end
+
+    it "does nothing when require_auth_in_production is false" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      RailsAiBridge.configuration.mcp.require_auth_in_production = false
+      RailsAiBridge.configuration.http_mcp_token = nil
+      expect { RailsAiBridge.validate_mcp_require_auth_in_production! }.not_to raise_error
+    end
+
+    it "raises when production, flag true, and no auth mechanism" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      RailsAiBridge.configuration.mcp.require_auth_in_production = true
+      RailsAiBridge.configuration.http_mcp_token = nil
+      RailsAiBridge.configuration.mcp.auth.token_resolver = nil
+      RailsAiBridge.configuration.mcp.auth.jwt_decoder = nil
+      expect { RailsAiBridge.validate_mcp_require_auth_in_production! }.to raise_error(
+        RailsAiBridge::ConfigurationError,
+        /require_auth_in_production/
+      )
+    end
+
+    it "passes with static http_mcp_token" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      RailsAiBridge.configuration.mcp.require_auth_in_production = true
+      RailsAiBridge.configuration.http_mcp_token = "secret"
+      expect { RailsAiBridge.validate_mcp_require_auth_in_production! }.not_to raise_error
+    end
+
+    it "passes with token_resolver only" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      RailsAiBridge.configuration.mcp.require_auth_in_production = true
+      RailsAiBridge.configuration.http_mcp_token = nil
+      RailsAiBridge.configuration.mcp.auth.token_resolver = ->(_t) { nil }
+      expect { RailsAiBridge.validate_mcp_require_auth_in_production! }.not_to raise_error
+    end
+
+    it "passes with jwt_decoder only" do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      RailsAiBridge.configuration.mcp.require_auth_in_production = true
+      RailsAiBridge.configuration.http_mcp_token = nil
+      RailsAiBridge.configuration.mcp.auth.token_resolver = nil
+      RailsAiBridge.configuration.mcp.auth.jwt_decoder = ->(_t) { nil }
+      expect { RailsAiBridge.validate_mcp_require_auth_in_production! }.not_to raise_error
+    end
+  end
+
+  describe ".validate_mcp_strategy_configuration!" do
+    it "raises when strategy is :bearer_token without resolver or static token" do
+      RailsAiBridge.configuration.http_mcp_token = nil
+      RailsAiBridge.configuration.mcp.auth.strategy = :bearer_token
+      RailsAiBridge.configuration.mcp.auth.token_resolver = nil
+      expect { RailsAiBridge.validate_mcp_strategy_configuration! }.to raise_error(
+        RailsAiBridge::ConfigurationError,
+        /:bearer_token requires/
+      )
+    end
+
+    it "passes when :bearer_token with token_resolver" do
+      RailsAiBridge.configuration.http_mcp_token = nil
+      RailsAiBridge.configuration.mcp.auth.strategy = :bearer_token
+      RailsAiBridge.configuration.mcp.auth.token_resolver = ->(_t) { nil }
+      expect { RailsAiBridge.validate_mcp_strategy_configuration! }.not_to raise_error
+    end
+
+    it "passes when :bearer_token with static token only" do
+      RailsAiBridge.configuration.http_mcp_token = "secret"
+      RailsAiBridge.configuration.mcp.auth.strategy = :bearer_token
+      RailsAiBridge.configuration.mcp.auth.token_resolver = nil
+      expect { RailsAiBridge.validate_mcp_strategy_configuration! }.not_to raise_error
+    end
+
+    it "does nothing when strategy is not :bearer_token" do
+      RailsAiBridge.configuration.http_mcp_token = nil
+      RailsAiBridge.configuration.mcp.auth.strategy = :jwt
+      RailsAiBridge.configuration.mcp.auth.jwt_decoder = nil
+      expect { RailsAiBridge.validate_mcp_strategy_configuration! }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/rails_ai_bridge_spec.rb
+++ b/spec/lib/rails_ai_bridge/rails_ai_bridge_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge do
+  describe ".resolve_generate_format" do
+    it "returns :all when install.yml selection is absent" do
+      allow(RailsAiBridge::AssistantFormatsPreference).to receive(:formats_for_default_bridge_task).and_return(nil)
+      expect(described_class.resolve_generate_format(:install)).to eq(:all)
+    end
+
+    it "returns normalized list when install.yml defines formats" do
+      allow(RailsAiBridge::AssistantFormatsPreference).to receive(:formats_for_default_bridge_task)
+        .and_return(%i[claude json])
+      expect(described_class.resolve_generate_format(:install)).to eq(%i[claude json])
+    end
+
+    it "passes through non-install format symbols" do
+      expect(described_class.resolve_generate_format(:codex)).to eq(:codex)
+    end
+  end
+
+  describe ".generate_context" do
+    it "warns when assistant overrides are still the install stub" do
+      allow(RailsAiBridge::Serializers::SharedAssistantGuidance).to receive(:overrides_stub_active?).and_return(true)
+
+      ctx = { app_name: "T" }
+      allow(described_class).to receive(:introspect).and_return(ctx)
+      serializer = instance_double(RailsAiBridge::Serializers::ContextFileSerializer, call: { written: [], skipped: [] })
+      allow(RailsAiBridge::Serializers::ContextFileSerializer).to receive(:new).with(ctx, format: :claude).and_return(serializer)
+
+      expect do
+        described_class.generate_context(format: :claude)
+      end.to output(/omit-merge/).to_stderr
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/serializers/codex_serializer_spec.rb
+++ b/spec/lib/rails_ai_bridge/serializers/codex_serializer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe RailsAiBridge::Serializers::CodexSerializer do
         app_name: "App",
         rails_version: "8.0",
         ruby_version: "3.3.10",
+        environment: "test",
         schema: { adapter: "postgresql", total_tables: 10 },
         models: { "User" => { associations: [ { type: "has_many", name: "posts" } ], validations: [] } },
         routes: { total_routes: 50, by_controller: { "users" => [] } },
@@ -22,7 +23,11 @@ RSpec.describe RailsAiBridge::Serializers::CodexSerializer do
 
       expect(output).to include("Codex")
       expect(output).to include("AGENTS.md")
-      expect(output.index("Engineering rules")).to be < output.index("Project overview")
+      expect(output).to include("This repository (from introspection)")
+      eng = output.index("General engineering guidance")
+      agree = output.index("Working agreements")
+      expect(eng).to be < agree
+      expect(output).to include("This is not your team policy file")
       expect(output).to include("rails_get_schema")
       expect(output).to include('detail:"summary"')
       expect(output).to include("User")

--- a/spec/lib/rails_ai_bridge/serializers/copilot_serializer_spec.rb
+++ b/spec/lib/rails_ai_bridge/serializers/copilot_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RailsAiBridge::Serializers::CopilotSerializer do
 
     it "generates compact output with MCP tool references" do
       context = {
-        app_name: "App", rails_version: "8.0", ruby_version: "3.4",
+        app_name: "App", rails_version: "8.0", ruby_version: "3.4", environment: "test",
         schema: { adapter: "postgresql", total_tables: 10 },
         models: { "User" => { associations: [ { type: "has_many", name: "posts" } ], validations: [] } },
         routes: { total_routes: 50, by_controller: { "users" => [] } },
@@ -18,10 +18,11 @@ RSpec.describe RailsAiBridge::Serializers::CopilotSerializer do
 
       output = described_class.new(context).call
       expect(output).to include("Copilot Context")
+      expect(output).to include("This repository (from introspection)")
       expect(output).to include("MCP tools")
       expect(output).to include("rails_get_schema")
       expect(output).to include("Performance & security (baseline)")
-      expect(output).to include("Engineering rules (read first)")
+      expect(output).to include("General engineering guidance (rails-ai-bridge baseline)")
       expect(output).to include("strong parameters")
       expect(output).to include("N+1")
       expect(output).to include("Rails patterns")

--- a/spec/lib/rails_ai_bridge/serializers/shared_assistant_guidance_spec.rb
+++ b/spec/lib/rails_ai_bridge/serializers/shared_assistant_guidance_spec.rb
@@ -35,10 +35,12 @@ RSpec.describe RailsAiBridge::Serializers::SharedAssistantGuidance do
   end
 
   describe ".repo_specific_guidance_section_lines" do
-    it "is empty without overrides" do
+    it "suggests overrides when the file does not exist yet" do
       Dir.mktmpdir do |dir|
         allow(Rails.application).to receive(:root).and_return(Pathname.new(dir))
-        expect(described_class.repo_specific_guidance_section_lines).to eq([])
+        lines = described_class.repo_specific_guidance_section_lines
+        expect(lines.join).to include("Repo-specific guidance")
+        expect(lines.join).to include("overrides.md")
       end
     end
 

--- a/spec/lib/rails_ai_bridge/tasks/rails_ai_bridge_rake_spec.rb
+++ b/spec/lib/rails_ai_bridge/tasks/rails_ai_bridge_rake_spec.rb
@@ -35,8 +35,14 @@ RSpec.describe "rails_ai_bridge rake tasks" do
     rake[name].invoke(*args)
   end
 
-  it "invokes ai:bridge with the aggregate format" do
+  it "invokes ai:bridge with install selection (install.yml or default)" do
     invoke_task("ai:bridge")
+
+    expect(RailsAiBridge).to have_received(:generate_context).with(format: :install)
+  end
+
+  it "invokes ai:bridge:all with every format" do
+    invoke_task("ai:bridge:all")
 
     expect(RailsAiBridge).to have_received(:generate_context).with(format: :all)
   end

--- a/spec/lib/rails_ai_bridge/version_spec.rb
+++ b/spec/lib/rails_ai_bridge/version_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "RailsAiBridge::VERSION" do
+  specify do
+    expect(RailsAiBridge::VERSION).to be_a(String)
+    expect(RailsAiBridge::VERSION).to match(/\A\d+\.\d+\.\d+/)
+  end
+end

--- a/spec/lib/rails_ai_bridge/watcher_spec.rb
+++ b/spec/lib/rails_ai_bridge/watcher_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsAiBridge::Watcher do
+  describe "#initialize" do
+    it "defaults app to Rails.application" do
+      watcher = described_class.new
+      expect(watcher.app).to eq(Rails.application)
+    end
+
+    it "accepts an explicit app" do
+      fake = instance_double(Rails::Application)
+      allow(fake).to receive(:root).and_return(Pathname.new("/tmp"))
+      allow(RailsAiBridge::Fingerprinter).to receive(:compute).with(fake).and_return("fp1")
+
+      watcher = described_class.new(fake)
+      expect(watcher.app).to eq(fake)
+    end
+  end
+
+  describe "#start" do
+    context "when no watchable directories exist" do
+      it "prints a message and returns without calling Listen" do
+        require "listen" # defines +Listen+ for the expectation below
+
+        root = Pathname.new(Dir.mktmpdir)
+        fake_app = instance_double(Rails::Application, root: root)
+        allow(RailsAiBridge::Fingerprinter).to receive(:compute).with(fake_app).and_return("fp")
+
+        watcher = described_class.new(fake_app)
+        expect(Listen).not_to receive(:to)
+
+        expect { watcher.start }.to output(/No watchable directories/).to_stderr
+      end
+    end
+
+    context "when watchable directories exist" do
+      it "starts Listen, runs one wait iteration, then stops on Interrupt from sleep" do
+        require "listen"
+
+        listener = instance_double(Listen::Listener)
+        allow(listener).to receive(:start)
+        allow(listener).to receive(:stop)
+        allow(Listen).to receive(:to).and_return(listener)
+
+        watcher = described_class.new(Rails.application)
+        # +loop+ inside +#start+ resolves on the watcher instance; shadow Kernel’s infinite +loop+ for one iteration.
+        watcher.define_singleton_method(:loop) do |&block|
+          block.call
+        end
+        allow(watcher).to receive(:sleep).with(1).and_raise(Interrupt.new)
+
+        expect(listener).to receive(:start)
+        expect(listener).to receive(:stop)
+        expect { watcher.start }.to output(/Watching for changes/).to_stderr
+      end
+    end
+  end
+
+  describe "#handle_change" do
+    it "does nothing when fingerprint is unchanged" do
+      watcher = described_class.new(Rails.application)
+      allow(RailsAiBridge::Fingerprinter).to receive(:changed?).and_return(false)
+
+      expect(RailsAiBridge).not_to receive(:generate_context)
+      watcher.send(:handle_change)
+    end
+
+    it "regenerates context when fingerprint changed" do
+      watcher = described_class.new(Rails.application)
+      allow(RailsAiBridge::Fingerprinter).to receive(:changed?).and_return(true)
+      allow(RailsAiBridge::Fingerprinter).to receive(:compute).and_return("new_fp")
+      allow(RailsAiBridge).to receive(:generate_context).with(format: :install).and_return({ written: %w[/a.md], skipped: [] })
+
+      expect do
+        watcher.send(:handle_change)
+      end.to output(%r{Updated: /a\.md}).to_stderr
+    end
+
+    it "rescues and logs errors from generate_context" do
+      watcher = described_class.new(Rails.application)
+      allow(RailsAiBridge::Fingerprinter).to receive(:changed?).and_return(true)
+      allow(RailsAiBridge::Fingerprinter).to receive(:compute).and_return("fp")
+      allow(RailsAiBridge).to receive(:generate_context).and_raise(StandardError.new("boom"))
+
+      expect do
+        watcher.send(:handle_change)
+      end.to output(/Error regenerating: boom/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Consolidates **MCP HTTP hardening** (`RailsAiBridge::Mcp`) with earlier **install / introspection / extensibility** work. HTTP MCP now has a clear auth pipeline, optional rate limiting, optional structured access logs, and stricter production/boot guards, while standalone and middleware paths share one Rack builder.

Also adds **contributor roadmaps** (`docs/roadmaps.md`, `roadmap-mcp-v2.md`, `roadmap-context-assistants.md`) and refreshes **GUIDE / SECURITY / UPGRADING / CHANGELOG**.

## MCP HTTP

- **`Mcp::HttpAuth`** — `AuthResult`, strategy resolution, `env["rails_ai_bridge.mcp.context"]` for static Bearer (`:static_bearer`) and resolver/JWT payloads.
- **Strategies** — `Mcp::Auth::Strategies::BearerToken` (static secret + optional `token_resolver`, digest compare, safe resolver path); `Mcp::Auth::Strategies::Jwt` (host-supplied `jwt_decoder`, no JWT gem in the bridge).
- **`config.mcp`** — `Mcp::Settings`: `auth_configure`, `authorize` (403 after auth), `require_auth_in_production`, `mode` / `security_profile` for **implicit** rate limits when `rate_limit_max_requests` is `nil`, explicit `http_log_json`, effective limit/window helpers (nil-safe `mode` / `security_profile`).
- **`HttpTransportApp`** — single Rack entry for middleware + standalone HTTP: path match → rate limit → auth → optional `authorize` → transport; limiter snapshot at `build`, JSON log evaluated per request when enabled.
- **`Mcp::HttpRateLimiter`** — in-process sliding window per IP, mutex, prune empty buckets after window expiry.
- **`Mcp::HttpStructuredLog`** — one JSON line per MCP HTTP outcome (`event` as string); no Bearer token logging.
- **`McpHttpAuth`** — delegates auth to `Mcp::HttpAuth`; `401` / `403` / `429` JSON helpers including `Retry-After` where applicable.
- **Boot / config validation** — `:bearer_token` requires resolver or static token; `require_auth_in_production` + `mcp_auth_mechanism_configured?` alignment; resolver/JWT errors mapped to auth failures (no 500 from resolver/decoder in normal paths).

## Other (earlier plan / same branch)

- **`ContextProvider`** — shared snapshot/cache path for MCP tools and `rails://` resources; `fetch_section` / `BaseTool.cached_section` for section-level reads.
- **Extension hooks** — `config.additional_introspectors`, `additional_tools`, `additional_resources`; integration spec for custom introspector + tool + resource.
- **Install & presets** — `install.yml`, `rails ai:bridge:all`, `:large_monolith` / `:regulated`, `disabled_introspection_categories`, `excluded_tables` alignment; generator UX (`--assistants`, `--non-interactive`), Copilot merge region + `RAILS_AI_BRIDGE_COPILOT_MERGE`, fingerprint reuse on invalidation, contributor folder READMEs.

## Documentation

- **GUIDE / SECURITY / UPGRADING** — MCP HTTP, PII in Rack `env`, rate limit semantics (proxy / trusted IPs, per-process limits), structured logging, `bundle exec rspec` note in CONTRIBUTING.
- **Roadmaps** — `docs/roadmaps.md` (progress index), `docs/roadmap-mcp-v2.md` (MCP track + principles), `docs/roadmap-context-assistants.md` (future context/IDE work; major release deferred).

## Migration / breaking notes

- Implicit rate limits apply in **production** when `mode` is `:hybrid` and `rate_limit_max_requests` is `nil` (see **UPGRADING**). Set **`rate_limit_max_requests = 0`** to disable entirely.
- See **[UPGRADING.md](UPGRADING.md)** for `require_auth_in_production`, `strategy :bearer_token`, resolver/JWT behavior, and logging.

## How to test

```bash
bundle exec rspec
bundle exec rubocop