### PR TITLE
Update guides and getting ready for 2.2.0 release last check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-_Targeting **v2.2.0** when Phase 2–3 and final review are done; gem version remains **2.1.0** until that release tag._
+## [2.2.0] - 2026-04-04
 
 ### Added
 
@@ -23,6 +21,10 @@ _Targeting **v2.2.0** when Phase 2–3 and final review are done; gem version re
 - **Claude rules `rails-models.md`** — Each model line includes `tier: …` when present.
 - **`rails_get_model_details` formatters** — Summary, standard, full, and single-model views include semantic tier where applicable.
 - **Combustion test setup** — `Combustion.path` is set to `spec/internal`, `Combustion::Database.setup` runs after boot so `:memory:` SQLite has schema before examples, and the internal `ExampleJob` no longer subclasses `ActiveJob::Base` (Active Job is not loaded in the minimal stack).
+
+## [Unreleased]
+
+_Targeting **v2.3.0** when Phase 2–3 and final review are done; gem version remains **2.2.0** until that release tag._
 
 ## [2.1.0] - 2026-04-02
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Each file respects the AI tool's format and size limits. **Commit these files** 
 |----------|-------------------|
 | **Database** | Every table, column, index, foreign key, and migration |
 | **Models** | Associations, validations, scopes, enums, callbacks, concerns, macros (`has_secure_password`, `encrypts`, `normalizes`, etc.), **semantic tier** (`core_entity`, `pure_join`, `rich_join`, `supporting`) |
+| **Non-AR Models** | Ruby classes under `app/models` that aren't ActiveRecord, tagged as `[POJO/Service]` (opt-in via `:non_ar_models` introspector) |
 | **Routing** | Every route with HTTP verbs, paths, controller actions, API namespaces |
 | **Controllers** | Actions, filters, strong params, concerns, API controllers |
 | **Views** | Layouts, templates, partials, helpers, template engines, view components |
@@ -187,7 +188,7 @@ The gem exposes **11 built-in tools** via MCP that AI clients call on-demand (ho
 | Tool | What it returns |
 |------|----------------|
 | `rails_get_schema` | Tables, columns, indexes, foreign keys |
-| `rails_get_model_details` | Associations, validations, scopes, enums, callbacks |
+| `rails_get_model_details` | Associations, validations, scopes, enums, callbacks, semantic tier, non-AR models (when enabled) |
 | `rails_get_routes` | HTTP verbs, paths, controller actions |
 | `rails_get_controllers` | Actions, filters, strong params, concerns |
 | `rails_get_config` | Cache, session, timezone, middleware, initializers |

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -665,7 +665,7 @@ end
 | `cache_ttl` | Integer | `30` | Cache TTL in seconds for introspection results |
 | `excluded_models` | Array | internal Rails models | Models to skip |
 | `core_models` | Array | `[]` | Model names tagged as `core_entity` in introspection output and `.claude/rules/rails-context.md`. Used by `RailsAiBridge::ModelSemanticClassifier` to mark primary domain models. |
-| `non_ar_models` | Symbol | `nil` (not included) | Opt-in introspector for non-ActiveRecord classes under `app/models`. Enable with `config.introspectors << :non_ar_models`. |
+| `introspectors` | Array | 9 core symbols | Which introspectors to run. Add `:non_ar_models` to include non-ActiveRecord classes under `app/models`. |
 | `excluded_paths` | Array | `node_modules tmp log vendor .git` | Paths excluded from code search |
 | `output_dir` | String | `nil` (Rails.root) | Where to write context files |
 | `auto_mount` | Boolean | `false` | Auto-mount HTTP MCP endpoint |

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -626,6 +626,9 @@ RailsAiBridge.configure do |config|
   # Primary domain models (semantic tier: core_entity in introspection + Claude rules)
   # config.core_models += %w[User Order Project]
 
+  # Opt-in: Non-ActiveRecord models (POJO/Service classes under app/models)
+  # config.introspectors << :non_ar_models
+
   # Paths to exclude from code search
   config.excluded_paths += %w[vendor/bundle]
 
@@ -661,7 +664,8 @@ end
 | `max_tool_response_chars` | Integer | `120_000` | Safety cap for MCP tool responses |
 | `cache_ttl` | Integer | `30` | Cache TTL in seconds for introspection results |
 | `excluded_models` | Array | internal Rails models | Models to skip |
-| `core_models` | Array | `[]` | Model names tagged as `core_entity` in introspection output and `.claude/rules/rails-context.md` |
+| `core_models` | Array | `[]` | Model names tagged as `core_entity` in introspection output and `.claude/rules/rails-context.md`. Used by `RailsAiBridge::ModelSemanticClassifier` to mark primary domain models. |
+| `non_ar_models` | Symbol | `nil` (not included) | Opt-in introspector for non-ActiveRecord classes under `app/models`. Enable with `config.introspectors << :non_ar_models`. |
 | `excluded_paths` | Array | `node_modules tmp log vendor .git` | Paths excluded from code search |
 | `output_dir` | String | `nil` (Rails.root) | Where to write context files |
 | `auto_mount` | Boolean | `false` | Auto-mount HTTP MCP endpoint |

--- a/lib/rails_ai_bridge/introspectors/non_ar_models_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/non_ar_models_introspector.rb
@@ -18,7 +18,10 @@ module RailsAiBridge
       # @example Basic usage
       #   introspector = NonArModelsIntrospector.new(Rails.application)
       #   result = introspector.call
-      #   result[:non_ar_models] # => [{ name: "OrderCalculator", relative_path: "app/models/order_calculator.rb", tag: "POJO/Service" }]
+      ##
+      # Initializes the introspector for a Rails application.
+      # Stores the provided Rails application and its root path (as a string) for later introspection.
+      # @param [Rails::Application] app - The Rails application instance to inspect.
       def initialize(app)
         @app = app
         @root = app.root.to_s
@@ -32,7 +35,18 @@ module RailsAiBridge
       # @example Basic usage
       #   introspector = NonArModelsIntrospector.new(Rails.application)
       #   result = introspector.call
-      #   result[:non_ar_models] # => [{ name: "OrderCalculator", relative_path: "app/models/order_calculator.rb", tag: "POJO/Service" }]
+      ##
+      # Discovers concrete Ruby classes under app/models that do not inherit from ActiveRecord::Base.
+      #
+      # The returned hash contains either a `:non_ar_models` array of discovered entries or an `:error` string
+      # when introspection fails. Each entry in `:non_ar_models` is a Hash with:
+      # - `:name` — the constant name of the class (String)
+      # - `:relative_path` — path to the source file relative to the app root (String)
+      # - `:tag` — the discovery tag, `"POJO/Service"` (String)
+      #
+      # @return [Hash] Either:
+      #   - `{ non_ar_models: Array<Hash> }` where each Hash has keys `:name`, `:relative_path`, and `:tag`, or
+      #   - `{ error: String }` containing a sanitized, truncated error message.
       def call
         eager_load!
         models_dir = File.join(@root, "app", "models")
@@ -53,7 +67,10 @@ module RailsAiBridge
       #   sanitize_error_message("Failed to load /path/to/secret/file")
       #   # => "Failed to load /[REDACTED]"
       #   sanitize_error_message("Very long error message that should be truncated...")
-      #   # => "Very long error message that should be trunc..."
+      ##
+      # Produces a sanitized, truncated error message safe for external exposure.
+      # @param [String, nil] message - The original error message which may contain file paths.
+      # @return [String] A message with filesystem paths replaced by "/[REDACTED]" and limited to 200 characters; returns "Introspection failed" if the input is nil or empty.
       def sanitize_error_message(message)
         return "Introspection failed" if message.nil? || message.empty?
 
@@ -70,6 +87,14 @@ module RailsAiBridge
 
       private
 
+      ##
+      # Collects discovered non-ActiveRecord classes defined under the given models root.
+      # Populates and returns a hash keyed by constant name with metadata for each discovered class.
+      # @param [String] models_root - Absolute path to the application's `app/models` directory.
+      # @return [Hash{String=>Hash}] A hash mapping class name strings to metadata hashes with keys:
+      #   - :name [String] the constant name
+      #   - :relative_path [String] the file path relative to the application root
+      #   - :tag [String] the discovery tag (e.g., "POJO/Service")
       def collect_entries(models_root)
         entries = {}
         collect_safe_object_space_entries(models_root, entries)
@@ -82,7 +107,12 @@ module RailsAiBridge
       # @return [Hash] The populated entries hash
       # @example Basic usage
       #   collect_safe_object_space_entries("/path/to/app/models", {})
-      #   # => { "OrderCalculator" => { name: "OrderCalculator", relative_path: "app/models/order_calculator.rb", tag: "POJO/Service" } }
+      ##
+      # Populates the given entries hash with discovered non-ActiveRecord model classes defined under the provided models_root.
+      # Iteration errors for individual classes are logged with only the error class name.
+      # @param [String] models_root - Absolute path to the application's app/models directory.
+      # @param [Hash] entries - Accumulator hash which will be mutated; keys are class names and values are detail hashes.
+      # @return [Hash] The same entries hash, populated with discovered non-AR model entries.
       def collect_safe_object_space_entries(models_root, entries)
         ObjectSpace.each_object(Class) do |klass|
           next unless safe_to_process?(klass)
@@ -100,7 +130,11 @@ module RailsAiBridge
       # @return [Boolean] true if safe to process
       # @example Checking if a class is safe
       #   safe_to_process?(OrderCalculator) # => true
-      #   safe_to_process?(ActiveRecord::Base) # => false
+      ##
+      # Determines whether a class is a safe candidate for introspection.
+      # Returns `true` only when the class has a non-empty, dot-free constant name that matches `\A[A-Z][A-Za-z0-9_:]*\z` and is not a subclass of `ActiveRecord::Base`.
+      # @param [Class] klass - The class to validate.
+      # @return [Boolean] `true` if the class meets the naming and inheritance criteria, `false` otherwise (also returns `false` on error).
       def safe_to_process?(klass)
         name = klass.name
         return false if name.nil? || name.empty?
@@ -113,6 +147,15 @@ module RailsAiBridge
         false
       end
 
+      ##
+      # Records a non-ActiveRecord class defined under the application's models directory into the provided entries hash.
+      #
+      # Only classes that have a valid constant name, do not inherit from `ActiveRecord::Base`,
+      # and whose source file is located inside `models_root` are recorded. When recorded,
+      # the method sets `entries[name] = { name: name, relative_path: relative_to_root(path), tag: TAG }`.
+      # @param [Class] klass - The class to inspect.
+      # @param [String] models_root - Absolute path to the `app/models` directory.
+      # @param [Hash] entries - Mutable hash that will be populated with discovered entries keyed by class name.
       def record_if_non_ar_model(klass, models_root, entries)
         name = klass.name
         return if name.nil? || name.empty?

--- a/lib/rails_ai_bridge/introspectors/non_ar_models_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/non_ar_models_introspector.rb
@@ -43,17 +43,74 @@ module RailsAiBridge
 
         { non_ar_models: entries.values.sort_by { |h| h[:name] } }
       rescue StandardError => e
-        { error: e.message }
+        { error: sanitize_error_message(e.message) }
+      end
+
+      # Sanitizes error messages to prevent potential path disclosure
+      # @param message [String] The original error message
+      # @return [String] Sanitized error message safe for logging
+      # @example Sanitizing an error with a file path
+      #   sanitize_error_message("Failed to load /path/to/secret/file")
+      #   # => "Failed to load /[REDACTED]"
+      #   sanitize_error_message("Very long error message that should be truncated...")
+      #   # => "Very long error message that should be trunc..."
+      def sanitize_error_message(message)
+        return "Introspection failed" if message.nil? || message.empty?
+
+        # Remove potential file paths that could expose directory structure
+        sanitized = message.gsub(%r{/[^\s]*[/][^/\s]+}, "/[REDACTED]")
+
+        # Limit length to prevent log flooding and information disclosure
+        if sanitized.length > 200
+          "#{sanitized[0...197]}..."
+        else
+          sanitized
+        end
       end
 
       private
 
       def collect_entries(models_root)
         entries = {}
+        collect_safe_object_space_entries(models_root, entries)
+        entries
+      end
+
+      # Safely iterates through ObjectSpace with security boundaries and validation.
+      # @param models_root [String] The absolute path to app/models directory
+      # @param entries [Hash] Hash to populate with discovered entries
+      # @return [Hash] The populated entries hash
+      # @example Basic usage
+      #   collect_safe_object_space_entries("/path/to/app/models", {})
+      #   # => { "OrderCalculator" => { name: "OrderCalculator", relative_path: "app/models/order_calculator.rb", tag: "POJO/Service" } }
+      def collect_safe_object_space_entries(models_root, entries)
         ObjectSpace.each_object(Class) do |klass|
+          next unless safe_to_process?(klass)
+
           record_if_non_ar_model(klass, models_root, entries)
+        rescue => e
+          # Log security-relevant errors without exposing details
+          Rails.logger.warn "NonArModelsIntrospector: Error processing class: #{e.class.name}" if defined?(Rails.logger)
         end
         entries
+      end
+
+      # Security check before processing a class from ObjectSpace
+      # @param klass [Class] The class to validate
+      # @return [Boolean] true if safe to process
+      # @example Checking if a class is safe
+      #   safe_to_process?(OrderCalculator) # => true
+      #   safe_to_process?(ActiveRecord::Base) # => false
+      def safe_to_process?(klass)
+        name = klass.name
+        return false if name.nil? || name.empty?
+        return false if name.include?(".")
+        return false unless name.match?(/\A[A-Z][A-Za-z0-9_:]*\z/)
+        return false if klass < ActiveRecord::Base
+        true
+      rescue => e
+        Rails.logger.warn "NonArModelsIntrospector: Error validating class: #{e.class.name}" if defined?(Rails.logger)
+        false
       end
 
       def record_if_non_ar_model(klass, models_root, entries)
@@ -61,7 +118,6 @@ module RailsAiBridge
         return if name.nil? || name.empty?
         return if name.include?(".")
         return unless name.match?(/\A[A-Z][A-Za-z0-9_:]*\z/)
-
         return if klass < ActiveRecord::Base
 
         loc = safe_const_source_location(name)

--- a/lib/rails_ai_bridge/introspectors/non_ar_models_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/non_ar_models_introspector.rb
@@ -4,16 +4,21 @@ module RailsAiBridge
   module Introspectors
     # Discovers concrete Ruby classes under +app/models+ that do not inherit from
     # {ActiveRecord::Base}, so assistants can surface POJOs and service objects that
-    # would not appear in the ActiveRecord model introspector.
+    # would not appear in ActiveRecord model introspector.
     #
     # After a best-effort eager load (including Zeitwerk +eager_load_dir+ for +app/models+
     # when enabled), entries are derived from +Object.const_source_location+ so anonymous
     # or invalidly named classes are skipped.
+    # @since 2.2.0
     class NonArModelsIntrospector
       # Default label attached to each discovered non-AR class in tool and rules output.
       TAG = "POJO/Service"
 
       # @param app [Rails::Application] host application whose +root+ and paths are used
+      # @example Basic usage
+      #   introspector = NonArModelsIntrospector.new(Rails.application)
+      #   result = introspector.call
+      #   result[:non_ar_models] # => [{ name: "OrderCalculator", relative_path: "app/models/order_calculator.rb", tag: "POJO/Service" }]
       def initialize(app)
         @app = app
         @root = app.root.to_s
@@ -24,6 +29,10 @@ module RailsAiBridge
       # @return [Hash] On success, a hash with key +:non_ar_models+ — an Array of hashes with
       #   keys +:name+ (String), +:relative_path+ (String from app root), and +:tag+ (String, usually the same value as NonArModelsIntrospector::TAG).
       #   On failure, a hash with key +:error+ and a String message.
+      # @example Basic usage
+      #   introspector = NonArModelsIntrospector.new(Rails.application)
+      #   result = introspector.call
+      #   result[:non_ar_models] # => [{ name: "OrderCalculator", relative_path: "app/models/order_calculator.rb", tag: "POJO/Service" }]
       def call
         eager_load!
         models_dir = File.join(@root, "app", "models")

--- a/lib/rails_ai_bridge/version.rb
+++ b/lib/rails_ai_bridge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiBridge
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
@@ -6,18 +6,62 @@ RSpec.describe RailsAiBridge::Introspectors::NonArModelsIntrospector do
   let(:introspector) { described_class.new(Rails.application) }
 
   describe "#call" do
-    it "returns a list including plain Ruby classes under app/models" do
-      result = introspector.call
-      expect(result).not_to have_key(:error)
-      names = (result[:non_ar_models] || []).map { |h| h[:name] }
-      expect(names).to include("OrderCalculator")
+    context "when app/models contains non-ActiveRecord classes" do
+      it "returns a list including plain Ruby classes under app/models" do
+        result = introspector.call
+        expect(result).not_to have_key(:error)
+        names = (result[:non_ar_models] || []).map { |h| h[:name] }
+        expect(names).to include("OrderCalculator")
+      end
+
+      it "tags entries as POJO/Service with correct structure" do
+        result = introspector.call
+        row = result[:non_ar_models].find { |h| h[:name] == "OrderCalculator" }
+        expect(row[:tag]).to eq("POJO/Service")
+        expect(row[:relative_path]).to eq("app/models/order_calculator.rb")
+        expect(row).to have_key(:name)
+      end
+
+      it "returns entries sorted by name" do
+        result = introspector.call
+        entries = result[:non_ar_models]
+        names = entries.map { |h| h[:name] }
+        expect(names).to eq(names.sort)
+      end
     end
 
-    it "tags entries as POJO/Service" do
-      result = introspector.call
-      row = result[:non_ar_models].find { |h| h[:name] == "OrderCalculator" }
-      expect(row[:tag]).to eq("POJO/Service")
-      expect(row[:relative_path]).to eq("app/models/order_calculator.rb")
+    context "when app/models directory does not exist" do
+      before do
+        allow(Dir).to receive(:exist?).with(introspector.instance_variable_get(:@root) + "/app/models").and_return(false)
+      end
+
+      it "returns empty non_ar_models array" do
+        result = introspector.call
+        expect(result).to eq({ non_ar_models: [] })
+      end
+    end
+
+    context "when eager loading fails" do
+      before do
+        # Mock the eager_load! method to raise an error
+        allow(introspector).to receive(:eager_load!).and_raise(StandardError.new("Load failed"))
+      end
+
+      it "handles errors gracefully and returns error hash" do
+        result = introspector.call
+        expect(result).to have_key(:error)
+        expect(result[:error]).to be_a(String)
+      end
+    end
+  end
+
+  describe "#initialize" do
+    it "stores application root and app reference" do
+      app = double("Rails::Application", root: "/path/to/app")
+      introspector = described_class.new(app)
+
+      expect(introspector.instance_variable_get(:@app)).to eq(app)
+      expect(introspector.instance_variable_get(:@root)).to eq("/path/to/app")
     end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
@@ -52,6 +52,68 @@ RSpec.describe RailsAiBridge::Introspectors::NonArModelsIntrospector do
         expect(result).to have_key(:error)
         expect(result[:error]).to be_a(String)
       end
+
+      it "sanitizes error messages to prevent path disclosure" do
+        # Test with file path in error message
+        allow(introspector).to receive(:eager_load!)
+          .and_raise(StandardError.new("Failed to load /path/to/secret/file"))
+
+        result = introspector.call
+        expect(result[:error]).to eq("Failed to load /[REDACTED]")
+        expect(result[:error]).not_to include("/path/to/secret/file")
+      end
+
+      it "truncates long error messages" do
+        long_message = "a" * 250  # 250 character error message
+        allow(introspector).to receive(:eager_load!)
+          .and_raise(StandardError.new(long_message))
+
+        result = introspector.call
+        expect(result[:error].length).to be <= 200
+        expect(result[:error]).to end_with("...")
+      end
+    end
+  end
+
+  describe "#collect_entries" do
+    context "security boundaries" do
+      it "filters classes to app/models directory only" do
+        result = introspector.call
+        entries = result[:non_ar_models] || []
+
+        # All entries should be within app/models
+        entries.each do |entry|
+          expect(entry[:relative_path]).to start_with("app/models/")
+        end
+      end
+
+      it "validates class names before processing" do
+        result = introspector.call
+        entries = result[:non_ar_models] || []
+
+        # All entries should have valid Ruby class names
+        entries.each do |entry|
+          name = entry[:name]
+          expect(name).to match(/\A[A-Z][A-Za-z0-9_:]*\z/)
+          expect(name).not_to include(".")
+          expect(name).not_to be_nil
+          expect(name).not_to be_empty
+        end
+      end
+
+      it "excludes ActiveRecord classes" do
+        result = introspector.call
+        entries = result[:non_ar_models] || []
+        names = entries.map { |e| e[:name] }
+
+        # Should not include any ActiveRecord models
+        ar_models = ActiveRecord::Base.descendants.map(&:name)
+        ar_models.compact!
+
+        names.each do |name|
+          expect(ar_models).not_to include(name)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Update guides and getting ready for 2.2.0 release
- [X] **CHANGELOG.md Update:** Track all changes from v2.1.0 to v2.2.0 using semantic versioning and Git tags.
- [X] **README.md Refresh:** Update "Capabilities" to include the new Semantic Tiering and Model Classification features.
- [X] **Docs Audit:** Ensure `docs/GUIDE.md` reflects the latest configuration options (like `config.core_models`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in support for Non-AR Models (Ruby POJOs/services) via a new introspector; introspection now reports semantic tier and non-AR models when enabled.

* **Bug Fixes**
  * Safer discovery with stricter validation, per-item error handling, and sanitized/truncated error messages.

* **Documentation**
  * README and configuration guide updated with Non-AR Models usage, examples, and option details.

* **Tests**
  * Expanded specs covering discovery, sorting, edge cases, and error sanitization.

* **Chores**
  * Version bumped to 2.2.0 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->