### PR TITLE
Add skill pack registry system with resolver caching and MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`git_timeout` for git operations** — `Config::Registry#git_timeout` (default `30` seconds) is
+  now passed to `DefaultGitRunner`, which wraps every git subprocess (`clone`, `pull`, `checkout`)
+  in `Timeout.timeout`. A slow or unreachable remote can no longer block the calling thread
+  indefinitely; a descriptive `RuntimeError` (e.g. `"git clone timed out after 30s"`) is raised
+  instead. `DefaultGitRunner#timeout` exposes the configured value for introspection.
+- **`git_pull_ttl` — per-pack pull freshness window** — `Config::Registry#git_pull_ttl` (default
+  `86400` seconds = 24 h) controls how often `SkillSourceResolver` issues a `git pull` for an
+  already-cached pack. Successive `resolve` calls within the TTL window skip the pull entirely,
+  removing the previous behaviour of pulling on every resolver rebuild. Set to `0` to restore
+  pull-on-every-resolve. Pull timestamps are tracked in a thread-safe, in-memory `Mutex`-guarded
+  hash; they reset when the process restarts.
+- **`checkout_ref` timeout** — `git checkout <ref>` is now also subject to `git_timeout`.
+  A `SkillSourceResolver::ResolutionError` is raised on timeout with the ref name and pack source
+  in the message.
+- **`Registry::Truncatable` shared module** (`lib/rails_ai_bridge/registry/truncatable.rb`) —
+  extracts the `truncate(text, max)` helper that was duplicated between `RakePresenter` and
+  `RegistryCatalogFormatter`. Both classes now `include Truncatable` and the private duplicates
+  are removed.
+- **`Engine.to_prepare` hook** — the Rails Engine now registers a `config.to_prepare` block that
+  calls `Registry.invalidate_resolver_cache!`. This discards the cached resolver on every
+  Zeitwerk code reload in development, preventing stale config after an initializer change.
+  In production it fires once after eager load and is effectively a no-op.
+- **`depends_on` missing-dependency warning** — `PackResolver` now emits a clear `[rails-ai-bridge]`
+  warning to stderr when an active pack declares `depends_on` entries that are not in the active
+  pack set. The warning names each missing dependency and tells the user which manifest field to
+  update. Packs still load; this is an advisory warning, not an abort. Transitive dependency
+  loading remains unimplemented (see `docs/gem-general-improvements.md`).
+- **Stable local pack names** — local registry packs previously received names like `local_0`,
+  `local_1` based on array index, so reordering `local_registry_paths` silently shifted pack
+  identities. Names are now derived from a SHA256 digest of the path
+  (`local_<first 8 hex chars>`), making them stable regardless of ordering.
+- **`docs/offline-mode.md`** — design plan for a future `offline:` config flag that prevents
+  all git operations and serves the local cache as-is; includes rake pull task design, vendored
+  snapshot pattern, and CI caching guidance.
+- **`docs/gem-general-improvements.md`** — roadmap of eight broader improvements: manifest
+  schema validation, pack version lock file, agent-facing JSON output from rake tasks, full
+  SHA-256 cache keys, transitive `depends_on` loading, structured logging, and more.
+
+### Changed
+
+- **`PackResolver` errors raised as `ResolutionError`** — the two bare `raise "..."` calls in
+  `PackResolver` (unknown pack name, missing tile manifest) and the one in `load_local_registries`
+  now raise `SkillSourceResolver::ResolutionError` instead of a plain `RuntimeError`. Callers
+  that rescue `ResolutionError` from `SkillSourceResolver` will now also catch pack-level failures
+  without needing a separate `rescue RuntimeError`.
+- **`SourceParser` rejects `http://` URLs** — plain HTTP was previously accepted as a git source.
+  It is now rejected because cloning over unencrypted HTTP exposes credentials and pack content in
+  transit. Use `https://` or `git@` (SSH) instead. The error message and module docstring are
+  updated to explain the reason and list the supported formats.
+- **`ListRegistry` type-guard comment** — the `unless %w[skills agents packs].include?(type)`
+  guard is retained as a defence-in-depth fallback (the MCP SDK enum constraint catches invalid
+  values first) and now carries an explanatory comment to prevent future confusion.
+- **`Registry.build_resolver_uncached`** — wires `git_timeout` and `git_pull_ttl` from
+  `Config::Registry` into `DefaultGitRunner` and `SkillSourceResolver` respectively, so
+  configuration changes take effect on the next resolver rebuild.
+
+### Fixed
+
+- **`validate_cache_dir` documentation clarified** — the YARD docstring now explains why the
+  lexical `Pathname#cleanpath` check (rather than `File.realpath`) is used: the cache directory
+  may not exist yet at validation time. The security guarantee is stated explicitly: cache keys
+  are SHA256-derived and not attacker-controlled, so even an unexpected symlink target is safe.
+
+### Tests
+
+- **`checkout_ref` — 8 new examples** covering: successful checkout returns the cache path;
+  git checkout called with the correct ref; non-zero exit raises `ResolutionError`; error message
+  includes ref name, source pack name, and stderr text; timeout raises `ResolutionError` with
+  `"timed out"` and ref name in message; nil ref skips `git checkout` entirely.
+- **Pull freshness — 3 new examples**: TTL=0 always pulls on every resolve; large TTL skips
+  the second pull within the window; second resolve after TTL expiry re-pulls (verified by
+  backdating `@last_pulled` via instance variable access).
+- **`DefaultGitRunner` timeout — 4 new examples**: `#timeout` defaults to 30; configurable
+  via constructor; clone timeout raises `RuntimeError` with duration; pull timeout same.
+- **`ResolverCache` TTL spec** — replaced `sleep(0.01)` (wall-clock dependency) with an
+  injectable `monotonic_clock:` lambda that returns `0` on the first call and `99_999` thereafter,
+  making the TTL-expiry test deterministic and instant.
+- **Total: 2043 examples, 0 failures, 94.67% line coverage** (up from 94.53%)
+
 - **Registry data structures (PR 1)** — new `RailsAiBridge::Registry` module with immutable value objects
   porting the Rust `agent-mcp-runtime` registry types to Ruby:
   - `Registry::RegistryManifest` — root manifest (version, packs, default\_stack); `from_json` / `from_file`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `registry.skill_packs` — explicit pack names to load, or `nil` for auto-detection based on framework
   - `registry.local_registry_paths` — local registry directory paths for skill pack overrides
   - Registry module required in main `rails_ai_bridge.rb` for configuration availability
+- **Registry tools, cache, source formats, and docs (PR 5 → PR 6)** — user-visible entry points
+  plus three production-quality refinements:
+  - `Tools::ListRegistry` (`rails_list_registry`) — single MCP tool replacing the previous
+    `rails_list_skills`, `rails_list_agents`, and `rails_list_packs`; required `type:` param
+    (`"skills"` | `"agents"` | `"packs"`); optional `pack:` filter for skills/agents;
+    inner `RegistryCatalogFormatter` class owns all markdown rendering (SRP)
+  - `Registry::ResolverCache` — thread-safe in-memory cache for the wired `Resolver`;
+    configurable TTL via `config.registry.resolver_ttl` (default 1800 s = 30 min);
+    nil results never cached so manifest-missing setup retries on next call;
+    `Registry.invalidate_resolver_cache!` for explicit invalidation
+  - `Config::Registry#resolver_ttl` — new accessor with 1800 s default
+  - `Registry::SourceParser` — new single-responsibility parser that classifies source strings
+    into `:local_path`, `:git_url`, or `:github_shorthand` and resolves canonical URLs;
+    raises `ResolutionError` naming all three valid formats for invalid inputs;
+    `SkillSourceResolver#resolve` now delegates to `SourceParser` and returns local paths
+    directly without git operations
+  - `PackDefinition#ref` — new optional field for git version pinning (branch, tag, or SHA);
+    `SkillSourceResolver` runs `git checkout ref` after clone/pull when set
+  - `PackResolver` — default pack catalog filename changed from `tile.json` to `directory.json`;
+    priority matching is now case-insensitive
+  - `Registry::RakePresenter` — extracted from inline rake task logic; owns all CLI formatting
+    for skill tables and resolve output
+  - `rails ai:skills:list` — delegates to `RakePresenter`
+  - `rails "ai:skills:resolve[pack,skill_name]"` — delegates to `RakePresenter`
+  - `rails ai:skills:clear_cache` — new rake task; removes cached pack repositories and
+    invalidates the in-memory resolver cache
+  - `docs/skill-registry-guide.md` — new user guide covering concepts, quick start, source
+    formats, priority rules, version pinning, `directory.json` format, MCP tool reference,
+    rake task reference, resolver cache, troubleshooting, and security model
+  - `docs/registry-resolution.md` — updated to "Registry Resolution Reference"; all
+    `tile.json` references updated to `directory.json`; new source formats table; new
+    `ref` field; `resolver_ttl` config option; cache management section; security section
+    updated for `SourceParser`
 
 ## [3.4.0] - 2026-05-21
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   gem 'rubocop', '~> 1.65'
   gem 'rubocop-rails', '~> 2.35'
   gem 'rubocop-rails-omakase', '~> 1.0'
-  gem 'rubocop-rspec', '~> 3.0'
+  gem 'rubocop-rspec', '~> 3.10'
   gem 'simplecov', '~> 0.22'
   gem 'skunk', '~> 0.5'
   gem 'sqlite3', '~> 1.4'

--- a/README.md
+++ b/README.md
@@ -494,6 +494,8 @@ end
 | `registry.skill_packs` | `nil` | Explicit pack names to load, or `nil` for auto-detection based on framework |
 | `registry.local_registry_paths` | `[]` | Local directory paths (must contain `directory.json`) loaded at priority 0 |
 | `registry.resolver_ttl` | `1800` | Seconds to cache the wired resolver in memory; `0` disables caching |
+| `registry.git_pull_ttl` | `86400` | Seconds between `git pull` refreshes per cached pack (24 h default). Set to `0` to pull on every resolver rebuild |
+| `registry.git_timeout` | `30` | Seconds before a git operation (clone, pull, checkout) is forcibly interrupted |
 
 Other HTTP MCP knobs live only on the nested object, for example `RailsAiBridge.configuration.mcp.authorize`, `mcp.mode`, `mcp.security_profile`, and `mcp.require_auth_in_production` — see [docs/GUIDE.md](docs/GUIDE.md) and [docs/mcp-security.md](docs/mcp-security.md).
 </details>
@@ -596,7 +598,9 @@ Quick example manifest (`config/rails_ai_bridge_registry.json`):
 }
 ```
 
-Pack sources accept local paths, full git URLs, or `owner/repo` GitHub shorthands. Packs can be pinned to a specific version with `"ref": "v1.2.0"`.
+Pack sources accept local paths, HTTPS URLs (`https://`), SSH URLs (`git@`), or `owner/repo` GitHub shorthands. Plain `http://` URLs are rejected. Packs can be pinned to a specific version with `"ref": "v1.2.0"`.
+
+To prevent network timeouts from blocking your server, set `config.registry.git_timeout` (default: 30 s). To control how often cached packs are refreshed, set `config.registry.git_pull_ttl` (default: 24 h; `0` to always pull).
 
 See [docs/skill-registry-guide.md](docs/skill-registry-guide.md) for the full setup guide.
 
@@ -694,6 +698,8 @@ The docs are layered so new users do not need to read everything at once.
 | HTTP MCP hardening and production safety | [docs/mcp-security.md](docs/mcp-security.md) and [SECURITY.md](SECURITY.md) |
 | Skill packs: setup, sources, pinning, cache, troubleshooting | [docs/skill-registry-guide.md](docs/skill-registry-guide.md) |
 | Skill registry technical reference | [docs/registry-resolution.md](docs/registry-resolution.md) |
+| Offline mode design plan | [docs/offline-mode.md](docs/offline-mode.md) |
+| Gem improvement roadmap | [docs/gem-general-improvements.md](docs/gem-general-improvements.md) |
 | Upgrade notes between major versions | [UPGRADING.md](UPGRADING.md) |
 | Release history | [CHANGELOG.md](CHANGELOG.md) |
 | Development and contribution workflow | [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Optional: `gem install rails-ai-bridge` installs the gem into your Ruby environm
 | Zero config | Yes — Railtie + install generator | No — per-project `projects.yml` | No |
 | Token optimization | Yes — compact files + `detail:"summary"` workflow | Varies | No |
 | Codex-oriented repo files | Yes — `AGENTS.md`, `.codex/README.md` | No | DIY |
-| Live MCP tools | Yes — 11 read-only `rails_*` tools (extensible) | Yes | No |
+| Live MCP tools | Yes — 13 read-only `rails_*` tools (extensible) | Yes | No |
 | Auto-introspection | Yes — up to **27** domains (`:full`) | No — server points at projects you configure | DIY |
 
 *Comparison reflects typical documented setups; verify against each project before treating any row as absolute.*
@@ -247,7 +247,7 @@ This keeps context focused and avoids unnecessary token usage while still allowi
 
 ## MCP Tools
 
-The gem exposes **12 built-in tools** via MCP that AI clients call on-demand (hosts can append more via `config.additional_tools`):
+The gem exposes **13 built-in tools** via MCP that AI clients call on-demand (hosts can append more via `config.additional_tools`):
 
 | Tool | What it returns |
 |------|----------------|
@@ -263,6 +263,7 @@ The gem exposes **12 built-in tools** via MCP that AI clients call on-demand (ho
 | `rails_get_view` | View layouts, templates, partials; optional per-file detail under the configured `app/views` path |
 | `rails_search_semantic` | Semantic code search using rubydex — find declarations by name with types, locations, and relationships |
 | `rails_get_stimulus` | Stimulus controllers: targets, values, actions, outlets (requires `:stimulus` introspector) |
+| `rails_list_registry` | Skill pack catalog — list skills, agents, or active packs; requires `config/rails_ai_bridge_registry.json` |
 
 All tools are **read-only** — they never modify your application or database.
 
@@ -491,7 +492,8 @@ end
 | `registry.registry_manifest_path` | `"config/rails_ai_bridge_registry.json"` | Path to the registry manifest JSON file for skill pack resolution |
 | `registry.skill_cache_dir` | `"~/.rails-ai-bridge/cache"` | Directory for caching git repositories containing skill packs |
 | `registry.skill_packs` | `nil` | Explicit pack names to load, or `nil` for auto-detection based on framework |
-| `registry.local_registry_paths` | `[]` | Local registry directory paths for skill pack overrides |
+| `registry.local_registry_paths` | `[]` | Local directory paths (must contain `directory.json`) loaded at priority 0 |
+| `registry.resolver_ttl` | `1800` | Seconds to cache the wired resolver in memory; `0` disables caching |
 
 Other HTTP MCP knobs live only on the nested object, for example `RailsAiBridge.configuration.mcp.authorize`, `mcp.mode`, `mcp.security_profile`, and `mcp.require_auth_in_production` — see [docs/GUIDE.md](docs/GUIDE.md) and [docs/mcp-security.md](docs/mcp-security.md).
 </details>
@@ -573,6 +575,33 @@ To customize it in your initializer (`config/initializers/rails_ai_bridge.rb`):
 
 ---
 
+### Skill Packs
+
+rails-ai-bridge can load **skill packs** — shared collections of agent instructions — from versioned git repositories and surface them through `rails_list_registry` and rake tasks.
+
+```ruby
+config.registry.registry_manifest_path = "config/rails_ai_bridge_registry.json"
+```
+
+Quick example manifest (`config/rails_ai_bridge_registry.json`):
+
+```json
+{
+  "version": "1.0.0",
+  "packs": {
+    "rails": { "source": "igmarin/rails-agent-skills" },
+    "core":  { "source": "igmarin/ruby-core-skills", "always_loaded": true }
+  },
+  "default_stack": ["core"]
+}
+```
+
+Pack sources accept local paths, full git URLs, or `owner/repo` GitHub shorthands. Packs can be pinned to a specific version with `"ref": "v1.2.0"`.
+
+See [docs/skill-registry-guide.md](docs/skill-registry-guide.md) for the full setup guide.
+
+---
+
 ## Stack Compatibility
 
 Works with every Rails architecture — auto-detects what's relevant:
@@ -606,6 +635,9 @@ Frontend introspectors (views, Turbo, Stimulus, assets) degrade gracefully — t
 | `rails ai:doctor` | Run diagnostics and AI readiness score (0-100) |
 | `rails ai:watch` | Auto-regenerate bridge files on code changes |
 | `rails ai:inspect` | Print introspection summary to stdout |
+| `rails ai:skills:list` | Print skill catalog from loaded skill packs |
+| `rails "ai:skills:resolve[pack,name]"` | Resolve and print a skill's full content |
+| `rails ai:skills:clear_cache` | Remove locally cached pack repositories |
 
 > **Bridge modes:**
 > ```bash
@@ -660,6 +692,8 @@ The docs are layered so new users do not need to read everything at once.
 | How to get better AI output day to day | [docs/BEST_PRACTICES.md](docs/BEST_PRACTICES.md) |
 | Every command, config option, generated file, and MCP parameter | [docs/GUIDE.md](docs/GUIDE.md) |
 | HTTP MCP hardening and production safety | [docs/mcp-security.md](docs/mcp-security.md) and [SECURITY.md](SECURITY.md) |
+| Skill packs: setup, sources, pinning, cache, troubleshooting | [docs/skill-registry-guide.md](docs/skill-registry-guide.md) |
+| Skill registry technical reference | [docs/registry-resolution.md](docs/registry-resolution.md) |
 | Upgrade notes between major versions | [UPGRADING.md](UPGRADING.md) |
 | Release history | [CHANGELOG.md](CHANGELOG.md) |
 | Development and contribution workflow | [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/docs/gem-general-improvements.md
+++ b/docs/gem-general-improvements.md
@@ -1,0 +1,160 @@
+# Gem General Improvements — Roadmap
+
+Collected opportunities for improving the `rails-ai-bridge` gem beyond the issues already
+addressed in the current session. Ordered roughly by impact vs effort.
+
+---
+
+## 1. Manifest Schema Validation
+
+**Problem:** `RegistryManifest.from_file` parses JSON but does not validate the structure.
+A typo in a pack entry (e.g. missing `source`) surfaces as a confusing `KeyError` or `nil`
+deep in `PackResolver`, not as a clear validation failure.
+
+**Plan:**
+
+- Add a `RegistryManifest.validate!(data)` class method that raises `RegistryManifest::ValidationError`
+  with a descriptive message on the first invalid field.
+- Required top-level keys: none (empty manifest is valid).
+- Required pack keys: `source`.
+- Optional pack keys: `ref`, `tile`, `depends_on`, `priority`.
+- Validate types: `source` is a non-empty String; `depends_on` is an Array of Strings; etc.
+- Add a `rails rails_ai:registry:validate` rake task that loads the manifest and runs validation,
+  suitable for use in pre-commit hooks or CI.
+
+**Files:** `registry_manifest.rb`, `rails_ai_bridge.rake`, specs.
+
+---
+
+## 2. Pack Version Lock File
+
+**Problem:** Two developers running the same registry manifest may resolve different pack content
+if packs do not pin a `ref`. There is no equivalent of `Gemfile.lock` for skill packs.
+
+**Plan:**
+
+- After a successful resolver build, write a `config/rails_ai_bridge_registry.lock` JSON file
+  containing the resolved SHA for each pack's HEAD commit:
+  ```json
+  {
+    "rails-core-skills": { "sha": "abc123...", "resolved_at": "2025-06-01T10:00:00Z" },
+    "ruby-core-skills":  { "sha": "def456...", "resolved_at": "2025-06-01T10:00:00Z" }
+  }
+  ```
+- When the lock file is present, `SkillSourceResolver#resolve` uses the locked SHA as the
+  `ref` argument, bypassing any branch-tip divergence.
+- A `rails rails_ai:registry:update` task regenerates the lock (analogous to `bundle update`).
+- The lock file should be committed to version control.
+- `git_pull_ttl` is ignored when a lock file SHA is present — the cached commit is pinned.
+
+**Files:** `registry_manifest.rb`, `skill_source_resolver.rb`, new `lock_file.rb`, rake task, specs.
+
+---
+
+## 3. RakePresenter / Agent-Facing Output
+
+**Problem:** The `rails rails_ai:skills` rake task is currently designed for human consumption
+(table layout, truncation, colour-free text). Agents calling the registry tool via MCP receive
+a different, richer format. The two diverge over time.
+
+**Plan:**
+
+- Add an `--format=json` flag to `rails rails_ai:skills` and `rails rails_ai:registry` tasks.
+- Output a stable JSON schema that agents can parse directly when the MCP server is not available
+  (e.g. in CI or when writing custom tooling).
+- Schema:
+  ```json
+  {
+    "packs": [{ "name": "...", "version": "...", "summary": "...", "priority": 10 }],
+    "skills": [{ "name": "...", "pack": "...", "description": "..." }]
+  }
+  ```
+- `RakePresenter` gains a `skills_json` and `packs_json` method alongside the existing
+  `skills_table` / `resolve_skill_output`.
+
+**Files:** `rake_presenter.rb`, `rails_ai_bridge.rake`, specs.
+
+---
+
+## 4. Full SHA-256 for compute_cache_key
+
+**Problem:** `SkillSourceResolver.compute_cache_key` currently uses only the first 16 hex
+characters of the SHA-256 digest (`hexdigest[0..15]`). This is 64 bits of entropy — sufficient
+for collision avoidance across a handful of packs, but inconsistent with the rest of the gem
+(which uses full 64-hex SHA-256 digests for fingerprinting).
+
+**Plan:**
+
+- Change `hexdigest(source)[0..15]` to `hexdigest(source)` (full 64-character hash).
+- This is a breaking change for any existing cached directories. Document in CHANGELOG.
+- Existing caches under the old key format will become orphaned; document that users should
+  run `rm -rf ~/.rails-ai-bridge/cache` after upgrading.
+- Alternatively, implement a migration: scan the cache dir for directories matching the old
+  key pattern and rename them to the new format.
+
+**Files:** `skill_source_resolver.rb`, `CHANGELOG.md`, specs.
+
+---
+
+## 5. Transitive depends_on Loading
+
+**Problem:** `PackDefinition#depends_on` is parsed and stored but never acted upon.
+`PackResolver` currently only emits a warning when a dependency is missing from the active set.
+There is no automatic dependency resolution.
+
+**Plan:**
+
+- In `PackResolver#gather_active_packs`, after computing the initial active set, iterate over
+  all active packs and union their `depends_on` into the active set. Repeat until stable
+  (fixed-point iteration), capped at a reasonable depth (e.g. 10) to prevent infinite loops
+  from circular dependencies.
+- Detect and report circular dependencies with a clear error message.
+- Add a config flag `config.registry.auto_load_dependencies = true` (default `false` initially
+  to avoid surprising behavior, then `true` in a future major version).
+
+**Files:** `pack_resolver.rb`, `config/registry.rb`, specs.
+
+---
+
+## 6. HTTP Transport Authentication for MCP
+
+**Problem:** `http_mcp_token` is a static bearer token. JWTs with short expiry are not supported
+for the registry MCP endpoint, making rotation hard.
+
+**Plan:** Already partially addressed by `mcp_jwt_decoder` config; document the pattern in
+`docs/mcp-security.md` with a worked example using `JWT.decode`.
+
+---
+
+## 7. pack_resolver_spec.rb — depends_on Warning Coverage
+
+The warning emitted by `warn_missing_dependencies` is not yet tested. Add:
+
+```ruby
+context 'when an active pack declares a missing dependency' do
+  it 'emits a warning naming the pack and missing dependency' do
+    expect { resolver.resolve(manifest, ['pack-with-dep'], ...) }
+      .to output(/depends on.*'missing-dep'/).to_stderr
+  end
+
+  it 'still loads the pack despite the missing dependency' do
+    result = resolver.resolve(manifest, ['pack-with-dep'], ...)
+    expect(result.packs.map(&:name)).to include('pack-with-dep')
+  end
+end
+```
+
+---
+
+## 8. Observability — Structured Logging
+
+**Problem:** Errors from git operations surface as raised exceptions with no structured context.
+In production it is hard to correlate a `ResolutionError` with a specific pack or commit.
+
+**Plan:**
+
+- Accept an optional `logger:` parameter in `SkillSourceResolver#initialize`.
+- Before each git operation, log at DEBUG: `{ op: :clone, source:, cache_path: }`.
+- On success, log at INFO: `{ op: :clone, duration_ms:, cache_path: }`.
+- On failure, log at ERROR: `{ op: :clone, source:, error: message }`.
+- Default logger: `Rails.logger` when in a Rails context, `Logger.new($stderr)` otherwise.

--- a/docs/gem-general-improvements.md
+++ b/docs/gem-general-improvements.md
@@ -35,6 +35,7 @@ if packs do not pin a `ref`. There is no equivalent of `Gemfile.lock` for skill 
 
 - After a successful resolver build, write a `config/rails_ai_bridge_registry.lock` JSON file
   containing the resolved SHA for each pack's HEAD commit:
+
   ```json
   {
     "rails-core-skills": { "sha": "abc123...", "resolved_at": "2025-06-01T10:00:00Z" },
@@ -63,6 +64,7 @@ a different, richer format. The two diverge over time.
 - Output a stable JSON schema that agents can parse directly when the MCP server is not available
   (e.g. in CI or when writing custom tooling).
 - Schema:
+
   ```json
   {
     "packs": [{ "name": "...", "version": "...", "summary": "...", "priority": 10 }],

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -1,0 +1,121 @@
+# Offline Mode — Design Plan
+
+## Problem
+
+The registry resolver currently requires network access on every fresh start to clone or pull
+skill pack repositories. In offline environments (CI without egress, corporate networks with
+proxy restrictions, air-gapped machines) this makes the registry unusable.
+
+## Goals
+
+1. Allow a pre-populated cache to be used without any git operations.
+2. Allow operators to ship a vendored snapshot of packs alongside their application.
+3. Produce a clear, actionable error message when a pack is missing and network is unavailable.
+
+## Non-Goals
+
+- Partial offline (some packs online, some local) — the existing `local_registry_paths` already
+  covers this; offline mode is a broader system-level switch.
+- Automatic cache population — that still requires a prior online `rails rails_ai:registry:pull`.
+
+---
+
+## Proposed Configuration API
+
+```ruby
+# config/initializers/rails_ai_bridge.rb
+RailsAiBridge.configure do |config|
+  config.registry.offline = true          # raise ResolutionError instead of cloning/pulling
+  # config.registry.offline = :warn       # log a warning but continue (use stale cache)
+end
+```
+
+Default: `false` (current behavior).
+
+---
+
+## Implementation Plan
+
+### Phase 1 — Config flag
+
+- Add `attr_accessor :offline` to `Config::Registry` with default `false`.
+- Document the three valid values (`false`, `true`, `:warn`).
+
+### Phase 2 — Wire into SkillSourceResolver
+
+In `SkillSourceResolver#resolve`:
+
+```ruby
+if offline?
+  raise ResolutionError, offline_error(source) unless File.exist?(cache_path)
+  return cache_path                           # use cache as-is
+end
+```
+
+In `#perform_pull` and `#perform_clone`:
+
+```ruby
+if offline? == :warn
+  warn "[rails-ai-bridge] Offline mode :warn — skipping git #{op} for pack: #{source}"
+  return
+end
+```
+
+The `offline?` helper reads from the injected config; `DefaultGitRunner` is not called at all.
+
+### Phase 3 — Rake task: `rails rails_ai:registry:pull`
+
+A new rake task that forces a full pull of all configured packs regardless of TTL:
+
+```ruby
+task pull: :environment do
+  resolver = RailsAiBridge::Registry.build_resolver_uncached(config)
+  puts "Pulled #{resolver&.packs&.count || 0} pack(s) to #{config.skill_cache_dir}"
+end
+```
+
+Running this before switching `offline: true` ensures the cache is populated.
+
+### Phase 4 — Vendored pack snapshot
+
+Document a pattern where packs are committed to `vendor/skill_packs/` and each pack entry
+in the registry manifest uses a `local_registry_paths` entry pointing there. No git at all.
+
+### Phase 5 — CI guidance
+
+Add a GitHub Actions example that:
+
+1. Caches `~/.rails-ai-bridge/cache` across runs keyed on the manifest hash.
+2. Runs `rails rails_ai:registry:pull` only on cache miss.
+3. Sets `RAILS_AI_BRIDGE_OFFLINE=true` (mapped to `config.registry.offline = true`)
+   for the test job to prevent accidental pulls.
+
+---
+
+## Error Messages
+
+| Scenario | Message |
+|----------|---------|
+| `offline: true`, pack not cached | `"Offline mode is enabled. Run \`rails rails_ai:registry:pull\` to populate the cache before going offline."` |
+| `offline: :warn`, pack not cached | Warning logged, pack skipped, no raise |
+| Network error + `offline: false` | Existing `ResolutionError` with git stderr |
+
+---
+
+## Files to Create / Modify
+
+| File | Change |
+|------|--------|
+| `lib/rails_ai_bridge/config/registry.rb` | Add `offline` attr, default `false` |
+| `lib/rails_ai_bridge/registry/skill_source_resolver.rb` | Guard clone/pull with offline check |
+| `lib/rails_ai_bridge/tasks/rails_ai_bridge.rake` | Add `registry:pull` task |
+| `spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb` | Add offline mode contexts |
+| `docs/skill-registry-guide.md` | Document offline workflow |
+
+---
+
+## Open Questions
+
+1. Should `offline: true` also suppress `checkout_ref`? (Yes — if cache exists, trust it.)
+2. Should the rake pull task honour `git_pull_ttl`? (No — it is an explicit override.)
+3. Should ENV var `RAILS_AI_BRIDGE_OFFLINE` map to the config? (Yes, for CI convenience.)

--- a/docs/port-registry-resolution.md
+++ b/docs/port-registry-resolution.md
@@ -18,7 +18,7 @@ necessary for the future skill compiler feature.
 | `ContextProviderDefinition` / `ContextToolSpec` | **Deferred** (YAGNI — not in registry.json, no integration milestone) |
 | Git operations | Use `Open3` (stdlib) — no new gem dependency |
 | `ruby-skill-bench` `PackResolver` | Stays independent — no cross-repo dependency |
-| MCP tools | `rails_list_skills`, `rails_list_agents`, `rails_list_packs` included; `rails_use_skill` / `rails_use_agent` **deferred** |
+| MCP tools | `rails_list_registry` (unified — replaces the originally-planned split `rails_list_skills` / `rails_list_agents` / `rails_list_packs` tools); `rails_use_skill` / `rails_use_agent` **deferred** |
 | Configuration access | New `Config::Registry` sub-object; accessed as `configuration.registry.*` — no top-level delegators |
 | Priorities | Hardcoded matching Rust (`local=0`, `rails/hanami=10`, `core=20`, `other=30`) |
 | Frontmatter parser | Include as internal utility (`Registry::FrontmatterParser`) — used when `tile.json` `SkillEntry` has no `description` |
@@ -133,12 +133,9 @@ necessary for the future skill compiler feature.
 - Append to `lib/rails_ai_bridge/tasks/rails_ai_bridge.rake`:
   - `rails_ai_bridge:list_skills` — prints skill catalog from registry
   - `rails_ai_bridge:resolve_skill[pack,name]` — resolves and prints skill content
-- `lib/rails_ai_bridge/tools/rails_list_skills_tool.rb`
-- `lib/rails_ai_bridge/tools/rails_list_agents_tool.rb`
-- `lib/rails_ai_bridge/tools/rails_list_packs_tool.rb`
-- `spec/lib/rails_ai_bridge/tools/rails_list_skills_tool_spec.rb`
-- `spec/lib/rails_ai_bridge/tools/rails_list_agents_tool_spec.rb`
-- `spec/lib/rails_ai_bridge/tools/rails_list_packs_tool_spec.rb`
+- `lib/rails_ai_bridge/tools/list_registry.rb` — unified `rails_list_registry` tool (replaces
+  the originally-planned split `rails_list_skills`, `rails_list_agents`, `rails_list_packs`)
+- `spec/lib/rails_ai_bridge/tools/list_registry_spec.rb`
 - `docs/registry-resolution.md` — user-facing docs (priority rules, example registry.json, config options)
 
 ## Deferred (follow-up)
@@ -164,7 +161,7 @@ necessary for the future skill compiler feature.
 - [x] All registry modules created with passing specs (PR 1–3)
 - [x] `Config::Registry` wired and documented (PR 4)
 - [x] `rails ai:skills:list` and `rails "ai:skills:resolve[pack,name]"` Rake tasks work (PR 5)
-- [x] `rails_list_skills`, `rails_list_agents`, `rails_list_packs` MCP tools exposed (PR 5)
+- [x] `rails_list_registry` MCP tool exposed (PR 5 — unified, replaces split tools)
 - [x] `docs/registry-resolution.md` written (PR 5)
 - [x] Priority-based resolution handles core/rails/hanami/planning correctly
 - [x] Deprecation redirects work (old skill name → new location)

--- a/docs/port-registry-resolution.md
+++ b/docs/port-registry-resolution.md
@@ -1,6 +1,6 @@
 # Port Registry Resolution from Rust Runtime to rails-ai-bridge
 
-**Status:** In progress — PR 1 completed ✅, PR 2 completed ✅, PR 3 completed ✅, PR 4 next
+**Status:** Complete — PR 1 ✅, PR 2 ✅, PR 3 ✅, PR 4 ✅, PR 5 ✅
 **Reference source:** `../agent-mcp-runtime/src/registry/` (Rust)
 **Delivery model:** Sequential PRs, each reviewed by Qodo + CodeRabbit before proceeding
 
@@ -161,15 +161,15 @@ necessary for the future skill compiler feature.
 
 ## Success Criteria
 
-- [ ] All registry modules created with passing specs (PR 1–3)
-- [ ] `Config::Registry` wired and documented (PR 4)
-- [ ] `rails_ai_bridge:list_skills` and `rails_ai_bridge:resolve_skill[pack,name]` Rake tasks work (PR 5)
-- [ ] `rails_list_skills`, `rails_list_agents`, `rails_list_packs` MCP tools exposed (PR 5)
-- [ ] `docs/registry-resolution.md` written (PR 5)
-- [ ] Priority-based resolution handles core/rails/hanami/planning correctly
-- [ ] Deprecation redirects work (old skill name → new location)
-- [ ] Path traversal guard enforced in resolver
-- [ ] `CHANGELOG.md` updated in every PR
-- [ ] `README.md` updated in PR 4 and PR 5
-- [ ] `UPGRADING.md` updated if breaking changes are introduced
+- [x] All registry modules created with passing specs (PR 1–3)
+- [x] `Config::Registry` wired and documented (PR 4)
+- [x] `rails ai:skills:list` and `rails "ai:skills:resolve[pack,name]"` Rake tasks work (PR 5)
+- [x] `rails_list_skills`, `rails_list_agents`, `rails_list_packs` MCP tools exposed (PR 5)
+- [x] `docs/registry-resolution.md` written (PR 5)
+- [x] Priority-based resolution handles core/rails/hanami/planning correctly
+- [x] Deprecation redirects work (old skill name → new location)
+- [x] Path traversal guard enforced in resolver
+- [x] `CHANGELOG.md` updated in every PR
+- [x] `README.md` updated in PR 4 and PR 5
+- [ ] `UPGRADING.md` updated if breaking changes are introduced (no breaking changes introduced)
 - [ ] All PRs pass Qodo + CodeRabbit review gates

--- a/docs/registry-resolution.md
+++ b/docs/registry-resolution.md
@@ -1,0 +1,225 @@
+# Registry Resolution Reference
+
+rails-ai-bridge can load **skill packs** — curated collections of agent skills and workflows — from versioned git repositories and make them discoverable via MCP tools and rake tasks.
+
+> **New to skill packs?** Read the [Skill Registry Guide](skill-registry-guide.md) first. It covers concepts, step-by-step setup, source formats, version pinning, and troubleshooting.
+
+## What a skill pack is
+
+A skill pack is a git repository that contains:
+
+- A **`directory.json`** manifest listing available skills and agents
+- Markdown skill files (e.g. `skills/code-review.md`) referenced by the manifest
+- Optional deprecation redirects when skills are renamed
+
+When a pack is loaded, its skills and agents appear in `rails_list_registry`, and any skill can be resolved to full content for an AI client.
+
+## Quick start
+
+**1. Create the registry manifest** at `config/rails_ai_bridge_registry.json`:
+
+```json
+{
+  "version": "1.0.0",
+  "packs": {
+    "rails": {
+      "source": "igmarin/rails-agent-skills",
+      "always_loaded": false
+    },
+    "core": {
+      "source": "igmarin/ruby-core-skills",
+      "always_loaded": true
+    }
+  },
+  "default_stack": ["core"]
+}
+```
+
+**2. Configure the bridge** in `config/initializers/rails_ai_bridge.rb`:
+
+```ruby
+RailsAiBridge.configure do |config|
+  config.registry.registry_manifest_path = "config/rails_ai_bridge_registry.json"
+end
+```
+
+**3. Verify** packs are loaded:
+
+```bash
+rails ai:skills:list
+```
+
+## Registry manifest format
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | String | Manifest schema version (currently `"1.0.0"`) |
+| `packs` | Object | Map of pack name → pack definition |
+| `default_stack` | Array | Pack names loaded when no framework is detected |
+
+### Pack definition fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `source` | String | Yes | — | Pack source: local path, full git URL, or `owner/repo` GitHub shorthand |
+| `tile` | String | No | `"directory.json"` | Relative path to the pack's catalog file |
+| `always_loaded` | Boolean | No | `false` | Load this pack regardless of framework detection |
+| `depends_on` | Array | No | `[]` | Other pack names this pack requires |
+| `ref` | String | No | `nil` | Git branch, tag, or SHA to check out; `nil` uses the default branch |
+
+### Source formats
+
+Three formats are accepted for the `source` field:
+
+| Format | Example |
+|--------|---------|
+| Local path | `/abs/path`, `./relative`, `../sibling` |
+| Full git URL | `https://github.com/org/repo.git` |
+| GitHub shorthand | `owner/repo` (expanded to `https://github.com/owner/repo.git`) |
+
+## Priority rules
+
+Packs are assigned priorities based on their name (case-insensitive exact match). Lower number = higher priority.
+
+| Pack name | Priority | Reasoning |
+|-----------|----------|-----------|
+| `local_*` (local registries) | 0 | Highest — local overrides always win |
+| `rails`, `hanami` | 10 | Framework-specific packs shadow generic ones |
+| `core` | 20 | Core packs provide defaults |
+| Any other name | 30 | Lowest — third-party or custom packs |
+
+When the same skill name appears in multiple packs, the version from the **highest priority** pack (lowest number) is returned.
+
+Note: only exact name matches qualify for high/medium priority. `rails-extras` gets priority 30.
+
+## Configuration options
+
+All options live under `config.registry.*`:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `registry_manifest_path` | `"config/rails_ai_bridge_registry.json"` | Path to the registry manifest JSON |
+| `skill_cache_dir` | `~/.rails-ai-bridge/cache` | Directory for caching cloned git repositories |
+| `skill_packs` | `nil` | Explicit list of pack names to load, or `nil` for auto-detection |
+| `local_registry_paths` | `[]` | Local directory paths containing a `directory.json` (loaded at priority 0) |
+| `resolver_ttl` | `1800` | Seconds to keep the wired `Resolver` in memory before rebuilding (default: 30 min) |
+
+### Auto-detection
+
+When `skill_packs` is `nil`, the bridge auto-detects the framework from your `Gemfile`:
+
+- Rails detected → loads the `rails` pack
+- Hanami detected → loads the `hanami` pack
+- Neither detected → falls back to `default_stack` from the manifest
+
+Set `skill_packs` explicitly to bypass auto-detection:
+
+```ruby
+config.registry.skill_packs = %w[rails core]
+```
+
+### Local registry paths
+
+Use `local_registry_paths` to load packs from local directories (useful during pack development):
+
+```ruby
+config.registry.local_registry_paths = ["/path/to/my-local-pack"]
+```
+
+The directory must contain a `directory.json` at its root. Local packs get priority 0 and always shadow remote packs.
+
+### Cache directory
+
+Remote packs are cloned to `skill_cache_dir` on first use and updated via `git pull` on subsequent loads. Override with the `RAILS_AI_BRIDGE_CACHE_DIR` environment variable or the config option.
+
+### Resolver cache TTL
+
+The wired `Resolver` object is cached in memory to avoid re-reading the manifest and re-running git operations on every MCP call. The default TTL is 30 minutes.
+
+```ruby
+config.registry.resolver_ttl = 300  # rebuild every 5 minutes
+config.registry.resolver_ttl = 0    # disable caching (rebuild on every call)
+```
+
+Invalidate manually:
+
+```ruby
+RailsAiBridge::Registry.invalidate_resolver_cache!
+```
+
+## Available MCP tools
+
+Once a registry manifest is configured:
+
+| Tool | Description |
+|------|-------------|
+| `rails_list_registry type=skills` | Lists all skills across loaded packs (optional `pack:` filter) |
+| `rails_list_registry type=agents` | Lists all agents/workflows across loaded packs (optional `pack:` filter) |
+| `rails_list_registry type=packs` | Lists active packs with version, priority, and summary |
+
+## Available rake tasks
+
+| Task | Description |
+|------|-------------|
+| `rails ai:skills:list` | Print skill catalog to stdout |
+| `rails "ai:skills:resolve[pack,skill_name]"` | Resolve and print a skill's full content |
+| `rails ai:skills:clear_cache` | Remove all cached pack git repositories and invalidate the resolver cache |
+
+Examples:
+
+```bash
+# List all skills
+rails ai:skills:list
+
+# Resolve a specific skill (pack filter is optional)
+rails "ai:skills:resolve[rails,code-review]"
+rails "ai:skills:resolve[,write-tests]"
+
+# Or using env vars
+PACK=rails SKILL=code-review rails ai:skills:resolve
+
+# Clear cache after a force-push or config change
+rails ai:skills:clear_cache
+```
+
+## Deprecation redirects
+
+Packs can declare that an old skill name now points to a new one. When an AI client requests a deprecated skill by name, the bridge transparently resolves the new skill and returns a deprecation warning.
+
+Example `directory.json` deprecation entry:
+
+```json
+{
+  "deprecated_skills": {
+    "old-code-review": {
+      "moved_to": "code-review",
+      "message": "Renamed to code-review in v2.0",
+      "removed_in": "3.0.0"
+    }
+  }
+}
+```
+
+## Dependency validation
+
+Packs can declare dependencies on other packs via `depends_on`. The bridge validates these at load time and emits warnings for unsatisfied dependencies, but does not abort — partial loads are allowed.
+
+## Cache management
+
+```bash
+rails ai:skills:clear_cache
+```
+
+Removes all cloned pack repositories from the `skill_cache_dir` and invalidates the in-memory resolver. Run this when:
+
+- A remote pack was force-pushed and the local clone is stale
+- You want to free disk space
+- You changed `skill_cache_dir` and need to re-clone elsewhere
+
+## Security
+
+- **Path traversal guard**: skill file paths in `directory.json` are validated against the pack's base directory using canonical path comparison. Paths that escape the pack root are silently skipped.
+- **Source validation**: `SourceParser` classifies each source string into one of three valid formats before any git operation. Strings that do not match are rejected with a `ResolutionError` that names the valid formats.
+- **Open3 subprocess isolation**: git operations use Open3 with array arguments — no shell interpolation.
+- **Cache key sanitization**: cache directory names are derived from a sanitized source string + SHA256 hash to prevent filesystem collisions.
+- **Local path security**: local paths are used as-is without git operations. The path traversal guard in the `Resolver` still applies to all file reads within the pack, regardless of source type.

--- a/docs/registry-resolution.md
+++ b/docs/registry-resolution.md
@@ -74,8 +74,12 @@ Three formats are accepted for the `source` field:
 | Format | Example |
 |--------|---------|
 | Local path | `/abs/path`, `./relative`, `../sibling` |
-| Full git URL | `https://github.com/org/repo.git` |
+| HTTPS URL | `https://github.com/org/repo.git` |
+| SSH URL | `git@github.com:org/repo.git` |
 | GitHub shorthand | `owner/repo` (expanded to `https://github.com/owner/repo.git`) |
+
+> **Note:** plain `http://` URLs are rejected to prevent unencrypted transmission of credentials
+> and pack content. Use `https://` or `git@` (SSH) instead.
 
 ## Priority rules
 
@@ -103,6 +107,8 @@ All options live under `config.registry.*`:
 | `skill_packs` | `nil` | Explicit list of pack names to load, or `nil` for auto-detection |
 | `local_registry_paths` | `[]` | Local directory paths containing a `directory.json` (loaded at priority 0) |
 | `resolver_ttl` | `1800` | Seconds to keep the wired `Resolver` in memory before rebuilding (default: 30 min) |
+| `git_pull_ttl` | `86400` | Seconds between `git pull` refreshes per cached pack (default: 24 h). Set to `0` to pull on every resolver rebuild |
+| `git_timeout` | `30` | Seconds before a git operation (clone, pull, checkout) is forcibly interrupted and a `ResolutionError` raised |
 
 ### Auto-detection
 
@@ -130,11 +136,41 @@ The directory must contain a `directory.json` at its root. Local packs get prior
 
 ### Cache directory
 
-Remote packs are cloned to `skill_cache_dir` on first use and updated via `git pull` on subsequent loads. Override with the `RAILS_AI_BRIDGE_CACHE_DIR` environment variable or the config option.
+Remote packs are cloned to `skill_cache_dir` on first use. Subsequent loads update the clone via
+`git pull` only when the pack's pull freshness window has expired (see `git_pull_ttl` below).
+Override the directory with the `RAILS_AI_BRIDGE_CACHE_DIR` environment variable or the config
+option.
+
+### Git pull freshness
+
+`git_pull_ttl` (default 86400 s = 24 h) controls how often a cached pack is refreshed via `git
+pull`. The timestamp of the last successful pull is tracked in memory per pack. If the TTL window
+has not elapsed, the existing clone is used as-is.
+
+```ruby
+config.registry.git_pull_ttl = 3600  # refresh packs every hour
+config.registry.git_pull_ttl = 0     # always pull on every resolver rebuild
+```
+
+Pull timestamps reset when the process restarts. To force a pull on the next rebuild, run
+`rails ai:skills:clear_cache` — this removes the cached clones entirely so the next build
+triggers a fresh `git clone`.
+
+### Git operation timeout
+
+`git_timeout` (default 30 s) limits how long any single git operation (clone, pull, checkout)
+may run before it is interrupted. A `ResolutionError` is raised if the limit is exceeded,
+naming the operation and pack in the message.
+
+```ruby
+config.registry.git_timeout = 10  # tighter limit for fast networks
+config.registry.git_timeout = 60  # more time for slow remotes
+```
 
 ### Resolver cache TTL
 
-The wired `Resolver` object is cached in memory to avoid re-reading the manifest and re-running git operations on every MCP call. The default TTL is 30 minutes.
+The wired `Resolver` object is cached in memory to avoid re-reading the manifest and re-running
+git operations on every MCP call. The default TTL is 30 minutes.
 
 ```ruby
 config.registry.resolver_ttl = 300  # rebuild every 5 minutes
@@ -146,6 +182,9 @@ Invalidate manually:
 ```ruby
 RailsAiBridge::Registry.invalidate_resolver_cache!
 ```
+
+In development, the resolver cache is invalidated automatically on every Zeitwerk code reload
+via the Engine's `to_prepare` hook, so initializer changes take effect without a server restart.
 
 ## Available MCP tools
 
@@ -202,7 +241,14 @@ Example `directory.json` deprecation entry:
 
 ## Dependency validation
 
-Packs can declare dependencies on other packs via `depends_on`. The bridge validates these at load time and emits warnings for unsatisfied dependencies, but does not abort — partial loads are allowed.
+Packs can declare dependencies on other packs via `depends_on`. The bridge validates these at load
+time. When an active pack lists a dependency that is not in the active set, a `[rails-ai-bridge]`
+warning is emitted to stderr naming each missing dependency and pointing to the manifest field that
+should be updated. The pack itself still loads — this is an advisory warning, not an abort.
+
+> Transitive dependency loading (automatically pulling in a pack's `depends_on` entries) is not
+> yet implemented. All required packs must be listed explicitly in `always_loaded` or the
+> `skill_packs` config option.
 
 ## Cache management
 
@@ -220,6 +266,9 @@ Removes all cloned pack repositories from the `skill_cache_dir` and invalidates 
 
 - **Path traversal guard**: skill file paths in `directory.json` are validated against the pack's base directory using canonical path comparison. Paths that escape the pack root are silently skipped.
 - **Source validation**: `SourceParser` classifies each source string into one of three valid formats before any git operation. Strings that do not match are rejected with a `ResolutionError` that names the valid formats.
+- **HTTPS/SSH only**: plain `http://` URLs are rejected. Only `https://` and `git@` (SSH) sources are accepted for remote packs, preventing unencrypted transmission of credentials and pack content.
 - **Open3 subprocess isolation**: git operations use Open3 with array arguments — no shell interpolation.
 - **Cache key sanitization**: cache directory names are derived from a sanitized source string + SHA256 hash to prevent filesystem collisions.
+- **Stable local pack names**: local registry packs use a SHA256 digest of the directory path as their name suffix, so reordering `local_registry_paths` cannot silently shift pack identities.
+- **Timeout protection**: all git operations are bounded by `git_timeout` (default 30 s), preventing a slow remote from blocking the calling thread indefinitely.
 - **Local path security**: local paths are used as-is without git operations. The path traversal guard in the `Resolver` still applies to all file reads within the pack, regardless of source type.

--- a/docs/skill-registry-guide.md
+++ b/docs/skill-registry-guide.md
@@ -74,8 +74,9 @@ The `source` field in a pack definition accepts three formats:
 | Format | Example | When to use |
 |--------|---------|-------------|
 | Local path | `/Users/alice/my-skills` or `./local-pack` | Pack development, monorepo |
-| Full git URL | `https://github.com/org/skills.git` | Non-GitHub remotes, SSH |
-| GitHub shorthand | `igmarin/rails-agent-skills` | Most common — expanded automatically |
+| HTTPS URL | `https://github.com/org/skills.git` | Non-GitHub remotes; most common for public repos |
+| SSH URL | `git@github.com:org/skills.git` | Private repos or when SSH keys are configured |
+| GitHub shorthand | `igmarin/rails-agent-skills` | Shortest form — expanded to HTTPS automatically |
 
 ```json
 {
@@ -83,8 +84,11 @@ The `source` field in a pack definition accepts three formats:
     "local-override": {
       "source": "/Users/alice/dev/my-skills"
     },
-    "via-url": {
+    "via-https": {
       "source": "https://gitlab.com/myorg/skills.git"
+    },
+    "via-ssh": {
+      "source": "git@gitlab.com:myorg/skills.git"
     },
     "via-shorthand": {
       "source": "igmarin/ruby-core-skills"
@@ -94,6 +98,8 @@ The `source` field in a pack definition accepts three formats:
 ```
 
 Local paths are never cloned — the directory is used directly. Git URL and shorthand sources are cloned to the skill cache directory.
+
+> **`http://` is not accepted.** Plain HTTP URLs are rejected to prevent credentials and pack content from being transmitted unencrypted. Use `https://` or SSH (`git@`) instead.
 
 ---
 
@@ -204,7 +210,7 @@ Once a registry manifest is configured, use `rails_list_registry` to query the c
 
 ### List all skills
 
-```
+```bash
 rails_list_registry type=skills
 ```
 
@@ -212,7 +218,7 @@ Returns a markdown table of all skills across all loaded packs with name, pack, 
 
 ### Filter by pack
 
-```
+```bash
 rails_list_registry type=skills pack=rails
 rails_list_registry type=agents pack=core
 ```
@@ -221,7 +227,7 @@ Narrows results to one pack.
 
 ### List active packs
 
-```
+```bash
 rails_list_registry type=packs
 ```
 
@@ -266,9 +272,39 @@ Removes all locally cached pack repositories from the skill cache directory and 
 
 ---
 
+## Git operation settings
+
+### Pull freshness window (`git_pull_ttl`)
+
+By default, a cached pack is refreshed via `git pull` at most once every 24 hours. This avoids
+redundant network calls — skill pack files are documentation and rarely change between releases.
+
+```ruby
+config.registry.git_pull_ttl = 3600  # refresh every hour
+config.registry.git_pull_ttl = 0     # always pull on every resolver rebuild (old behaviour)
+```
+
+Pull timestamps are tracked in memory per pack and reset when the process restarts. To force an
+immediate re-pull without restarting, run `rails ai:skills:clear_cache` — this removes cached
+clones entirely so the next build does a fresh `git clone`.
+
+### Git operation timeout (`git_timeout`)
+
+All git operations (clone, pull, checkout) have a 30-second timeout by default. If the limit is
+exceeded, a `ResolutionError` is raised — the server stays responsive even when a remote is slow
+or unreachable.
+
+```ruby
+config.registry.git_timeout = 10  # faster fail on fast networks
+config.registry.git_timeout = 60  # more time for large repos or slow remotes
+```
+
+---
+
 ## Resolver cache
 
-rails-ai-bridge caches the wired `Resolver` object in memory to avoid re-reading the manifest and re-running git operations on every MCP tool call.
+rails-ai-bridge caches the wired `Resolver` object in memory to avoid re-reading the manifest
+and re-running git operations on every MCP tool call.
 
 **Default TTL:** 30 minutes (1800 seconds).
 
@@ -284,11 +320,15 @@ Set to `0` to disable caching (rebuilds on every call — only useful in develop
 config.registry.resolver_ttl = 0
 ```
 
-The cache is invalidated automatically by `rails ai:skills:clear_cache`. You can also invalidate it programmatically:
+The cache is invalidated automatically by `rails ai:skills:clear_cache`. You can also invalidate
+it programmatically:
 
 ```ruby
 RailsAiBridge::Registry.invalidate_resolver_cache!
 ```
+
+In development, the cache is also invalidated automatically on every Zeitwerk code reload so that
+initializer changes take effect immediately.
 
 ---
 
@@ -298,17 +338,24 @@ RailsAiBridge::Registry.invalidate_resolver_cache!
 |---------|-------------|-----|
 | `rails ai:skills:list` shows "No registry manifest found" | Manifest file does not exist or path is wrong | Create `config/rails_ai_bridge_registry.json` or check `config.registry.registry_manifest_path` |
 | Git clone fails with "not found" | Pack source URL is wrong or repo is private | Check the `source` field; for private repos use a full SSH URL `git@github.com:org/repo.git` |
+| `Invalid source format` error mentioning `http://` | Pack source uses plain HTTP | Change `source` to `https://` or `git@` — plain HTTP is not accepted |
 | Pack loads but shows 0 skills | `directory.json` is missing or has wrong path | Check the root of the cloned pack for `directory.json`; set `tile:` field if the file is elsewhere |
 | Skill resolves from wrong pack | Priority mismatch | Use `rails_list_registry type=packs` to see priorities; use local registry or explicit `skill_packs` to override |
-| Stale skills after pack update | Resolver cache is warm | Run `rails ai:skills:clear_cache` |
+| Stale skills after pack update | Resolver cache is warm or pull TTL has not elapsed | Run `rails ai:skills:clear_cache` to force a re-clone on the next build |
+| Pack is not re-fetched even after `resolver_ttl` expired | Pack was cloned recently — `git_pull_ttl` (24 h) is still fresh | Run `rails ai:skills:clear_cache` or set `git_pull_ttl: 0` temporarily |
 | `git checkout <ref>` failed | Invalid ref or detached HEAD issue | Verify the `ref` value matches a branch, tag, or SHA in the remote repo |
+| Git operation hangs / server request times out | Slow or unreachable remote | Reduce `git_timeout` to fail faster; check network connectivity to the remote |
+| Warning: "Pack '…' depends on '…' which is not in the active pack set" | A loaded pack has an unsatisfied `depends_on` entry | Add the missing pack name to `always_loaded` or `skill_packs` in your manifest |
 
 ---
 
 ## Security model
 
 - **Path traversal guard**: skill file paths in `directory.json` are validated against the pack's base directory. A path like `../../etc/passwd` is silently skipped.
-- **Source validation**: all three source formats are validated by `SourceParser` before any git operation. Strings that do not match a known format raise `ResolutionError` before any subprocess is spawned.
+- **Source validation**: all source formats are validated by `SourceParser` before any git operation. Strings that do not match a known format raise `ResolutionError` before any subprocess is spawned.
+- **HTTPS/SSH only**: plain `http://` URLs are rejected at parse time to prevent unencrypted transmission of credentials and pack content.
 - **Subprocess isolation**: git operations use Open3 with array arguments — no shell interpolation.
-- **Cache key sanitization**: local cache directory names are derived from a sanitized source string plus a SHA256 hash suffix.
+- **Timeout protection**: all git operations are bounded by `git_timeout` (default 30 s) so a slow remote cannot block the calling thread indefinitely.
+- **Cache key sanitization**: local cache directory names are derived from a sanitized source string plus a SHA256 hash suffix to prevent filesystem collisions.
+- **Stable local pack names**: local registry pack names use a SHA256 digest of the directory path, so reordering `local_registry_paths` cannot silently shift pack identities.
 - **Local path trust**: local paths are used directly without git operations. The path traversal guard in the Resolver still applies to file reads within a local pack.

--- a/docs/skill-registry-guide.md
+++ b/docs/skill-registry-guide.md
@@ -1,0 +1,314 @@
+# Skill Registry Guide
+
+This guide walks you through setting up and using the rails-ai-bridge skill registry. If you want the dry technical reference instead, see [docs/registry-resolution.md](registry-resolution.md).
+
+## What problem this solves
+
+Every Rails team has conventions: how they name service objects, how they structure tests, what patterns they enforce in code review. Without the skill registry, an AI assistant rediscovers those conventions from scratch every session — or worse, ignores them.
+
+Skill packs let you codify those conventions once as agent instruction files and load them automatically into any project's MCP context. A code-review skill written for your team's Rails style is available in every repo, every session, and every AI tool that speaks MCP.
+
+---
+
+## Mental model
+
+A **skill pack** is a git repository containing:
+
+- A **`directory.json`** catalog that lists available skills and agents
+- **Markdown files** for each skill (e.g. `skills/code-review.md`)
+- Optional **deprecation redirects** when skills are renamed
+
+The skill registry in your Rails app is a **`config/rails_ai_bridge_registry.json`** manifest that tells rails-ai-bridge which packs to load, where to find them, and how to prioritize them when two packs define a skill with the same name.
+
+---
+
+## Quick start (3 steps)
+
+### Step 1 — Create the registry manifest
+
+Create `config/rails_ai_bridge_registry.json` in your Rails app:
+
+```json
+{
+  "version": "1.0.0",
+  "packs": {
+    "rails": {
+      "source": "igmarin/rails-agent-skills",
+      "always_loaded": false
+    },
+    "core": {
+      "source": "igmarin/ruby-core-skills",
+      "always_loaded": true
+    }
+  },
+  "default_stack": ["core"]
+}
+```
+
+The `source` field is a GitHub `owner/repo` shorthand. The `tile` field is optional — it defaults to `directory.json` at the root of the pack.
+
+### Step 2 — Configure the bridge
+
+In `config/initializers/rails_ai_bridge.rb`:
+
+```ruby
+RailsAiBridge.configure do |config|
+  config.registry.registry_manifest_path = "config/rails_ai_bridge_registry.json"
+end
+```
+
+### Step 3 — Verify packs are loaded
+
+```bash
+rails ai:skills:list
+```
+
+You should see a table of skills with their pack name and description. If packs are not yet cached locally, the first run clones them from GitHub.
+
+---
+
+## Source formats
+
+The `source` field in a pack definition accepts three formats:
+
+| Format | Example | When to use |
+|--------|---------|-------------|
+| Local path | `/Users/alice/my-skills` or `./local-pack` | Pack development, monorepo |
+| Full git URL | `https://github.com/org/skills.git` | Non-GitHub remotes, SSH |
+| GitHub shorthand | `igmarin/rails-agent-skills` | Most common — expanded automatically |
+
+```json
+{
+  "packs": {
+    "local-override": {
+      "source": "/Users/alice/dev/my-skills"
+    },
+    "via-url": {
+      "source": "https://gitlab.com/myorg/skills.git"
+    },
+    "via-shorthand": {
+      "source": "igmarin/ruby-core-skills"
+    }
+  }
+}
+```
+
+Local paths are never cloned — the directory is used directly. Git URL and shorthand sources are cloned to the skill cache directory.
+
+---
+
+## Priority rules
+
+When two packs define a skill with the same name, the version from the **highest priority** pack wins. Priority is assigned by pack name (case-insensitive matching):
+
+| Pack name | Priority | Reason |
+|-----------|----------|--------|
+| `local_*` (local registries) | 0 | Always win — local overrides |
+| `rails` or `hanami` | 10 | Framework-specific packs override generic ones |
+| `core` | 20 | Core defaults |
+| Any other name | 30 | Third-party or custom packs |
+
+**Note:** Only exact name matches get the boosted priority. A pack named `rails-extras` gets priority 30, not 10.
+
+To override a skill from any remote pack, add a local registry path:
+
+```ruby
+config.registry.local_registry_paths = ["/path/to/my-local-pack"]
+```
+
+Local registry packs always get priority 0.
+
+---
+
+## Version pinning
+
+Pin a pack to a specific branch, tag, or commit SHA using the `ref` field:
+
+```json
+{
+  "packs": {
+    "rails": {
+      "source": "igmarin/rails-agent-skills",
+      "ref": "v1.2.0"
+    },
+    "core": {
+      "source": "igmarin/ruby-core-skills",
+      "ref": "main"
+    }
+  }
+}
+```
+
+When `ref` is set, rails-ai-bridge runs `git checkout <ref>` after cloning or pulling. Without `ref`, the default branch (usually `main`) is used.
+
+**When to pin:**
+- Production deployments where you want deterministic skill behavior
+- When a pack update broke your workflow
+- When you need to test against a specific version before upgrading
+
+---
+
+## The `directory.json` format
+
+Each skill pack repository should have a `directory.json` at its root. Here is an annotated example:
+
+```json
+{
+  "name": "rails-agent-skills",
+  "version": "1.2.0",
+  "summary": "Rails development skills for AI agents",
+  "depends_on": ["core"],
+  "skills": {
+    "code-review": {
+      "path": "skills/code-review.md",
+      "description": "Review Rails code against team conventions."
+    },
+    "write-tests": {
+      "path": "skills/write-tests.md",
+      "description": "Write RSpec tests for Rails models and services."
+    }
+  },
+  "agents": {
+    "tdd-workflow": {
+      "path": "agents/tdd-workflow.md",
+      "description": "Full TDD cycle from failing test to passing implementation."
+    }
+  },
+  "deprecated_skills": {
+    "review-rails-code": {
+      "moved_to": "code-review",
+      "message": "Renamed to code-review in v1.1",
+      "removed_in": "2.0.0"
+    }
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | String | Pack identifier |
+| `version` | String | SemVer version string |
+| `summary` | String | Brief description shown in `rails_list_registry type=packs` |
+| `depends_on` | Array | Pack names this pack needs loaded first |
+| `skills` | Object | Map of skill name → `{ path, description }` |
+| `agents` | Object | Map of agent name → `{ path, description }` |
+| `deprecated_skills` | Object | Rename redirects for old skill names |
+
+Skill and agent paths are relative to the pack's root directory.
+
+---
+
+## MCP tool reference
+
+Once a registry manifest is configured, use `rails_list_registry` to query the catalog:
+
+### List all skills
+
+```
+rails_list_registry type=skills
+```
+
+Returns a markdown table of all skills across all loaded packs with name, pack, and description.
+
+### Filter by pack
+
+```
+rails_list_registry type=skills pack=rails
+rails_list_registry type=agents pack=core
+```
+
+Narrows results to one pack.
+
+### List active packs
+
+```
+rails_list_registry type=packs
+```
+
+Returns all loaded packs with name, version, priority, and summary. Use this to confirm which packs are active and what their priorities are.
+
+---
+
+## Rake task reference
+
+### List skills
+
+```bash
+rails ai:skills:list
+```
+
+Prints a skills table to stdout with skill name, pack, and truncated description. Good for quickly checking what is loaded.
+
+### Resolve a skill
+
+```bash
+rails "ai:skills:resolve[rails,code-review]"
+```
+
+Resolves and prints the full content of a skill. The pack argument is optional and used only for a mismatch warning:
+
+```bash
+rails "ai:skills:resolve[,write-tests]"         # resolve by name, no pack filter
+PACK=rails SKILL=code-review rails ai:skills:resolve   # same via env vars
+```
+
+### Clear the cache
+
+```bash
+rails ai:skills:clear_cache
+```
+
+Removes all locally cached pack repositories from the skill cache directory and invalidates the in-memory resolver cache. Run this when:
+
+- A remote pack was force-pushed and the cache is stale
+- You want to free disk space
+- You changed the `skill_cache_dir` configuration
+
+---
+
+## Resolver cache
+
+rails-ai-bridge caches the wired `Resolver` object in memory to avoid re-reading the manifest and re-running git operations on every MCP tool call.
+
+**Default TTL:** 30 minutes (1800 seconds).
+
+Override in your initializer:
+
+```ruby
+config.registry.resolver_ttl = 300  # rebuild every 5 minutes
+```
+
+Set to `0` to disable caching (rebuilds on every call — only useful in development):
+
+```ruby
+config.registry.resolver_ttl = 0
+```
+
+The cache is invalidated automatically by `rails ai:skills:clear_cache`. You can also invalidate it programmatically:
+
+```ruby
+RailsAiBridge::Registry.invalidate_resolver_cache!
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `rails ai:skills:list` shows "No registry manifest found" | Manifest file does not exist or path is wrong | Create `config/rails_ai_bridge_registry.json` or check `config.registry.registry_manifest_path` |
+| Git clone fails with "not found" | Pack source URL is wrong or repo is private | Check the `source` field; for private repos use a full SSH URL `git@github.com:org/repo.git` |
+| Pack loads but shows 0 skills | `directory.json` is missing or has wrong path | Check the root of the cloned pack for `directory.json`; set `tile:` field if the file is elsewhere |
+| Skill resolves from wrong pack | Priority mismatch | Use `rails_list_registry type=packs` to see priorities; use local registry or explicit `skill_packs` to override |
+| Stale skills after pack update | Resolver cache is warm | Run `rails ai:skills:clear_cache` |
+| `git checkout <ref>` failed | Invalid ref or detached HEAD issue | Verify the `ref` value matches a branch, tag, or SHA in the remote repo |
+
+---
+
+## Security model
+
+- **Path traversal guard**: skill file paths in `directory.json` are validated against the pack's base directory. A path like `../../etc/passwd` is silently skipped.
+- **Source validation**: all three source formats are validated by `SourceParser` before any git operation. Strings that do not match a known format raise `ResolutionError` before any subprocess is spawned.
+- **Subprocess isolation**: git operations use Open3 with array arguments — no shell interpolation.
+- **Cache key sanitization**: local cache directory names are derived from a sanitized source string plus a SHA256 hash suffix.
+- **Local path trust**: local paths are used directly without git operations. The path traversal guard in the Resolver still applies to file reads within a local pack.

--- a/lib/rails_ai_bridge/config/registry.rb
+++ b/lib/rails_ai_bridge/config/registry.rb
@@ -29,11 +29,44 @@ module RailsAiBridge
       # @return [Integer] TTL in seconds between git pull refreshes per cached pack (default: 86400 = 24 h).
       #   Set to 0 to pull on every resolver rebuild. Skill pack files are documentation and rarely
       #   change between releases, so a long freshness window is appropriate.
-      attr_accessor :git_pull_ttl
+      attr_reader :git_pull_ttl
 
       # @return [Integer] timeout in seconds for individual git operations (clone, pull, checkout).
       #   Prevents a slow or unreachable remote from blocking the calling thread indefinitely.
-      attr_accessor :git_timeout
+      attr_reader :git_timeout
+
+      # Sets the git pull TTL.
+      #
+      # Coerces the value to a non-negative integer; raises +ArgumentError+ for
+      # non-numeric or negative inputs.
+      #
+      # @param value [Integer, #to_i] pull refresh interval in seconds; 0 pulls on every rebuild
+      # @raise [ArgumentError] if value cannot be coerced to a non-negative integer
+      def git_pull_ttl=(value)
+        int = Integer(value)
+        raise ArgumentError, "git_pull_ttl must be >= 0, got #{int}" if int.negative?
+
+        @git_pull_ttl = int
+      rescue ArgumentError, TypeError
+        raise ArgumentError, "git_pull_ttl must be a non-negative integer, got #{value.inspect}"
+      end
+
+      # Sets the git operation timeout.
+      #
+      # Coerces the value to a positive integer (must be >= 1); raises +ArgumentError+
+      # for non-numeric, zero, or negative inputs because a zero-second timeout is
+      # never useful and would cause every git operation to fail immediately.
+      #
+      # @param value [Integer, #to_i] timeout in seconds
+      # @raise [ArgumentError] if value cannot be coerced to a positive integer
+      def git_timeout=(value)
+        int = Integer(value)
+        raise ArgumentError, "git_timeout must be >= 1, got #{int}" unless int >= 1
+
+        @git_timeout = int
+      rescue ArgumentError, TypeError
+        raise ArgumentError, "git_timeout must be a positive integer, got #{value.inspect}"
+      end
 
       # Sets the in-memory resolver cache TTL.
       #

--- a/lib/rails_ai_bridge/config/registry.rb
+++ b/lib/rails_ai_bridge/config/registry.rb
@@ -24,7 +24,33 @@ module RailsAiBridge
       attr_accessor :local_registry_paths
 
       # @return [Integer] TTL in seconds for the in-memory resolver cache (default: 1800 = 30 min)
-      attr_accessor :resolver_ttl
+      attr_reader :resolver_ttl
+
+      # @return [Integer] TTL in seconds between git pull refreshes per cached pack (default: 86400 = 24 h).
+      #   Set to 0 to pull on every resolver rebuild. Skill pack files are documentation and rarely
+      #   change between releases, so a long freshness window is appropriate.
+      attr_accessor :git_pull_ttl
+
+      # @return [Integer] timeout in seconds for individual git operations (clone, pull, checkout).
+      #   Prevents a slow or unreachable remote from blocking the calling thread indefinitely.
+      attr_accessor :git_timeout
+
+      # Sets the in-memory resolver cache TTL.
+      #
+      # Coerces the value to a non-negative integer; raises +ArgumentError+ for
+      # non-numeric or negative inputs to prevent silent +TypeError+ in
+      # {ResolverCache#expired?} when nil or strings are assigned.
+      #
+      # @param value [Integer, #to_i] cache TTL in seconds; 0 disables caching
+      # @raise [ArgumentError] if value cannot be coerced to a non-negative integer
+      def resolver_ttl=(value)
+        int = Integer(value)
+        raise ArgumentError, "resolver_ttl must be >= 0, got #{int}" if int.negative?
+
+        @resolver_ttl = int
+      rescue ArgumentError, TypeError
+        raise ArgumentError, "resolver_ttl must be a non-negative integer, got #{value.inspect}"
+      end
 
       def initialize
         @registry_manifest_path = 'config/rails_ai_bridge_registry.json'
@@ -32,6 +58,8 @@ module RailsAiBridge
         @skill_packs = nil
         @local_registry_paths = []
         @resolver_ttl = 1800
+        @git_pull_ttl = 86_400
+        @git_timeout = 30
       end
     end
   end

--- a/lib/rails_ai_bridge/config/registry.rb
+++ b/lib/rails_ai_bridge/config/registry.rb
@@ -23,11 +23,15 @@ module RailsAiBridge
       # @return [Array<String>] local registry directory paths
       attr_accessor :local_registry_paths
 
+      # @return [Integer] TTL in seconds for the in-memory resolver cache (default: 1800 = 30 min)
+      attr_accessor :resolver_ttl
+
       def initialize
         @registry_manifest_path = 'config/rails_ai_bridge_registry.json'
         @skill_cache_dir = File.expand_path('~/.rails-ai-bridge/cache')
         @skill_packs = nil
         @local_registry_paths = []
+        @resolver_ttl = 1800
       end
     end
   end

--- a/lib/rails_ai_bridge/engine.rb
+++ b/lib/rails_ai_bridge/engine.rb
@@ -31,6 +31,16 @@ module RailsAiBridge
       end
     end
 
+    # Invalidate the registry resolver cache on each code reload in development.
+    #
+    # +to_prepare+ fires once in production (after eager load) and on every
+    # Zeitwerk reload in development. Discarding the cached resolver ensures
+    # the next MCP tool call rebuilds it with the current configuration,
+    # preventing stale config after an initializer change.
+    config.to_prepare do
+      RailsAiBridge::Registry.invalidate_resolver_cache!
+    end
+
     # Auto-mount MCP HTTP middleware when configured
     initializer 'rails_ai_bridge.middleware' do |app|
       RailsAiBridge.validate_auto_mount_configuration!

--- a/lib/rails_ai_bridge/registry.rb
+++ b/lib/rails_ai_bridge/registry.rb
@@ -69,7 +69,8 @@ module RailsAiBridge
       return nil unless File.exist?(manifest_path)
 
       manifest = RegistryManifest.from_file(manifest_path)
-      source_resolver = SkillSourceResolver.new(config.skill_cache_dir)
+      git_runner = Registry::DefaultGitRunner.new(timeout: config.git_timeout)
+      source_resolver = SkillSourceResolver.new(config.skill_cache_dir, git_runner, pull_ttl: config.git_pull_ttl)
       pack_resolver = PackResolver.new(source_resolver)
 
       pack_resolver.resolve(

--- a/lib/rails_ai_bridge/registry.rb
+++ b/lib/rails_ai_bridge/registry.rb
@@ -23,5 +23,61 @@ module RailsAiBridge
   # @see Registry::ResolvedSkill
   # @see Registry::SkillSummary
   module Registry
+    # Module-level resolver cache (one per process, lazy-initialized on first use).
+    #
+    # @api private
+    @resolver_cache = nil
+    @resolver_cache_mutex = Mutex.new
+
+    # Returns the module-level {ResolverCache} instance, creating it on first call.
+    #
+    # @api private
+    def self.resolver_cache
+      @resolver_cache_mutex.synchronize do
+        @resolver_cache ||= ResolverCache.new
+      end
+    end
+
+    # Discards the cached resolver so the next {build_resolver} call rebuilds from disk.
+    #
+    # Call this after clearing the git cache or modifying the registry manifest at runtime.
+    #
+    # @return [void]
+    def self.invalidate_resolver_cache!
+      @resolver_cache_mutex.synchronize { @resolver_cache&.invalidate! }
+    end
+
+    # Builds (or returns a cached) {Resolver} from the current {Config::Registry}.
+    #
+    # The first call for a given TTL window loads the manifest from disk, wires the
+    # {SkillSourceResolver} and {PackResolver} pipeline, and caches the result.
+    # Subsequent calls within the TTL window return the same resolver without I/O.
+    #
+    # Returns +nil+ when the registry manifest file does not exist, allowing callers
+    # to surface a helpful setup message rather than raising. A nil result is never
+    # cached — the next call will retry.
+    #
+    # @param config [RailsAiBridge::Config::Registry] registry configuration
+    # @return [Resolver, nil] wired resolver, or nil if manifest file is missing
+    def self.build_resolver(config = RailsAiBridge.configuration.registry)
+      resolver_cache.fetch(config) { build_resolver_uncached(config) }
+    end
+
+    # @api private
+    def self.build_resolver_uncached(config)
+      manifest_path = config.registry_manifest_path
+      return nil unless File.exist?(manifest_path)
+
+      manifest = RegistryManifest.from_file(manifest_path)
+      source_resolver = SkillSourceResolver.new(config.skill_cache_dir)
+      pack_resolver = PackResolver.new(source_resolver)
+
+      pack_resolver.resolve(
+        manifest,
+        config.skill_packs,
+        config.local_registry_paths.empty? ? nil : config.local_registry_paths
+      )
+    end
+    private_class_method :build_resolver_uncached
   end
 end

--- a/lib/rails_ai_bridge/registry/pack_definition.rb
+++ b/lib/rails_ai_bridge/registry/pack_definition.rb
@@ -5,14 +5,17 @@ module RailsAiBridge
     # Immutable value object describing a single pack's source and loading behaviour.
     #
     # @!attribute [r] source
-    #   @return [String] GitHub source identifier, e.g. "igmarin/ruby-core-skills"
+    #   @return [String] pack source — local path, full git URL, or "owner/repo" shorthand
     # @!attribute [r] tile
-    #   @return [String] relative path to the pack's tile manifest, usually "tile.json"
+    #   @return [String] relative path to the pack's tile manifest, usually "directory.json"
     # @!attribute [r] always_loaded
     #   @return [Boolean] whether this pack is unconditionally loaded
     # @!attribute [r] depends_on
     #   @return [Array<String>] names of packs this pack depends on
-    PackDefinition = Data.define(:source, :tile, :always_loaded, :depends_on) do
+    # @!attribute [r] ref
+    #   @return [String, nil] optional git ref (branch, tag, or SHA) to pin the pack version;
+    #     nil means use the default branch (HEAD)
+    PackDefinition = Data.define(:source, :tile, :always_loaded, :depends_on, :ref) do
       # @return [Boolean]
       def always_loaded? = always_loaded
     end

--- a/lib/rails_ai_bridge/registry/pack_resolver.rb
+++ b/lib/rails_ai_bridge/registry/pack_resolver.rb
@@ -102,7 +102,7 @@ module RailsAiBridge
           pack_def = manifest.packs[name]
           raise "Pack '#{name}' not defined in registry manifest" unless pack_def
 
-          base_path = @source_resolver.resolve(pack_def.source)
+          base_path = @source_resolver.resolve(pack_def.source, ref: pack_def.ref)
           tile_path = File.join(base_path, pack_def.tile)
 
           raise "Failed to read tile manifest for pack '#{name}' at #{tile_path}" unless File.exist?(tile_path)
@@ -132,7 +132,7 @@ module RailsAiBridge
         return loaded_packs unless local_registries
 
         local_registries.each_with_index do |path, i|
-          tile_path = File.join(path, 'tile.json')
+          tile_path = File.join(path, 'directory.json')
 
           raise "Failed to read local registry tile manifest at #{tile_path}" unless File.exist?(tile_path)
 
@@ -151,10 +151,13 @@ module RailsAiBridge
 
       # Computes priority for a pack based on its name.
       #
+      # Matching is case-insensitive. Only exact name matches qualify for
+      # high/medium priority — "rails-extras" gets PRIORITY_LOW.
+      #
       # @param name [String] pack name
       # @return [Integer] priority value (lower is higher priority)
       def compute_priority(name)
-        case name
+        case name.downcase
         when RAILS_PACK, HANAMI_PACK
           PRIORITY_HIGH
         when CORE_PACK

--- a/lib/rails_ai_bridge/registry/pack_resolver.rb
+++ b/lib/rails_ai_bridge/registry/pack_resolver.rb
@@ -90,7 +90,9 @@ module RailsAiBridge
       # Loads defined packs from the manifest.
       #
       # Resolves each pack via the source resolver, loads its tile manifest,
-      # and assigns priority based on pack name.
+      # and assigns priority based on pack name. Emits a warning when a pack
+      # lists a +depends_on+ entry that is not in the active set — transitive
+      # dependency loading is not yet implemented.
       #
       # @param manifest [RegistryManifest] the registry manifest
       # @param active_pack_names [Set<String>] set of pack names to load
@@ -100,15 +102,16 @@ module RailsAiBridge
 
         active_pack_names.each do |name|
           pack_def = manifest.packs[name]
-          raise "Pack '#{name}' not defined in registry manifest" unless pack_def
+          raise SkillSourceResolver::ResolutionError, "Pack '#{name}' not defined in registry manifest" unless pack_def
 
           base_path = @source_resolver.resolve(pack_def.source, ref: pack_def.ref)
           tile_path = File.join(base_path, pack_def.tile)
 
-          raise "Failed to read tile manifest for pack '#{name}' at #{tile_path}" unless File.exist?(tile_path)
+          raise SkillSourceResolver::ResolutionError, "Failed to read tile manifest for pack '#{name}' at #{tile_path}" unless File.exist?(tile_path)
 
           tile = TileManifest.from_file(tile_path)
           priority = compute_priority(name)
+          warn_missing_dependencies(name, pack_def.depends_on, active_pack_names)
 
           loaded_packs << LoadedPack.new(
             name: name,
@@ -131,15 +134,18 @@ module RailsAiBridge
       def load_local_registries(loaded_packs, local_registries)
         return loaded_packs unless local_registries
 
-        local_registries.each_with_index do |path, i|
+        local_registries.each do |path|
           tile_path = File.join(path, 'directory.json')
 
-          raise "Failed to read local registry tile manifest at #{tile_path}" unless File.exist?(tile_path)
+          raise SkillSourceResolver::ResolutionError, "Failed to read local registry tile manifest at #{tile_path}" unless File.exist?(tile_path)
 
           tile = TileManifest.from_file(tile_path)
+          # Derive a stable name from the path so renaming or reordering entries in
+          # local_registry_paths does not silently shift pack identities.
+          name = "local_#{Digest::SHA256.hexdigest(path)[0..7]}"
 
           loaded_packs << LoadedPack.new(
-            name: "local_#{i}",
+            name: name,
             tile: tile,
             base_path: path,
             priority: 0 # Highest priority
@@ -147,6 +153,26 @@ module RailsAiBridge
         end
 
         loaded_packs
+      end
+
+      # Warns when a pack declares dependencies that are not in the active set.
+      #
+      # Transitive dependency loading is not yet implemented. Packs that declare
+      # +depends_on+ will still load, but their dependencies must be explicitly
+      # included in the active set for skills to be available.
+      #
+      # @param name [String] the loading pack's name
+      # @param deps [Array<String>] dependency names declared by the pack
+      # @param active_names [Set<String>] currently active pack names
+      # @return [void]
+      def warn_missing_dependencies(name, deps, active_names)
+        missing = deps.reject { |dep| active_names.include?(dep) }
+        return if missing.empty?
+
+        warn "[rails-ai-bridge] Pack '#{name}' depends on #{missing.map { |d| "'#{d}'" }.join(', ')} " \
+             "which #{missing.one? ? 'is' : 'are'} not in the active pack set. " \
+             "Add #{missing.one? ? 'it' : 'them'} to skill_packs or always_loaded in your registry manifest. " \
+             '(Transitive dependency loading is not yet implemented.)'
       end
 
       # Computes priority for a pack based on its name.

--- a/lib/rails_ai_bridge/registry/pack_resolver.rb
+++ b/lib/rails_ai_bridge/registry/pack_resolver.rb
@@ -107,7 +107,10 @@ module RailsAiBridge
           base_path = @source_resolver.resolve(pack_def.source, ref: pack_def.ref)
           tile_path = File.join(base_path, pack_def.tile)
 
-          raise SkillSourceResolver::ResolutionError, "Failed to read tile manifest for pack '#{name}' at #{tile_path}" unless File.exist?(tile_path)
+          unless File.exist?(tile_path)
+            Rails.logger.debug { "[rails-ai-bridge] tile manifest missing for pack '#{name}' at #{tile_path}" }
+            raise SkillSourceResolver::ResolutionError, "Failed to read tile manifest for pack '#{name}'"
+          end
 
           tile = TileManifest.from_file(tile_path)
           priority = compute_priority(name)

--- a/lib/rails_ai_bridge/registry/pack_resolver.rb
+++ b/lib/rails_ai_bridge/registry/pack_resolver.rb
@@ -108,7 +108,7 @@ module RailsAiBridge
           tile_path = File.join(base_path, pack_def.tile)
 
           unless File.exist?(tile_path)
-            Rails.logger.debug { "[rails-ai-bridge] tile manifest missing for pack '#{name}' at #{tile_path}" }
+            Rails.logger&.debug { "[rails-ai-bridge] tile manifest missing for pack '#{name}' at #{tile_path}" }
             raise SkillSourceResolver::ResolutionError, "Failed to read tile manifest for pack '#{name}'"
           end
 

--- a/lib/rails_ai_bridge/registry/rake_presenter.rb
+++ b/lib/rails_ai_bridge/registry/rake_presenter.rb
@@ -13,6 +13,8 @@ module RailsAiBridge
     #   puts presenter.skills_table
     #   puts presenter.resolve_skill_output('code-review', requested_pack: 'rails')
     class RakePresenter
+      include Truncatable
+
       SKILL_NAME_COL  = 30
       PACK_NAME_COL   = 15
       DESC_MAX_LENGTH = 50
@@ -23,8 +25,11 @@ module RailsAiBridge
         Create the file and configure skill packs. See docs/skill-registry-guide.md for details.
       MSG
 
-      # @param resolver [Registry::Resolver, nil] a resolved registry (nil = not configured)
+      # @param resolver [Registry::Resolver] resolved registry
+      # @raise [ArgumentError] if resolver is nil
       def initialize(resolver)
+        raise ArgumentError, 'RakePresenter requires a resolver; got nil — check registry configuration' if resolver.nil?
+
         @resolver = resolver
       end
 
@@ -67,14 +72,6 @@ module RailsAiBridge
       # @return [String]
       def self.no_manifest_message(path)
         format(NO_MANIFEST_MESSAGE, path: path)
-      end
-
-      private
-
-      def truncate(text, max)
-        return text if text.length <= max
-
-        "#{text[0, max - 1]}…"
       end
     end
   end

--- a/lib/rails_ai_bridge/registry/rake_presenter.rb
+++ b/lib/rails_ai_bridge/registry/rake_presenter.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Registry
+    # Formats registry data for CLI output in rake tasks.
+    #
+    # Single responsibility: converts resolver data into human-readable stdout
+    # strings for rake tasks. Does not know about MCP, tools, or configuration.
+    # Rake tasks delegate all formatting here to stay DRY with each other.
+    #
+    # @example
+    #   presenter = RakePresenter.new(resolver)
+    #   puts presenter.skills_table
+    #   puts presenter.resolve_skill_output('code-review', requested_pack: 'rails')
+    class RakePresenter
+      SKILL_NAME_COL  = 30
+      PACK_NAME_COL   = 15
+      DESC_MAX_LENGTH = 50
+      TABLE_WIDTH     = 80
+
+      NO_MANIFEST_MESSAGE = <<~MSG
+        No registry manifest found at '%<path>s'.
+        Create the file and configure skill packs. See docs/skill-registry-guide.md for details.
+      MSG
+
+      # @param resolver [Registry::Resolver, nil] a resolved registry (nil = not configured)
+      def initialize(resolver)
+        @resolver = resolver
+      end
+
+      # @return [String] skills table for stdout, or an error/empty message
+      def skills_table
+        skills = @resolver.list_skills
+        return "No skills are loaded. Check your registry manifest configuration.\n" if skills.empty?
+
+        lines = ["Available Skills (#{skills.length})", '']
+        lines << "#{'Skill'.ljust(SKILL_NAME_COL)} #{'Pack'.ljust(PACK_NAME_COL)} Description"
+        lines << ('-' * TABLE_WIDTH)
+        skills.each do |skill|
+          desc = truncate(skill.description, DESC_MAX_LENGTH)
+          lines << "#{skill.name.ljust(SKILL_NAME_COL)} #{skill.pack.ljust(PACK_NAME_COL)} #{desc}"
+        end
+        lines.join("\n")
+      end
+
+      # @param name [String] skill name
+      # @param requested_pack [String, nil] optional pack the user asked for
+      # @return [String] multi-line output including content, or an error message
+      def resolve_skill_output(name, requested_pack: nil)
+        resolved = @resolver.resolve_skill(name)
+        return "Skill '#{name}' not found in any loaded pack.\nRun `rails ai:skills:list` to see available skills.\n" unless resolved
+
+        lines = []
+        warning = @resolver.check_deprecated(name)
+        lines << "WARNING: #{warning}" if warning
+
+        lines << "INFO: Skill '#{name}' resolved from pack '#{resolved.pack}' (requested pack: '#{requested_pack}')." if requested_pack && resolved.pack != requested_pack
+
+        lines << "# #{resolved.name} (from pack: #{resolved.pack})"
+        lines << "# Path: #{resolved.path}"
+        lines << ''
+        lines << resolved.content
+        lines.join("\n")
+      end
+
+      # @param path [String] manifest path that was not found
+      # @return [String]
+      def self.no_manifest_message(path)
+        format(NO_MANIFEST_MESSAGE, path: path)
+      end
+
+      private
+
+      def truncate(text, max)
+        return text if text.length <= max
+
+        "#{text[0, max - 1]}…"
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/registry/registry_manifest.rb
+++ b/lib/rails_ai_bridge/registry/registry_manifest.rb
@@ -19,9 +19,10 @@ module RailsAiBridge
         packs = (hash['packs'] || {}).transform_values do |pack_hash|
           PackDefinition.new(
             source: pack_hash.fetch('source'),
-            tile: pack_hash.fetch('tile'),
+            tile: pack_hash.fetch('tile', 'directory.json'),
             always_loaded: pack_hash.fetch('always_loaded', false),
-            depends_on: pack_hash.fetch('depends_on', [])
+            depends_on: pack_hash.fetch('depends_on', []),
+            ref: pack_hash.fetch('ref', nil)
           )
         end
 

--- a/lib/rails_ai_bridge/registry/registry_manifest.rb
+++ b/lib/rails_ai_bridge/registry/registry_manifest.rb
@@ -37,11 +37,13 @@ module RailsAiBridge
       #
       # @param path [String] absolute or relative path to the registry JSON file
       # @return [RegistryManifest]
-      # @raise [ArgumentError] if the file does not exist
+      # @raise [ArgumentError] if the file does not exist or contains malformed JSON
       def self.from_file(path)
         raise ArgumentError, "Registry manifest not found at: #{path}" unless File.exist?(path)
 
         from_json(JSON.parse(File.read(path)))
+      rescue JSON::ParserError => error
+        raise ArgumentError, "Registry manifest at '#{path}' contains invalid JSON: #{error.message}"
       end
     end
   end

--- a/lib/rails_ai_bridge/registry/registry_manifest.rb
+++ b/lib/rails_ai_bridge/registry/registry_manifest.rb
@@ -44,6 +44,8 @@ module RailsAiBridge
         from_json(JSON.parse(File.read(path)))
       rescue JSON::ParserError => error
         raise ArgumentError, "Registry manifest at '#{path}' contains invalid JSON: #{error.message}"
+      rescue SystemCallError => error
+        raise ArgumentError, "Registry manifest at '#{path}' could not be read: #{error.message}"
       end
     end
   end

--- a/lib/rails_ai_bridge/registry/resolver.rb
+++ b/lib/rails_ai_bridge/registry/resolver.rb
@@ -77,7 +77,12 @@ module RailsAiBridge
           file_path = File.join(pack.base_path, entry.path)
           next unless descendant?(pack.base_path, file_path)
 
-          content = File.read(file_path)
+          begin
+            content = File.read(file_path)
+          rescue SystemCallError
+            next
+          end
+
           return ResolvedSkill.new(
             name: target_name,
             pack: pack.name,
@@ -101,7 +106,12 @@ module RailsAiBridge
           file_path = File.join(pack.base_path, entry.path)
           next unless descendant?(pack.base_path, file_path)
 
-          content = File.read(file_path)
+          begin
+            content = File.read(file_path)
+          rescue SystemCallError
+            next
+          end
+
           return ResolvedSkill.new(
             name: name,
             pack: pack.name,

--- a/lib/rails_ai_bridge/registry/resolver_cache.rb
+++ b/lib/rails_ai_bridge/registry/resolver_cache.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Registry
+    # Thread-safe resolver cache with configurable TTL.
+    #
+    # Single responsibility: holds one resolved +Resolver+ and tracks its age.
+    # Callers call {#fetch} with a build block; the cache returns the warm
+    # resolver when the TTL has not expired, or calls the block to rebuild.
+    #
+    # A nil result from the block (manifest missing) is never cached so the
+    # next call will try again — useful during initial setup.
+    #
+    # @example
+    #   cache = ResolverCache.new
+    #   resolver = cache.fetch(config) { Registry.build_resolver_uncached(config) }
+    class ResolverCache
+      # @param monotonic_clock [#call] injectable clock for testing; defaults to Process.clock_gettime
+      def initialize(monotonic_clock: method(:default_clock))
+        @mutex   = Mutex.new
+        @clock   = monotonic_clock
+        @entry   = nil
+        @built_at = nil
+      end
+
+      # Return a warm cached resolver or build a new one.
+      #
+      # @param config [Config::Registry] current registry configuration
+      # @yieldreturn [Registry::Resolver, nil] freshly built resolver, or nil if manifest is missing
+      # @return [Registry::Resolver, nil]
+      def fetch(config, &build_block)
+        @mutex.synchronize do
+          if @entry && !expired?(config)
+            @entry
+          else
+            result = build_block.call
+            if result
+              @entry    = result
+              @built_at = @clock.call
+            end
+            result
+          end
+        end
+      end
+
+      # Discard the cached resolver; the next {#fetch} call will rebuild.
+      # @return [void]
+      def invalidate!
+        @mutex.synchronize do
+          @entry    = nil
+          @built_at = nil
+        end
+      end
+
+      private
+
+      def expired?(config)
+        return true unless @built_at
+
+        age = @clock.call - @built_at
+        age >= config.resolver_ttl
+      end
+
+      def default_clock
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/registry/skill_source_resolver.rb
+++ b/lib/rails_ai_bridge/registry/skill_source_resolver.rb
@@ -65,7 +65,7 @@ module RailsAiBridge
       def clone_repo(url, dest)
         with_timeout('git clone') do
           _stdout, stderr, status = Open3.capture3('git', 'clone', url, dest)
-          raise "git clone failed: #{stderr}" unless status.success?
+          fail_with_sanitized_error!('git clone', stderr) unless status.success?
         end
       end
 
@@ -77,7 +77,7 @@ module RailsAiBridge
       def pull_repo(path)
         with_timeout('git pull') do
           _stdout, stderr, status = Open3.capture3('git', 'pull', chdir: path)
-          raise "git pull failed: #{stderr}" unless status.success?
+          fail_with_sanitized_error!('git pull', stderr) unless status.success?
         end
       end
 
@@ -90,7 +90,7 @@ module RailsAiBridge
       def checkout_ref(path, ref)
         with_timeout('git checkout') do
           _stdout, stderr, status = Open3.capture3('git', 'checkout', ref, chdir: path)
-          raise "git checkout failed: #{stderr}" unless status.success?
+          fail_with_sanitized_error!('git checkout', stderr) unless status.success?
         end
       end
 
@@ -100,6 +100,22 @@ module RailsAiBridge
         Timeout.timeout(@timeout, &)
       rescue Timeout::Error
         raise "#{label} timed out after #{@timeout}s"
+      end
+
+      # Logs the full stderr output at debug level (for diagnostics) and raises a
+      # generic, credential-safe error message.
+      #
+      # Git stderr may contain credential information embedded in remote URLs
+      # (e.g. https://token@github.com/...) and should never be surfaced in
+      # user-facing exception messages.
+      #
+      # @param label [String] human-readable command label (e.g. "git clone")
+      # @param stderr [String] raw stderr output from the git subprocess
+      # @raise [RuntimeError] always
+      def fail_with_sanitized_error!(label, stderr)
+        sanitized = stderr.to_s.gsub(%r{(?<=://)([^@/]+@)}, '[REDACTED]@').strip.truncate(200)
+        Rails.logger.debug { "[rails-ai-bridge] #{label} failed — #{sanitized}" }
+        raise "#{label} failed"
       end
     end
 

--- a/lib/rails_ai_bridge/registry/skill_source_resolver.rb
+++ b/lib/rails_ai_bridge/registry/skill_source_resolver.rb
@@ -142,7 +142,7 @@ module RailsAiBridge
         @cache_dir = validate_cache_dir(cache_dir)
         @git_runner = git_runner
         @pull_ttl = pull_ttl
-        @last_pulled = {} # cache_path => Time — in-memory freshness tracking
+        @last_pulled = {} # cache_path => Float (monotonic seconds) — in-memory freshness tracking
         @pull_mutex = Mutex.new
       end
 
@@ -224,13 +224,13 @@ module RailsAiBridge
 
         @pull_mutex.synchronize do
           last = @last_pulled[cache_path]
-          last.nil? || (Time.zone.now - last) >= @pull_ttl
+          last.nil? || (Process.clock_gettime(Process::CLOCK_MONOTONIC) - last) >= @pull_ttl
         end
       end
 
       # Records the time of a successful pull for +cache_path+. Thread-safe.
       def record_pull(cache_path)
-        @pull_mutex.synchronize { @last_pulled[cache_path] = Time.zone.now }
+        @pull_mutex.synchronize { @last_pulled[cache_path] = Process.clock_gettime(Process::CLOCK_MONOTONIC) }
       end
 
       # Validates +cache_dir+ by checking that the path does not contain traversal

--- a/lib/rails_ai_bridge/registry/skill_source_resolver.rb
+++ b/lib/rails_ai_bridge/registry/skill_source_resolver.rb
@@ -110,25 +110,31 @@ module RailsAiBridge
         "#{sanitized}_#{hash}"
       end
 
-      # Resolves a remote source to a local path.
+      # Resolves a source to a local path.
       #
-      # Clones the repository if not cached, or runs git pull if it already exists.
+      # Delegates format detection to {SourceParser}. Local paths are returned
+      # immediately without any git operations. For git sources, the repository
+      # is cloned if not cached, or pulled if it already exists.
       #
-      # @param source [String] source string (e.g., 'igmarin/ruby-core-skills')
-      # @return [String] local path to the cached repository
+      # @param source [String] source string — local path, git URL, or owner/repo shorthand
+      # @param ref [String, nil] optional git ref (branch, tag, or SHA) to check out after
+      #   cloning or pulling; nil means the default branch
+      # @return [String] local path to the resolved directory
       # @raise [ResolutionError] if git operations fail or source format is invalid
-      # :reek:TooManyStatements -- Necessary complexity for validation, cache lookup, and git operations
-      def resolve(source)
-        validate_source_format(source)
-        cache_key = self.class.compute_cache_key(source)
+      def resolve(source, ref: nil)
+        parsed = SourceParser.parse(source)
+        return parsed.resolved_url if parsed.type == :local_path
+
+        cache_key  = self.class.compute_cache_key(source)
         cache_path = File.join(@cache_dir, cache_key)
 
         if File.exist?(cache_path)
           perform_pull(source, cache_path)
         else
-          perform_clone(source, cache_path)
+          perform_clone(source, cache_path, parsed.resolved_url)
         end
 
+        checkout_ref(source, cache_path, ref) if ref
         cache_path
       end
 
@@ -141,12 +147,6 @@ module RailsAiBridge
         cache_dir
       end
 
-      def validate_source_format(source)
-        return if source.match?(%r{\A[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+\z})
-
-        raise ResolutionError, "Invalid source format: #{source}. Expected 'owner/repo' format"
-      end
-
       def perform_pull(source, cache_path)
         @git_runner.pull_repo(cache_path)
       rescue StandardError => error
@@ -154,14 +154,19 @@ module RailsAiBridge
       end
 
       # :reek:TooManyStatements -- Necessary complexity for git clone setup, execution, and error handling
-      def perform_clone(source, cache_path)
+      def perform_clone(source, cache_path, clone_url)
         FileUtils.mkdir_p(@cache_dir)
-        clone_url = "https://github.com/#{source}.git"
-
         @git_runner.clone_repo(clone_url, cache_path)
       rescue StandardError => error
         FileUtils.rm_rf(cache_path)
         raise ResolutionError, "git clone failed for pack: #{source}: #{error.message}"
+      end
+
+      def checkout_ref(source, cache_path, ref)
+        _stdout, stderr, status = Open3.capture3('git', 'checkout', ref, chdir: cache_path)
+        return if status.success?
+
+        raise ResolutionError, "git checkout #{ref} failed for pack: #{source}: #{stderr}"
       end
     end
   end

--- a/lib/rails_ai_bridge/registry/skill_source_resolver.rb
+++ b/lib/rails_ai_bridge/registry/skill_source_resolver.rb
@@ -29,44 +29,85 @@ module RailsAiBridge
       def pull_repo(_path)
         raise NotImplementedError
       end
+
+      # Checks out a specific git ref inside a local repository directory.
+      #
+      # @param _path [String] path to the local repository
+      # @param _ref [String] branch, tag, or commit SHA to check out
+      # @raise [StandardError] if git checkout fails
+      # @return [void]
+      def checkout_ref(_path, _ref)
+        raise NotImplementedError
+      end
     end
 
     # Default implementation of {GitRunner} using Open3 to spawn git subprocesses.
     #
     # This is the production implementation used for actual git operations.
+    # All git commands are wrapped in a +Timeout::timeout+ block so a slow or
+    # unreachable remote cannot block the calling thread indefinitely.
     class DefaultGitRunner
       include GitRunner
+
+      # @param timeout [Integer] seconds before a git operation is forcibly interrupted
+      attr_reader :timeout
+
+      def initialize(timeout: 30)
+        @timeout = timeout
+      end
 
       # Clones a remote repository to a local directory path.
       #
       # @param url [String] git repository URL
       # @param dest [String] destination directory path
-      # @raise [RuntimeError] if git clone command fails or returns non-zero exit code
+      # @raise [RuntimeError] if git clone command fails, returns non-zero, or times out
       # @return [void]
       def clone_repo(url, dest)
-        _stdout, stderr, status = Open3.capture3('git', 'clone', url, dest)
-        return if status.success?
-
-        raise "git clone failed: #{stderr}"
+        with_timeout('git clone') do
+          _stdout, stderr, status = Open3.capture3('git', 'clone', url, dest)
+          raise "git clone failed: #{stderr}" unless status.success?
+        end
       end
 
       # Pulls latest changes inside a local repository directory.
       #
       # @param path [String] path to the local repository
-      # @raise [RuntimeError] if git pull command fails or returns non-zero exit code
+      # @raise [RuntimeError] if git pull command fails, returns non-zero, or times out
       # @return [void]
       def pull_repo(path)
-        _stdout, stderr, status = Open3.capture3('git', 'pull', chdir: path)
-        return if status.success?
+        with_timeout('git pull') do
+          _stdout, stderr, status = Open3.capture3('git', 'pull', chdir: path)
+          raise "git pull failed: #{stderr}" unless status.success?
+        end
+      end
 
-        raise "git pull failed: #{stderr}"
+      # Checks out a specific git ref inside a local repository directory.
+      #
+      # @param path [String] path to the local repository
+      # @param ref [String] branch, tag, or commit SHA to check out
+      # @raise [RuntimeError] if git checkout command fails, returns non-zero, or times out
+      # @return [void]
+      def checkout_ref(path, ref)
+        with_timeout('git checkout') do
+          _stdout, stderr, status = Open3.capture3('git', 'checkout', ref, chdir: path)
+          raise "git checkout failed: #{stderr}" unless status.success?
+        end
+      end
+
+      private
+
+      def with_timeout(label, &)
+        Timeout.timeout(@timeout, &)
+      rescue Timeout::Error
+        raise "#{label} timed out after #{@timeout}s"
       end
     end
 
     # Resolves remote git skill pack sources by cloning or pulling them into a local cache directory.
     #
     # Manages a cache of git repositories based on source strings, computing a unique cache key
-    # for each source. If the repository is not cached, it clones it; if cached, it pulls updates.
+    # for each source. If the repository is not cached, it clones it; if already cached and the
+    # pull TTL window has elapsed, it pulls updates. Otherwise the cached copy is used as-is.
     #
     # @example
     #   resolver = SkillSourceResolver.new('/tmp/cache', DefaultGitRunner.new)
@@ -79,10 +120,14 @@ module RailsAiBridge
       #
       # @param cache_dir [String] path to the cache directory
       # @param git_runner [GitRunner] git runner implementation (defaults to DefaultGitRunner)
-      # @raise [ArgumentError] if cache_dir contains path traversal components
-      def initialize(cache_dir, git_runner = DefaultGitRunner.new)
+      # @param pull_ttl [Integer] seconds between git pull refreshes per cached pack (default: 86400 = 24 h).
+      #   Set to 0 to always pull on every resolve call.
+      def initialize(cache_dir, git_runner = DefaultGitRunner.new, pull_ttl: 86_400)
         @cache_dir = validate_cache_dir(cache_dir)
         @git_runner = git_runner
+        @pull_ttl = pull_ttl
+        @last_pulled = {} # cache_path => Time — in-memory freshness tracking
+        @pull_mutex = Mutex.new
       end
 
       # Resolves the default cache directory, checking RAILS_AI_BRIDGE_CACHE_DIR then HOME.
@@ -97,49 +142,86 @@ module RailsAiBridge
         File.join(home, '.rails-ai-bridge', 'cache')
       end
 
-      # Computes a cache key for a given source string.
+      # Computes a cache key for a given source string and optional ref.
       #
-      # Sanitizes non-alphanumeric characters to underscores and appends a hash suffix
-      # to ensure uniqueness and prevent collisions.
+      # When a ref is provided the key includes it so that different refs for the
+      # same source produce isolated cache directories, preventing cross-ref
+      # contamination. Sanitizes non-alphanumeric characters to underscores and
+      # appends a SHA256 hash suffix to ensure uniqueness.
       #
       # @param source [String] source string (e.g., 'igmarin/ruby-core-skills')
-      # @return [String] cache key (e.g., 'igmarin_ruby-core-skills_a1b2c3d4')
-      def self.compute_cache_key(source)
-        sanitized = source.gsub(/[^a-zA-Z0-9]/, '_')
-        hash = Digest::SHA256.hexdigest(source)[0..15]
+      # @param ref [String, nil] git ref or nil for the default branch
+      # @return [String] cache key (e.g., 'igmarin_ruby_core_skills_a1b2c3d4')
+      def self.compute_cache_key(source, ref = nil)
+        identity  = ref ? "#{source}@#{ref}" : source
+        sanitized = identity.gsub(/[^a-zA-Z0-9]/, '_')
+        hash = Digest::SHA256.hexdigest(identity)[0..15]
         "#{sanitized}_#{hash}"
       end
 
       # Resolves a source to a local path.
       #
       # Delegates format detection to {SourceParser}. Local paths are returned
-      # immediately without any git operations. For git sources, the repository
-      # is cloned if not cached, or pulled if it already exists.
+      # immediately without any git operations. For git sources:
+      #
+      # * When +ref+ is nil (floating branch), a pull is attempted if the pack's
+      #   TTL window has elapsed, keeping the default branch up-to-date.
+      # * When +ref+ is set (pinned tag, SHA, or named branch), the pull is
+      #   skipped entirely. A pinned ref is deterministic — there is no reason to
+      #   pull, and doing so on a detached HEAD (after checkout) fails with
+      #   "You are not currently on a branch".
+      #
+      # Each (source, ref) pair gets its own cache directory so a repo checked out
+      # at two different refs coexists without interference.
       #
       # @param source [String] source string — local path, git URL, or owner/repo shorthand
       # @param ref [String, nil] optional git ref (branch, tag, or SHA) to check out after
-      #   cloning or pulling; nil means the default branch
+      #   cloning; nil means the default branch
       # @return [String] local path to the resolved directory
       # @raise [ResolutionError] if git operations fail or source format is invalid
       def resolve(source, ref: nil)
         parsed = SourceParser.parse(source)
         return parsed.resolved_url if parsed.type == :local_path
 
-        cache_key  = self.class.compute_cache_key(source)
+        cache_key  = self.class.compute_cache_key(source, ref)
         cache_path = File.join(@cache_dir, cache_key)
 
         if File.exist?(cache_path)
-          perform_pull(source, cache_path)
+          # Only pull when no ref is pinned. A pinned ref is deterministic and
+          # a previous checkout may have left the repo in detached HEAD, which
+          # causes git pull to fail with "not currently on a branch".
+          perform_pull(source, cache_path) if ref.nil? && pull_stale?(cache_path)
         else
           perform_clone(source, cache_path, parsed.resolved_url)
         end
 
-        checkout_ref(source, cache_path, ref) if ref
+        perform_checkout_ref(source, cache_path, ref) if ref
         cache_path
       end
 
       private
 
+      # Returns true when no successful pull has been recorded for +cache_path+ within
+      # the configured pull TTL window. Thread-safe.
+      def pull_stale?(cache_path)
+        return true if @pull_ttl.zero?
+
+        @pull_mutex.synchronize do
+          last = @last_pulled[cache_path]
+          last.nil? || (Time.zone.now - last) >= @pull_ttl
+        end
+      end
+
+      # Records the time of a successful pull for +cache_path+. Thread-safe.
+      def record_pull(cache_path)
+        @pull_mutex.synchronize { @last_pulled[cache_path] = Time.zone.now }
+      end
+
+      # Validates +cache_dir+ by checking that the path does not contain traversal
+      # sequences. Uses lexical normalisation only — symlinks are not resolved here
+      # because the directory may not exist yet. The security guarantee is that the
+      # cache key appended to this dir is SHA-256-derived and not attacker-controlled,
+      # so even if cache_dir itself resolves unexpectedly, written paths remain safe.
       def validate_cache_dir(cache_dir)
         clean_path = Pathname.new(cache_dir).cleanpath.to_s
         raise ArgumentError, "Cache directory contains path traversal components: #{cache_dir}" if clean_path != cache_dir
@@ -149,6 +231,7 @@ module RailsAiBridge
 
       def perform_pull(source, cache_path)
         @git_runner.pull_repo(cache_path)
+        record_pull(cache_path)
       rescue StandardError => error
         raise ResolutionError, "git pull failed for pack: #{source}: #{error.message}"
       end
@@ -157,16 +240,16 @@ module RailsAiBridge
       def perform_clone(source, cache_path, clone_url)
         FileUtils.mkdir_p(@cache_dir)
         @git_runner.clone_repo(clone_url, cache_path)
+        record_pull(cache_path)
       rescue StandardError => error
         FileUtils.rm_rf(cache_path)
         raise ResolutionError, "git clone failed for pack: #{source}: #{error.message}"
       end
 
-      def checkout_ref(source, cache_path, ref)
-        _stdout, stderr, status = Open3.capture3('git', 'checkout', ref, chdir: cache_path)
-        return if status.success?
-
-        raise ResolutionError, "git checkout #{ref} failed for pack: #{source}: #{stderr}"
+      def perform_checkout_ref(source, cache_path, ref)
+        @git_runner.checkout_ref(cache_path, ref)
+      rescue StandardError => error
+        raise ResolutionError, "git checkout #{ref} failed for pack: #{source}: #{error.message}"
       end
     end
   end

--- a/lib/rails_ai_bridge/registry/skill_source_resolver.rb
+++ b/lib/rails_ai_bridge/registry/skill_source_resolver.rb
@@ -114,7 +114,7 @@ module RailsAiBridge
       # @raise [RuntimeError] always
       def fail_with_sanitized_error!(label, stderr)
         sanitized = stderr.to_s.gsub(%r{(?<=://)([^@/]+@)}, '[REDACTED]@').strip.truncate(200)
-        Rails.logger.debug { "[rails-ai-bridge] #{label} failed — #{sanitized}" }
+        Rails.logger&.debug { "[rails-ai-bridge] #{label} failed — #{sanitized}" }
         raise "#{label} failed"
       end
     end

--- a/lib/rails_ai_bridge/registry/source_parser.rb
+++ b/lib/rails_ai_bridge/registry/source_parser.rb
@@ -11,7 +11,8 @@ module RailsAiBridge
     # Supported formats:
     #
     # * **Local path** — starts with +/+, +./+, or +../+. Returned as-is; no git needed.
-    # * **Full git URL** — starts with +https://+ or +git@+. Used directly as the clone URL.
+    # * **Full git URL** — starts with +https://+ or +git@+ (SSH). Plain +http://+ is rejected
+    #   to prevent unencrypted transmission of credentials and pack content. Used directly as the clone URL.
     # * **GitHub shorthand** — exactly +owner/repo+. Expanded to +https://github.com/owner/repo.git+.
     #
     # @example Local absolute path
@@ -34,8 +35,11 @@ module RailsAiBridge
 
         Valid formats:
           Local path    /absolute/path  OR  ./relative  OR  ../relative
-          HTTPS/SSH URL https://github.com/owner/repo.git  OR  git@github.com:owner/repo.git
+          HTTPS URL     https://github.com/owner/repo.git
+          SSH URL       git@github.com:owner/repo.git
           GitHub short  owner/repo  (expanded to https://github.com/owner/repo.git)
+
+        Note: plain http:// URLs are not supported — use https:// or git@ (SSH) instead.
       MSG
 
       # @param source [String] raw source string from the registry manifest
@@ -56,8 +60,10 @@ module RailsAiBridge
       private_class_method :local_path?
 
       # @api private
+      # Only HTTPS and SSH (git@) URLs are accepted. Plain HTTP is rejected because
+      # cloning over unencrypted HTTP exposes credentials and pack content in transit.
       def self.git_url?(source)
-        source.start_with?('https://', 'http://', 'git@')
+        source.start_with?('https://', 'git@')
       end
       private_class_method :git_url?
 

--- a/lib/rails_ai_bridge/registry/source_parser.rb
+++ b/lib/rails_ai_bridge/registry/source_parser.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Registry
+    # Parses a raw pack source string and returns a typed {ParsedSource} value object.
+    #
+    # Single responsibility: classify a source string into one of three formats and
+    # produce the canonical URL needed to resolve it. Raises {SkillSourceResolver::ResolutionError}
+    # for unrecognized formats so callers get a clear error message naming all valid forms.
+    #
+    # Supported formats:
+    #
+    # * **Local path** — starts with +/+, +./+, or +../+. Returned as-is; no git needed.
+    # * **Full git URL** — starts with +https://+ or +git@+. Used directly as the clone URL.
+    # * **GitHub shorthand** — exactly +owner/repo+. Expanded to +https://github.com/owner/repo.git+.
+    #
+    # @example Local absolute path
+    #   SourceParser.parse('/my/skills') #=> #<ParsedSource type=:local_path resolved_url="/my/skills">
+    # @example Full URL
+    #   SourceParser.parse('https://github.com/org/repo.git') #=> #<ParsedSource type=:git_url ...>
+    # @example GitHub shorthand
+    #   SourceParser.parse('igmarin/ruby-core-skills') #=> #<ParsedSource type=:github_shorthand ...>
+    module SourceParser
+      # Immutable value object produced by {SourceParser.parse}.
+      #
+      # @!attribute [r] type
+      #   @return [Symbol] +:local_path+, +:git_url+, or +:github_shorthand+
+      # @!attribute [r] resolved_url
+      #   @return [String] canonical URL/path suitable for git clone or direct use
+      ParsedSource = Data.define(:type, :resolved_url)
+
+      INVALID_SOURCE_MESSAGE = <<~MSG
+        Invalid source format: %<source>s
+
+        Valid formats:
+          Local path    /absolute/path  OR  ./relative  OR  ../relative
+          HTTPS/SSH URL https://github.com/owner/repo.git  OR  git@github.com:owner/repo.git
+          GitHub short  owner/repo  (expanded to https://github.com/owner/repo.git)
+      MSG
+
+      # @param source [String] raw source string from the registry manifest
+      # @return [ParsedSource]
+      # @raise [SkillSourceResolver::ResolutionError] for unrecognized formats
+      def self.parse(source)
+        return parse_local(source)     if local_path?(source)
+        return parse_git_url(source)   if git_url?(source)
+        return parse_shorthand(source) if github_shorthand?(source)
+
+        raise SkillSourceResolver::ResolutionError, format(INVALID_SOURCE_MESSAGE, source: source)
+      end
+
+      # @api private
+      def self.local_path?(source)
+        source.start_with?('/', './', '../')
+      end
+      private_class_method :local_path?
+
+      # @api private
+      def self.git_url?(source)
+        source.start_with?('https://', 'http://', 'git@')
+      end
+      private_class_method :git_url?
+
+      # @api private
+      def self.github_shorthand?(source)
+        # Exactly one slash, both segments non-empty, no extra path components
+        source.match?(%r{\A[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+\z})
+      end
+      private_class_method :github_shorthand?
+
+      # @api private
+      def self.parse_local(source)
+        ParsedSource.new(type: :local_path, resolved_url: source)
+      end
+      private_class_method :parse_local
+
+      # @api private
+      def self.parse_git_url(source)
+        ParsedSource.new(type: :git_url, resolved_url: source)
+      end
+      private_class_method :parse_git_url
+
+      # @api private
+      def self.parse_shorthand(source)
+        expanded = "https://github.com/#{source}.git"
+        ParsedSource.new(type: :github_shorthand, resolved_url: expanded)
+      end
+      private_class_method :parse_shorthand
+    end
+  end
+end

--- a/lib/rails_ai_bridge/registry/tile_manifest.rb
+++ b/lib/rails_ai_bridge/registry/tile_manifest.rb
@@ -73,11 +73,13 @@ module RailsAiBridge
       #
       # @param path [String] path to the tile JSON file
       # @return [TileManifest]
-      # @raise [ArgumentError] if the file does not exist
+      # @raise [ArgumentError] if the file does not exist or contains malformed JSON
       def self.from_file(path)
         raise ArgumentError, "Tile manifest not found at: #{path}" unless File.exist?(path)
 
         from_json(JSON.parse(File.read(path)))
+      rescue JSON::ParserError => error
+        raise ArgumentError, "Tile manifest at '#{path}' contains invalid JSON: #{error.message}"
       end
 
       # @api private

--- a/lib/rails_ai_bridge/registry/tile_manifest.rb
+++ b/lib/rails_ai_bridge/registry/tile_manifest.rb
@@ -80,6 +80,8 @@ module RailsAiBridge
         from_json(JSON.parse(File.read(path)))
       rescue JSON::ParserError => error
         raise ArgumentError, "Tile manifest at '#{path}' contains invalid JSON: #{error.message}"
+      rescue SystemCallError => error
+        raise ArgumentError, "Tile manifest at '#{path}' could not be read: #{error.message}"
       end
 
       # @api private

--- a/lib/rails_ai_bridge/registry/truncatable.rb
+++ b/lib/rails_ai_bridge/registry/truncatable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Registry
+    # Shared mixin for truncating text to a maximum byte length with a Unicode ellipsis.
+    #
+    # @example
+    #   include Truncatable
+    #   truncate('A very long description here', 20) #=> "A very long descript…"
+    module Truncatable
+      # Truncates +text+ to at most +max+ characters, appending +…+ when truncated.
+      #
+      # @param text [String] the text to truncate
+      # @param max [Integer] maximum number of characters (including the ellipsis)
+      # @return [String] original text when short enough, or truncated form
+      def truncate(text, max)
+        return text if text.length <= max
+
+        "#{text[0, max - 1]}…"
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/server.rb
+++ b/lib/rails_ai_bridge/server.rb
@@ -36,7 +36,8 @@ module RailsAiBridge
       Tools::GetConfig,
       Tools::GetTestInfo,
       Tools::GetView,
-      Tools::GetStimulus
+      Tools::GetStimulus,
+      Tools::ListRegistry
     ].freeze
 
     # Initialize a new MCP server instance.

--- a/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
+++ b/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 unless defined?(ASSISTANT_TABLE)
   ASSISTANT_TABLE = <<~TABLE
     AI Assistant       Bridge File                           Command
@@ -323,7 +325,18 @@ namespace :ai do
     task clear_cache: :environment do
       require 'rails_ai_bridge'
 
-      cache_dir = RailsAiBridge.configuration.registry.skill_cache_dir
+      cache_dir = File.expand_path(RailsAiBridge.configuration.registry.skill_cache_dir.to_s)
+
+      abort 'Refusing to clear cache: skill_cache_dir is empty' if cache_dir.empty?
+
+      # Guard against misconfigured paths that could delete unrelated directories.
+      dangerous_roots = [
+        File.expand_path('/'),
+        File.expand_path('.'),
+        File.expand_path(Dir.home)
+      ].map { |p| p.chomp('/') }
+
+      abort "Refusing to clear cache from unsafe path: #{cache_dir}" if dangerous_roots.include?(cache_dir.chomp('/'))
 
       unless Dir.exist?(cache_dir)
         puts "Cache directory does not exist: #{cache_dir}"

--- a/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
+++ b/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
@@ -276,3 +276,66 @@ namespace :ai do
     end
   end
 end
+
+namespace :ai do
+  namespace :skills do
+    desc 'List all available skills from configured skill packs'
+    task list: :environment do
+      require 'rails_ai_bridge'
+
+      resolver = RailsAiBridge::Registry.build_resolver
+      unless resolver
+        path = RailsAiBridge.configuration.registry.registry_manifest_path
+        warn RailsAiBridge::Registry::RakePresenter.no_manifest_message(path)
+        exit 1
+      end
+
+      puts RailsAiBridge::Registry::RakePresenter.new(resolver).skills_table
+    end
+
+    desc 'Resolve and print a skill by name (usage: rails "ai:skills:resolve[pack_name,skill_name]")'
+    task :resolve, %i[pack name] => :environment do |_t, args|
+      require 'rails_ai_bridge'
+
+      pack_arg = args[:pack] || ENV.fetch('PACK', nil)
+      name_arg = args[:name] || ENV.fetch('SKILL', nil)
+
+      unless name_arg
+        warn 'Usage: rails "ai:skills:resolve[pack_name,skill_name]"'
+        warn 'Example: rails "ai:skills:resolve[rails,code-review]"'
+        exit 1
+      end
+
+      resolver = RailsAiBridge::Registry.build_resolver
+      unless resolver
+        path = RailsAiBridge.configuration.registry.registry_manifest_path
+        warn RailsAiBridge::Registry::RakePresenter.no_manifest_message(path)
+        exit 1
+      end
+
+      output = RailsAiBridge::Registry::RakePresenter.new(resolver)
+                                                     .resolve_skill_output(name_arg, requested_pack: pack_arg)
+      puts output
+      exit 1 if output.start_with?("Skill '#{name_arg}' not found")
+    end
+
+    desc 'Clear the local skill pack git cache'
+    task clear_cache: :environment do
+      require 'rails_ai_bridge'
+
+      cache_dir = RailsAiBridge.configuration.registry.skill_cache_dir
+
+      unless Dir.exist?(cache_dir)
+        puts "Cache directory does not exist: #{cache_dir}"
+        exit 0
+      end
+
+      packs = Dir.children(cache_dir).select { |entry| File.directory?(File.join(cache_dir, entry)) }
+      packs.each { |entry| FileUtils.rm_rf(File.join(cache_dir, entry)) }
+
+      RailsAiBridge::Registry.invalidate_resolver_cache!
+
+      puts "Cleared #{packs.length} cached pack(s) from #{cache_dir}"
+    end
+  end
+end

--- a/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
+++ b/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
@@ -325,23 +325,36 @@ namespace :ai do
     task clear_cache: :environment do
       require 'rails_ai_bridge'
 
-      cache_dir = File.expand_path(RailsAiBridge.configuration.registry.skill_cache_dir.to_s)
+      raw_dir = RailsAiBridge.configuration.registry.skill_cache_dir.to_s
 
-      abort 'Refusing to clear cache: skill_cache_dir is empty' if cache_dir.empty?
+      abort 'Refusing to clear cache: skill_cache_dir is empty' if raw_dir.strip.empty?
 
-      # Guard against misconfigured paths that could delete unrelated directories.
+      # Resolve the configured path first with expand_path (handles ~ and relative paths),
+      # then abort early if the directory does not exist (realpath would raise).
+      expanded = File.expand_path(raw_dir)
+
+      unless Dir.exist?(expanded)
+        puts "Cache directory does not exist: #{expanded}"
+        exit 0
+      end
+
+      # Use realpath to canonicalize the path and follow any symlinks before
+      # checking dangerous roots — this prevents a symlink pointing to / or $HOME
+      # from bypassing the safety guard.
+      begin
+        cache_dir = File.realpath(expanded)
+      rescue Errno::ENOENT
+        abort "Refusing to clear cache: configured path no longer exists: #{expanded}"
+      end
+
+      # Guard against misconfigured or symlinked paths that could delete unrelated directories.
       dangerous_roots = [
-        File.expand_path('/'),
-        File.expand_path('.'),
-        File.expand_path(Dir.home)
+        File.realpath('/'),
+        File.realpath(Dir.pwd),
+        File.realpath(Dir.home)
       ].map { |p| p.chomp('/') }
 
       abort "Refusing to clear cache from unsafe path: #{cache_dir}" if dangerous_roots.include?(cache_dir.chomp('/'))
-
-      unless Dir.exist?(cache_dir)
-        puts "Cache directory does not exist: #{cache_dir}"
-        exit 0
-      end
 
       packs = Dir.children(cache_dir).select { |entry| File.directory?(File.join(cache_dir, entry)) }
       packs.each { |entry| FileUtils.rm_rf(File.join(cache_dir, entry)) }

--- a/lib/rails_ai_bridge/tools/list_registry.rb
+++ b/lib/rails_ai_bridge/tools/list_registry.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Tools
+    # MCP tool for querying the skill pack registry catalog.
+    #
+    # A single entry point replacing the previous +rails_list_skills+,
+    # +rails_list_agents+, and +rails_list_packs+ tools. The required +type+
+    # parameter routes to the appropriate catalog view:
+    #
+    # - <tt>type: "skills"</tt>   — all available skills across loaded packs
+    # - <tt>type: "agents"</tt>   — all available agents/workflows
+    # - <tt>type: "packs"</tt>    — loaded packs with version, priority, and summary
+    #
+    # @example List all skills
+    #   rails_list_registry type=skills
+    # @example Filter skills by pack
+    #   rails_list_registry type=skills pack=rails
+    # @example List active packs
+    #   rails_list_registry type=packs
+    class ListRegistry < BaseTool
+      DESCRIPTION_MAX_LENGTH = 80
+      SETUP_DOC_PATH = 'docs/skill-registry-guide.md'
+
+      SETUP_MESSAGE = <<~MSG.freeze
+        No registry manifest found at `%<path>s`.
+
+        To use skill registry tools, create a registry manifest file.
+        See `#{SETUP_DOC_PATH}` for a step-by-step guide.
+
+        Quick start — add `config/rails_ai_bridge_registry.json` to your Rails app:
+
+        ```json
+        {
+          "version": "1.0.0",
+          "packs": {},
+          "default_stack": []
+        }
+        ```
+
+        Then configure the registry in `config/initializers/rails_ai_bridge.rb`:
+
+        ```ruby
+        RailsAiBridge.configure do |config|
+          config.registry.registry_manifest_path = "config/rails_ai_bridge_registry.json"
+        end
+        ```
+
+        Once configured, add packs and run `rails ai:skills:list` to verify.
+      MSG
+
+      UNKNOWN_TYPE_MESSAGE = 'Unknown type `%<type>s`. Valid values: "skills", "agents", "packs".'
+
+      tool_name 'rails_list_registry'
+      description 'Query the skill pack registry catalog. ' \
+                  'Use type=skills to list available skills, type=agents for workflows, ' \
+                  'type=packs to see loaded packs with version and priority. ' \
+                  'Optional pack: filter narrows skills/agents to one pack. ' \
+                  'Requires config/rails_ai_bridge_registry.json — see docs/skill-registry-guide.md.'
+
+      input_schema(
+        properties: {
+          type: {
+            type: 'string',
+            enum: %w[skills agents packs],
+            description: 'What to list: "skills", "agents", or "packs".'
+          },
+          pack: {
+            type: 'string',
+            description: 'Filter skills or agents by pack name (e.g. "rails", "core"). ' \
+                         'Ignored when type is "packs".'
+          }
+        },
+        required: ['type']
+      )
+
+      annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
+
+      # @param type [String] "skills", "agents", or "packs"
+      # @param pack [String, nil] optional pack name filter (skills/agents only)
+      # @param _server_context [Object, nil] reserved for MCP transport metadata (unused)
+      # @return [MCP::Tool::Response] formatted catalog or a setup/error message
+      def self.call(type:, pack: nil, _server_context: nil)
+        return text_response(format(UNKNOWN_TYPE_MESSAGE, type: type)) unless %w[skills agents packs].include?(type)
+
+        resolver = Registry.build_resolver
+        return text_response(format(SETUP_MESSAGE, path: manifest_path)) unless resolver
+
+        text_response(RegistryCatalogFormatter.new(resolver, type: type, pack_filter: pack).format)
+      end
+
+      # @api private
+      def self.manifest_path
+        RailsAiBridge.configuration.registry.registry_manifest_path
+      end
+      private_class_method :manifest_path
+
+      # Formats the registry catalog as markdown for a given type.
+      #
+      # Single responsibility: converts resolver data into display-ready markdown.
+      # Does not know about MCP, tools, or configuration.
+      #
+      # @api private
+      class RegistryCatalogFormatter
+        # @param resolver [Registry::Resolver]
+        # @param type [String] "skills", "agents", or "packs"
+        # @param pack_filter [String, nil]
+        def initialize(resolver, type:, pack_filter: nil)
+          @resolver    = resolver
+          @type        = type
+          @pack_filter = pack_filter
+        end
+
+        # @return [String] markdown string
+        def format
+          case @type
+          when 'skills'  then format_catalog(@resolver.list_skills,   noun: 'Skill')
+          when 'agents'  then format_catalog(@resolver.list_agents,   noun: 'Agent')
+          when 'packs'   then format_packs(@resolver.active_packs)
+          end
+        end
+
+        private
+
+        def format_catalog(items, noun:)
+          items = items.select { |i| i.pack == @pack_filter } if @pack_filter
+          return empty_catalog_message(noun) if items.empty?
+
+          lines = ["# Available #{noun}s (#{items.length})", '']
+          lines << "| #{noun} | Pack | Description |"
+          lines << '|--------|------|-------------|'
+          items.each do |item|
+            lines << "| `#{item.name}` | #{item.pack} | #{truncate(item.description)} |"
+          end
+          lines.join("\n")
+        end
+
+        def format_packs(packs)
+          return 'No packs are currently loaded. Check your registry manifest configuration.' if packs.empty?
+
+          lines = ["# Active Skill Packs (#{packs.length})", '']
+          lines << '| Pack | Version | Priority | Summary |'
+          lines << '|------|---------|----------|---------|'
+          packs.each do |pack|
+            summary = truncate(pack.tile.summary || 'No summary.')
+            lines << "| **#{pack.name}** | #{pack.tile.version} | #{pack.priority} | #{summary} |"
+          end
+          lines << ''
+          lines << '_Priority: 0 = local (highest), 10 = rails/hanami, 20 = core, 30 = other (lowest)._'
+          lines.join("\n")
+        end
+
+        def empty_catalog_message(noun)
+          if @pack_filter
+            "No #{noun.downcase}s found for pack `#{@pack_filter}`. " \
+              'Use `rails_list_registry type=packs` to see loaded packs.'
+          else
+            "No #{noun.downcase}s are loaded. Check your registry manifest configuration."
+          end
+        end
+
+        def truncate(text)
+          return text if text.length <= DESCRIPTION_MAX_LENGTH
+
+          "#{text[0, DESCRIPTION_MAX_LENGTH - 1]}…"
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/tools/list_registry.rb
+++ b/lib/rails_ai_bridge/tools/list_registry.rb
@@ -81,6 +81,10 @@ module RailsAiBridge
       # @param _server_context [Object, nil] reserved for MCP transport metadata (unused)
       # @return [MCP::Tool::Response] formatted catalog or a setup/error message
       def self.call(type:, pack: nil, _server_context: nil)
+        # The input_schema enum constraint above rejects unknown types before this
+        # method is called. The guard below is retained as a defence-in-depth
+        # fallback for callers that bypass the MCP SDK (e.g. direct Ruby tests or
+        # future transport layers that skip schema validation).
         return text_response(format(UNKNOWN_TYPE_MESSAGE, type: type)) unless %w[skills agents packs].include?(type)
 
         resolver = Registry.build_resolver
@@ -102,6 +106,8 @@ module RailsAiBridge
       #
       # @api private
       class RegistryCatalogFormatter
+        include Registry::Truncatable
+
         # @param resolver [Registry::Resolver]
         # @param type [String] "skills", "agents", or "packs"
         # @param pack_filter [String, nil]
@@ -130,7 +136,7 @@ module RailsAiBridge
           lines << "| #{noun} | Pack | Description |"
           lines << '|--------|------|-------------|'
           items.each do |item|
-            lines << "| `#{item.name}` | #{item.pack} | #{truncate(item.description)} |"
+            lines << "| `#{item.name}` | #{item.pack} | #{truncate(item.description, DESCRIPTION_MAX_LENGTH)} |"
           end
           lines.join("\n")
         end
@@ -142,7 +148,7 @@ module RailsAiBridge
           lines << '| Pack | Version | Priority | Summary |'
           lines << '|------|---------|----------|---------|'
           packs.each do |pack|
-            summary = truncate(pack.tile.summary || 'No summary.')
+            summary = truncate(pack.tile.summary || 'No summary.', DESCRIPTION_MAX_LENGTH)
             lines << "| **#{pack.name}** | #{pack.tile.version} | #{pack.priority} | #{summary} |"
           end
           lines << ''
@@ -157,12 +163,6 @@ module RailsAiBridge
           else
             "No #{noun.downcase}s are loaded. Check your registry manifest configuration."
           end
-        end
-
-        def truncate(text)
-          return text if text.length <= DESCRIPTION_MAX_LENGTH
-
-          "#{text[0, DESCRIPTION_MAX_LENGTH - 1]}…"
         end
       end
     end

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.igmarin/rails-ai-bridge",
   "title": "Rails AI Bridge",
-  "description": "Auto-expose Rails app structure to AI via MCP. Zero config, 11 read-only tools.",
+  "description": "Auto-expose Rails app structure to AI via MCP. Zero config, 13 read-only tools, skill pack registry.",
   "repository": {
     "url": "https://github.com/igmarin/rails-ai-bridge",
     "source": "github"

--- a/spec/lib/rails_ai_bridge/registry/pack_definition_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/pack_definition_spec.rb
@@ -5,12 +5,12 @@ require 'spec_helper'
 RSpec.describe RailsAiBridge::Registry::PackDefinition do
   describe '#always_loaded?' do
     it 'returns true when always_loaded is true' do
-      pack = described_class.new(source: 'org/repo', tile: 'tile.json', always_loaded: true, depends_on: [])
+      pack = described_class.new(source: 'org/repo', tile: 'directory.json', always_loaded: true, depends_on: [], ref: nil)
       expect(pack.always_loaded?).to be(true)
     end
 
     it 'returns false when always_loaded is false' do
-      pack = described_class.new(source: 'org/repo', tile: 'tile.json', always_loaded: false, depends_on: [])
+      pack = described_class.new(source: 'org/repo', tile: 'directory.json', always_loaded: false, depends_on: [], ref: nil)
       expect(pack.always_loaded?).to be(false)
     end
   end

--- a/spec/lib/rails_ai_bridge/registry/pack_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/pack_resolver_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
     FileUtils.rm_rf(cache_dir)
   end
 
-  # Helper to create a mock tile.json file
+  # Helper to create a mock directory.json file
   def create_mock_tile(base_path, name: 'test-pack', skills: {}, agents: {})
-    tile_path = File.join(base_path, 'tile.json')
+    tile_path = File.join(base_path, 'directory.json')
     tile_data = {
       'name' => name,
       'version' => '1.0.0',
@@ -63,9 +63,10 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         packs = {
           'core' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/core',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: true,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           )
         }
 
@@ -93,9 +94,10 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         packs = {
           'core' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/core',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: true,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           )
         }
 
@@ -124,9 +126,10 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         packs = {
           'core' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/core',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: false,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           )
         }
 
@@ -155,9 +158,10 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         packs = {
           'rails' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/rails',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: false,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           )
         }
 
@@ -187,9 +191,10 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         packs = {
           'core' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/core',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: false,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           )
         }
 
@@ -242,21 +247,24 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         packs = {
           'core' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/core',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: false,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           ),
           'rails' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/rails',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: false,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           ),
           'other' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/other',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: false,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           )
         }
 
@@ -287,9 +295,10 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         packs = {
           'hanami' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/hanami',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: false,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           )
         }
 
@@ -317,9 +326,10 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         packs = {
           'core' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/core',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: false,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           )
         }
 
@@ -331,7 +341,7 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
 
         allow(mock_git_runner).to receive(:clone_repo) do |_url, dest|
           FileUtils.mkdir_p(dest)
-          # Don't create tile.json to trigger read error
+          # Don't create directory.json to trigger read error
         end
         allow(mock_git_runner).to receive(:pull_repo)
 
@@ -365,9 +375,10 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         packs = {
           'core' => RailsAiBridge::Registry::PackDefinition.new(
             source: 'dummy/core',
-            tile: 'tile.json',
+            tile: 'directory.json',
             always_loaded: false,
-            depends_on: []
+            depends_on: [],
+            ref: nil
           )
         }
 
@@ -380,7 +391,7 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         allow(mock_git_runner).to receive(:clone_repo) do |_url, dest|
           FileUtils.mkdir_p(dest)
           # Create invalid JSON
-          File.write(File.join(dest, 'tile.json'), 'invalid json')
+          File.write(File.join(dest, 'directory.json'), 'invalid json')
         end
         allow(mock_git_runner).to receive(:pull_repo)
 
@@ -393,7 +404,7 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
       it 'handles local registry JSON parse errors' do
         local_dir = Dir.mktmpdir
         # Create invalid JSON
-        File.write(File.join(local_dir, 'tile.json'), 'invalid json')
+        File.write(File.join(local_dir, 'directory.json'), 'invalid json')
 
         packs = {}
 

--- a/spec/lib/rails_ai_bridge/registry/pack_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/pack_resolver_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         service = described_class.new(source_resolver)
 
         expect { service.resolve(manifest, ['core'], nil) }
-          .to raise_error(JSON::ParserError)
+          .to raise_error(ArgumentError, /invalid JSON/)
       end
 
       it 'handles local registry JSON parse errors' do
@@ -417,7 +417,7 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
         service = described_class.new(source_resolver)
 
         expect { service.resolve(manifest, nil, [local_dir]) }
-          .to raise_error(JSON::ParserError)
+          .to raise_error(ArgumentError, /invalid JSON/)
 
         FileUtils.rm_rf(local_dir)
       end

--- a/spec/lib/rails_ai_bridge/registry/rake_presenter_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/rake_presenter_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_ai_bridge/registry/resolver'
+
+RSpec.describe RailsAiBridge::Registry::RakePresenter do
+  # Minimal stand-ins so we do not need real pack fixtures.
+  subject(:presenter) { described_class.new(resolver) }
+
+  let(:skill_summary) do
+    RailsAiBridge::Registry::SkillSummary.new(
+      name: 'code-review',
+      pack: 'rails',
+      description: 'Review Rails code against team conventions.'
+    )
+  end
+
+  let(:resolved_skill) do
+    RailsAiBridge::Registry::ResolvedSkill.new(
+      name: 'code-review',
+      pack: 'rails',
+      path: 'skills/code-review.md',
+      content: "# Code Review\nReview your Rails code."
+    )
+  end
+
+  let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver) }
+
+  describe '#skills_table' do
+    context 'when skills are present' do
+      before { allow(resolver).to receive(:list_skills).and_return([skill_summary]) }
+
+      it 'includes a header with the skill count' do
+        expect(presenter.skills_table).to include('Available Skills (1)')
+      end
+
+      it 'includes the skill name' do
+        expect(presenter.skills_table).to include('code-review')
+      end
+
+      it 'includes the pack name' do
+        expect(presenter.skills_table).to include('rails')
+      end
+
+      it 'includes the description' do
+        expect(presenter.skills_table).to include('Review Rails code')
+      end
+
+      it 'includes column headers' do
+        output = presenter.skills_table
+        expect(output).to include('Skill')
+        expect(output).to include('Pack')
+        expect(output).to include('Description')
+      end
+
+      it 'includes a separator line' do
+        expect(presenter.skills_table).to include('-' * 20)
+      end
+    end
+
+    context 'when no skills are loaded' do
+      before { allow(resolver).to receive(:list_skills).and_return([]) }
+
+      it 'returns a helpful empty message' do
+        expect(presenter.skills_table).to include('No skills are loaded')
+      end
+    end
+
+    context 'when a description exceeds the truncation limit' do
+      let(:long_skill) do
+        RailsAiBridge::Registry::SkillSummary.new(
+          name: 'long-skill',
+          pack: 'core',
+          description: 'A' * 100
+        )
+      end
+
+      before { allow(resolver).to receive(:list_skills).and_return([long_skill]) }
+
+      it 'truncates the description with an ellipsis' do
+        output = presenter.skills_table
+        expect(output).to include('…')
+        expect(output).not_to include('A' * 100)
+      end
+    end
+  end
+
+  describe '#resolve_skill_output' do
+    context 'when the skill exists and no deprecation or pack mismatch' do
+      before do
+        allow(resolver).to receive(:resolve_skill).with('code-review').and_return(resolved_skill)
+        allow(resolver).to receive(:check_deprecated).with('code-review').and_return(nil)
+      end
+
+      it 'includes the skill name header' do
+        expect(presenter.resolve_skill_output('code-review')).to include('# code-review')
+      end
+
+      it 'includes the pack name' do
+        expect(presenter.resolve_skill_output('code-review')).to include('rails')
+      end
+
+      it 'includes the file path' do
+        expect(presenter.resolve_skill_output('code-review')).to include('skills/code-review.md')
+      end
+
+      it 'includes the full skill content' do
+        expect(presenter.resolve_skill_output('code-review')).to include('# Code Review')
+      end
+
+      it 'does not include a WARNING line' do
+        expect(presenter.resolve_skill_output('code-review')).not_to include('WARNING')
+      end
+
+      it 'does not include an INFO line when no pack was requested' do
+        expect(presenter.resolve_skill_output('code-review')).not_to include('INFO')
+      end
+    end
+
+    context 'when the skill has a deprecation warning' do
+      before do
+        allow(resolver).to receive(:resolve_skill).with('old-review').and_return(resolved_skill)
+        allow(resolver).to receive(:check_deprecated).with('old-review')
+                                                     .and_return("'old-review' is deprecated. Use 'code-review' instead.")
+      end
+
+      it 'prefixes the output with a WARNING line' do
+        output = presenter.resolve_skill_output('old-review')
+        expect(output).to start_with('WARNING:')
+        expect(output).to include('deprecated')
+      end
+    end
+
+    context 'when the resolved pack differs from the requested pack' do
+      before do
+        allow(resolver).to receive(:resolve_skill).with('code-review').and_return(resolved_skill)
+        allow(resolver).to receive(:check_deprecated).with('code-review').and_return(nil)
+      end
+
+      it 'includes an INFO line about the mismatch' do
+        output = presenter.resolve_skill_output('code-review', requested_pack: 'core')
+        expect(output).to include('INFO:')
+        expect(output).to include("resolved from pack 'rails'")
+        expect(output).to include("requested pack: 'core'")
+      end
+    end
+
+    context 'when requested_pack matches the resolved pack' do
+      before do
+        allow(resolver).to receive(:resolve_skill).with('code-review').and_return(resolved_skill)
+        allow(resolver).to receive(:check_deprecated).with('code-review').and_return(nil)
+      end
+
+      it 'does not include an INFO line' do
+        output = presenter.resolve_skill_output('code-review', requested_pack: 'rails')
+        expect(output).not_to include('INFO:')
+      end
+    end
+
+    context 'when the skill is not found' do
+      before do
+        allow(resolver).to receive(:resolve_skill).with('missing-skill').and_return(nil)
+      end
+
+      it 'returns a not-found message' do
+        output = presenter.resolve_skill_output('missing-skill')
+        expect(output).to include("Skill 'missing-skill' not found")
+      end
+
+      it 'hints to run the list task' do
+        output = presenter.resolve_skill_output('missing-skill')
+        expect(output).to include('rails ai:skills:list')
+      end
+    end
+  end
+
+  describe '.no_manifest_message' do
+    it 'returns a string containing the given path' do
+      msg = described_class.no_manifest_message('/config/registry.json')
+      expect(msg).to include('/config/registry.json')
+    end
+
+    it 'includes a reference to the setup guide' do
+      msg = described_class.no_manifest_message('/any/path.json')
+      expect(msg).to include('skill-registry-guide.md')
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/registry/resolver_cache_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/resolver_cache_spec.rb
@@ -38,14 +38,30 @@ RSpec.describe RailsAiBridge::Registry::ResolverCache do
     end
 
     context 'when TTL has expired' do
-      let(:config) { instance_double(RailsAiBridge::Config::Registry, resolver_ttl: 0) }
+      # Use the injectable monotonic_clock to control time without sleeping.
+      # The clock returns fixed values: 0 the first call (records @built_at),
+      # then 99999 on any subsequent call (making age = 99999 >> TTL).
+      let(:calls)  { [0] }
+      let(:clock)  do
+        lambda {
+          if calls[0] == 0
+            (calls[0] += 1
+             0)
+          else
+            99_999
+          end
+        }
+      end
+      let(:cache)  { described_class.new(monotonic_clock: clock) }
+      let(:config) { instance_double(RailsAiBridge::Config::Registry, resolver_ttl: 1800) }
 
       before { cache.fetch(config) { resolver_a } }
 
       it 'rebuilds and returns a fresh resolver' do
-        sleep(0.01) # ensure monotonic clock advances past 0-second TTL
+        # Act — clock returns 99_999 so age (99_999 - 0) >= 1800, cache is stale
         result = cache.fetch(config) { resolver_b }
 
+        # Assert
         expect(result).to eq(resolver_b)
       end
     end

--- a/spec/lib/rails_ai_bridge/registry/resolver_cache_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/resolver_cache_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::Registry::ResolverCache do
+  let(:config) do
+    instance_double(
+      RailsAiBridge::Config::Registry,
+      resolver_ttl: 1800
+    )
+  end
+  let(:resolver_a) { instance_double(RailsAiBridge::Registry::Resolver) }
+  let(:resolver_b) { instance_double(RailsAiBridge::Registry::Resolver) }
+  let(:cache) { described_class.new }
+
+  describe '#fetch' do
+    context 'when cache is empty' do
+      it 'calls the build block and returns the result' do
+        result = cache.fetch(config) { resolver_a }
+
+        expect(result).to eq(resolver_a)
+      end
+    end
+
+    context 'when cache is warm and TTL has not expired' do
+      before { cache.fetch(config) { resolver_a } }
+
+      it 'returns the cached resolver without calling the block again' do
+        calls = 0
+        result = cache.fetch(config) do
+          calls += 1
+          resolver_b
+        end
+
+        expect(result).to eq(resolver_a)
+        expect(calls).to eq(0)
+      end
+    end
+
+    context 'when TTL has expired' do
+      let(:config) { instance_double(RailsAiBridge::Config::Registry, resolver_ttl: 0) }
+
+      before { cache.fetch(config) { resolver_a } }
+
+      it 'rebuilds and returns a fresh resolver' do
+        sleep(0.01) # ensure monotonic clock advances past 0-second TTL
+        result = cache.fetch(config) { resolver_b }
+
+        expect(result).to eq(resolver_b)
+      end
+    end
+
+    context 'when block returns nil (manifest missing)' do
+      it 'returns nil and does not cache the nil result' do
+        result = cache.fetch(config) { nil } # rubocop:disable Style/RedundantFetchBlock
+
+        expect(result).to be_nil
+
+        # Second call should invoke block again, not cache nil
+        calls = 0
+        cache.fetch(config) do
+          calls += 1
+          nil
+        end
+        expect(calls).to eq(1)
+      end
+    end
+  end
+
+  describe '#invalidate!' do
+    before { cache.fetch(config) { resolver_a } }
+
+    it 'forces the next fetch to rebuild' do
+      cache.invalidate!
+
+      result = cache.fetch(config) { resolver_b }
+      expect(result).to eq(resolver_b)
+    end
+  end
+
+  describe 'thread safety' do
+    it 'allows concurrent fetches without raising' do
+      builds = Concurrent::AtomicFixnum.new(0)
+
+      threads = 10.times.map do
+        Thread.new do
+          cache.fetch(config) do
+            builds.increment
+            resolver_a
+          end
+        end
+      end
+      threads.each(&:join)
+
+      expect(builds.value).to be >= 1
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
@@ -494,17 +494,23 @@ RSpec.describe RailsAiBridge::Registry::SkillSourceResolver do
 end
 
 RSpec.describe RailsAiBridge::Registry::GitRunner do
+  subject(:runner) { Class.new { include RailsAiBridge::Registry::GitRunner }.new }
+
   describe '#clone_repo' do
     it 'raises NotImplementedError by default' do
-      runner = Class.new { include RailsAiBridge::Registry::GitRunner }.new
       expect { runner.clone_repo('url', 'dest') }.to raise_error(NotImplementedError)
     end
   end
 
   describe '#pull_repo' do
     it 'raises NotImplementedError by default' do
-      runner = Class.new { include RailsAiBridge::Registry::GitRunner }.new
       expect { runner.pull_repo('path') }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#checkout_ref' do
+    it 'raises NotImplementedError by default' do
+      expect { runner.checkout_ref('path', 'v1.0.0') }.to raise_error(NotImplementedError)
     end
   end
 end
@@ -583,7 +589,16 @@ RSpec.describe RailsAiBridge::Registry::DefaultGitRunner do
         .and_return(['', 'error: pathspec did not match', failing_status])
 
       expect { runner.checkout_ref('/tmp/pack', 'bad-ref') }
-        .to raise_error(RuntimeError, /git checkout failed/)
+        .to raise_error(RuntimeError, 'git checkout failed')
+    end
+
+    it 'does not embed raw stderr in the error message' do
+      allow(Open3).to receive(:capture3)
+        .with('git', 'checkout', 'bad-ref', chdir: '/tmp/pack')
+        .and_return(['', 'error: pathspec did not match', failing_status])
+
+      expect { runner.checkout_ref('/tmp/pack', 'bad-ref') }
+        .to raise_error(RuntimeError) { |e| expect(e.message).not_to include('pathspec') }
     end
   end
 
@@ -601,15 +616,15 @@ RSpec.describe RailsAiBridge::Registry::DefaultGitRunner do
         .and_return(['', 'Repository not found.', failing_status])
 
       expect { runner.clone_repo('https://github.com/org/missing.git', '/tmp/dest') }
-        .to raise_error(RuntimeError, /git clone failed: Repository not found\./)
+        .to raise_error(RuntimeError, 'git clone failed')
     end
 
-    it 'includes the stderr output in the raised error message' do
+    it 'does not embed raw stderr in the error message (credential safety)' do
       allow(Open3).to receive(:capture3)
-        .and_return(['', 'fatal: authentication required', failing_status])
+        .and_return(['', 'fatal: authentication required for https://token@github.com/org/repo', failing_status])
 
-      expect { runner.clone_repo('https://example.com/repo.git', '/tmp/dest') }
-        .to raise_error(RuntimeError, /authentication required/)
+      expect { runner.clone_repo('https://token@github.com/org/repo.git', '/tmp/dest') }
+        .to raise_error(RuntimeError) { |e| expect(e.message).not_to include('token') }
     end
   end
 
@@ -627,15 +642,15 @@ RSpec.describe RailsAiBridge::Registry::DefaultGitRunner do
         .and_return(['', 'error: could not lock config file', failing_status])
 
       expect { runner.pull_repo('/tmp/local-pack') }
-        .to raise_error(RuntimeError, /git pull failed: error: could not lock config file/)
+        .to raise_error(RuntimeError, 'git pull failed')
     end
 
-    it 'includes the stderr output in the raised error message' do
+    it 'does not embed raw stderr in the error message' do
       allow(Open3).to receive(:capture3)
         .and_return(['', 'CONFLICT (content): Merge conflict in file.rb', failing_status])
 
       expect { runner.pull_repo('/tmp/local-pack') }
-        .to raise_error(RuntimeError, /Merge conflict/)
+        .to raise_error(RuntimeError) { |e| expect(e.message).not_to include('Merge conflict') }
     end
   end
 end

--- a/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
@@ -325,6 +325,172 @@ RSpec.describe RailsAiBridge::Registry::SkillSourceResolver do
       end
     end
   end
+
+  describe '#resolve with ref:' do
+    let(:source) { 'igmarin/test-pack' }
+    let(:resolver) { described_class.new(cache_dir, mock_runner) }
+
+    # Helper: pre-seed a ref-specific cache dir so resolve() skips clone.
+    def seed_cache_for_ref(ref)
+      key  = described_class.compute_cache_key(source, ref)
+      path = File.join(cache_dir, key)
+      FileUtils.mkdir_p(path)
+      path
+    end
+
+    context 'when checkout succeeds' do
+      let(:ref) { 'v1.2.3' }
+      let(:cache_path) { seed_cache_for_ref(ref) }
+
+      before do
+        cache_path # ensure dir is created
+        allow(mock_runner).to receive(:checkout_ref)
+      end
+
+      it 'returns the cache path without raising' do
+        expect(resolver.resolve(source, ref: ref)).to eq(cache_path)
+      end
+
+      it 'delegates checkout to the git_runner with the correct ref' do
+        expect(mock_runner).to receive(:checkout_ref).with(cache_path, ref)
+
+        resolver.resolve(source, ref: ref)
+      end
+
+      it 'does not call pull_repo when ref is pinned (detached HEAD protection)' do
+        expect(mock_runner).not_to receive(:pull_repo)
+
+        resolver.resolve(source, ref: ref)
+      end
+    end
+
+    context 'when checkout fails (non-zero exit)' do
+      let(:ref) { 'nonexistent-branch' }
+      let(:cache_path) { seed_cache_for_ref(ref) }
+
+      before do
+        cache_path # ensure dir is created
+        allow(mock_runner).to receive(:checkout_ref)
+          .with(cache_path, ref)
+          .and_raise(StandardError, "error: pathspec 'nonexistent-branch' did not match any file(s)")
+      end
+
+      it 'raises ResolutionError' do
+        expect { resolver.resolve(source, ref: ref) }
+          .to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError)
+      end
+
+      it 'includes the ref name in the error message' do
+        expect { resolver.resolve(source, ref: ref) }
+          .to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError, /nonexistent-branch/)
+      end
+
+      it 'includes the source pack name in the error message' do
+        expect { resolver.resolve(source, ref: ref) }
+          .to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError, %r{igmarin/test-pack})
+      end
+
+      it 'includes the error output in the error message' do
+        expect { resolver.resolve(source, ref: ref) }
+          .to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError, /pathspec.*did not match/)
+      end
+    end
+
+    context 'when checkout times out' do
+      let(:ref) { 'slow-branch' }
+      let(:cache_path) { seed_cache_for_ref(ref) }
+
+      before do
+        cache_path # ensure dir is created
+        allow(mock_runner).to receive(:checkout_ref)
+          .and_raise(StandardError, 'git checkout timed out after 30s')
+      end
+
+      it 'raises ResolutionError with a timeout message' do
+        expect { resolver.resolve(source, ref: ref) }
+          .to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError, /timed out/)
+      end
+
+      it 'names the ref in the timeout error' do
+        expect { resolver.resolve(source, ref: ref) }
+          .to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError, /slow-branch/)
+      end
+    end
+
+    context 'when ref is nil' do
+      it 'does not call git checkout at all' do
+        # Arrange — cache exists so no clone either
+        FileUtils.mkdir_p(File.join(cache_dir, described_class.compute_cache_key(source, nil)))
+        allow(mock_runner).to receive(:pull_repo)
+        expect(mock_runner).not_to receive(:checkout_ref)
+
+        resolver.resolve(source, ref: nil)
+      end
+    end
+
+    context 'when two different refs for the same source are resolved' do
+      it 'uses distinct cache directories for each ref' do
+        key_v1 = described_class.compute_cache_key(source, 'v1.0.0')
+        key_v2 = described_class.compute_cache_key(source, 'v2.0.0')
+
+        expect(key_v1).not_to eq(key_v2)
+      end
+    end
+  end
+
+  describe '#resolve pull freshness (git_pull_ttl)' do
+    let(:source) { 'igmarin/test-pack' }
+    let(:cache_key) { described_class.compute_cache_key(source) }
+    let(:cache_path) { File.join(cache_dir, cache_key) }
+
+    before { FileUtils.mkdir_p(cache_path) }
+
+    context 'when pull_ttl is 0 (always pull)' do
+      let(:resolver) { described_class.new(cache_dir, mock_runner, pull_ttl: 0) }
+
+      it 'always calls pull_repo on every resolve' do
+        # Arrange
+        expect(mock_runner).to receive(:pull_repo).twice
+
+        # Act
+        resolver.resolve(source)
+        resolver.resolve(source)
+      end
+    end
+
+    context 'when pull_ttl is large (e.g. 86400)' do
+      let(:resolver) { described_class.new(cache_dir, mock_runner, pull_ttl: 86_400) }
+
+      it 'calls pull_repo only once across two back-to-back resolves' do
+        # Arrange
+        expect(mock_runner).to receive(:pull_repo).once
+
+        # Act — second call happens within the TTL window, so no pull
+        resolver.resolve(source)
+        resolver.resolve(source)
+      end
+    end
+
+    context 'when pull_ttl has elapsed between resolves' do
+      let(:resolver) { described_class.new(cache_dir, mock_runner, pull_ttl: 86_400) }
+
+      it 'calls pull_repo again after the TTL window expires' do
+        # Arrange
+        allow(mock_runner).to receive(:pull_repo)
+
+        # Act — first resolve populates @last_pulled
+        resolver.resolve(source)
+
+        # Simulate TTL expiry by backdating the recorded pull time
+        past_time = Time.zone.now - 90_000
+        resolver.instance_variable_get(:@last_pulled)[cache_path] = past_time
+
+        # Assert — second resolve after TTL should pull again
+        expect(mock_runner).to receive(:pull_repo).once
+        resolver.resolve(source)
+      end
+    end
+  end
 end
 
 RSpec.describe RailsAiBridge::Registry::GitRunner do
@@ -350,8 +516,76 @@ RSpec.describe RailsAiBridge::Registry::DefaultGitRunner do
   # and fail silently in headless CI environments.
   subject(:runner) { described_class.new }
 
-  let(:failing_status) { instance_double(Process::Status, success?: false) }
   let(:succeeding_status) { instance_double(Process::Status, success?: true) }
+  let(:failing_status) { instance_double(Process::Status, success?: false) }
+
+  describe '#timeout' do
+    it 'defaults to 30 seconds' do
+      # Assert
+      expect(runner.timeout).to eq(30)
+    end
+
+    it 'is configurable via constructor' do
+      # Arrange + Act
+      fast_runner = described_class.new(timeout: 5)
+
+      # Assert
+      expect(fast_runner.timeout).to eq(5)
+    end
+  end
+
+  describe 'timeout enforcement' do
+    subject(:runner) { described_class.new(timeout: 1) }
+
+    context 'when git clone times out' do
+      before { allow(Open3).to receive(:capture3) { sleep(5) } }
+
+      it 'raises RuntimeError mentioning the timeout duration' do
+        # Act + Assert
+        expect { runner.clone_repo('https://example.com/repo.git', '/tmp/dest') }
+          .to raise_error(RuntimeError, /timed out after 1s/)
+      end
+    end
+
+    context 'when git pull times out' do
+      before { allow(Open3).to receive(:capture3) { sleep(5) } }
+
+      it 'raises RuntimeError mentioning the timeout duration' do
+        # Act + Assert
+        expect { runner.pull_repo('/tmp/local-pack') }
+          .to raise_error(RuntimeError, /timed out after 1s/)
+      end
+    end
+
+    context 'when git checkout times out' do
+      before { allow(Open3).to receive(:capture3) { sleep(5) } }
+
+      it 'raises RuntimeError mentioning the timeout duration' do
+        # Act + Assert
+        expect { runner.checkout_ref('/tmp/local-pack', 'v1.0.0') }
+          .to raise_error(RuntimeError, /timed out after 1s/)
+      end
+    end
+  end
+
+  describe '#checkout_ref' do
+    it 'calls git checkout with the ref and chdir option' do
+      allow(Open3).to receive(:capture3)
+        .with('git', 'checkout', 'v1.2.3', chdir: '/tmp/pack')
+        .and_return(['', '', succeeding_status])
+
+      expect { runner.checkout_ref('/tmp/pack', 'v1.2.3') }.not_to raise_error
+    end
+
+    it 'raises RuntimeError when git checkout exits non-zero' do
+      allow(Open3).to receive(:capture3)
+        .with('git', 'checkout', 'bad-ref', chdir: '/tmp/pack')
+        .and_return(['', 'error: pathspec did not match', failing_status])
+
+      expect { runner.checkout_ref('/tmp/pack', 'bad-ref') }
+        .to raise_error(RuntimeError, /git checkout failed/)
+    end
+  end
 
   describe '#clone_repo' do
     it 'calls git clone with the url and destination' do

--- a/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe RailsAiBridge::Registry::SkillSourceResolver do
         resolver.resolve(source)
 
         # Simulate TTL expiry by backdating the recorded pull time
-        past_time = Time.zone.now - 90_000
+        past_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - 90_000
         resolver.instance_variable_get(:@last_pulled)[cache_path] = past_time
 
         # Assert — second resolve after TTL should pull again

--- a/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
@@ -137,10 +137,12 @@ RSpec.describe RailsAiBridge::Registry::SkillSourceResolver do
           .to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError, /Invalid source format/)
       end
 
-      it 'raises ResolutionError for path traversal in source' do
+      it 'returns the local path directly for relative traversal sources' do
+        # ../relative paths are now treated as valid local path sources by SourceParser.
+        # Path traversal security for file content is enforced by the Resolver layer.
         resolver = described_class.new(cache_dir, mock_runner)
-        expect { resolver.resolve('../etc/passwd') }
-          .to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError, /Invalid source format/)
+        result = resolver.resolve('../etc/passwd')
+        expect(result).to eq('../etc/passwd')
       end
     end
 
@@ -342,51 +344,64 @@ RSpec.describe RailsAiBridge::Registry::GitRunner do
 end
 
 RSpec.describe RailsAiBridge::Registry::DefaultGitRunner do
+  # Open3.capture3 is stubbed throughout this describe block.
+  # Real git network calls must never appear in unit tests — they are slow,
+  # require internet access, may trigger OS credential dialogs (macOS Keychain),
+  # and fail silently in headless CI environments.
+  subject(:runner) { described_class.new }
+
+  let(:failing_status) { instance_double(Process::Status, success?: false) }
+  let(:succeeding_status) { instance_double(Process::Status, success?: true) }
+
   describe '#clone_repo' do
-    it 'executes git clone command' do
-      runner = described_class.new
-      temp_dir = Dir.mktmpdir
-      dest = File.join(temp_dir, 'test-repo')
+    it 'calls git clone with the url and destination' do
+      allow(Open3).to receive(:capture3)
+        .with('git', 'clone', 'https://github.com/org/repo.git', '/tmp/dest')
+        .and_return(['', '', succeeding_status])
 
-      # Use a real but simple git command that should work
-      # We'll mock this in practice, but for coverage we need to call it
-      expect { runner.clone_repo('https://github.com/igmarin/test.git', dest) }
-        .to raise_error(/git clone failed/)
-
-      FileUtils.rm_rf(temp_dir)
+      expect { runner.clone_repo('https://github.com/org/repo.git', '/tmp/dest') }.not_to raise_error
     end
 
-    it 'raises RuntimeError on failure' do
-      runner = described_class.new
-      temp_dir = Dir.mktmpdir
-      dest = File.join(temp_dir, 'test-repo')
+    it 'raises RuntimeError when git clone exits non-zero' do
+      allow(Open3).to receive(:capture3)
+        .and_return(['', 'Repository not found.', failing_status])
 
-      expect { runner.clone_repo('invalid-url', dest) }
-        .to raise_error(RuntimeError, /git clone failed/)
+      expect { runner.clone_repo('https://github.com/org/missing.git', '/tmp/dest') }
+        .to raise_error(RuntimeError, /git clone failed: Repository not found\./)
+    end
 
-      FileUtils.rm_rf(temp_dir)
+    it 'includes the stderr output in the raised error message' do
+      allow(Open3).to receive(:capture3)
+        .and_return(['', 'fatal: authentication required', failing_status])
+
+      expect { runner.clone_repo('https://example.com/repo.git', '/tmp/dest') }
+        .to raise_error(RuntimeError, /authentication required/)
     end
   end
 
   describe '#pull_repo' do
-    it 'executes git pull command' do
-      runner = described_class.new
-      temp_dir = Dir.mktmpdir
+    it 'calls git pull inside the given directory' do
+      allow(Open3).to receive(:capture3)
+        .with('git', 'pull', chdir: '/tmp/local-pack')
+        .and_return(['Already up to date.', '', succeeding_status])
 
-      expect { runner.pull_repo(temp_dir) }
-        .to raise_error(/git pull failed/)
-
-      FileUtils.rm_rf(temp_dir)
+      expect { runner.pull_repo('/tmp/local-pack') }.not_to raise_error
     end
 
-    it 'raises RuntimeError on failure' do
-      runner = described_class.new
-      temp_dir = Dir.mktmpdir
+    it 'raises RuntimeError when git pull exits non-zero' do
+      allow(Open3).to receive(:capture3)
+        .and_return(['', 'error: could not lock config file', failing_status])
 
-      expect { runner.pull_repo(temp_dir) }
-        .to raise_error(RuntimeError, /git pull failed/)
+      expect { runner.pull_repo('/tmp/local-pack') }
+        .to raise_error(RuntimeError, /git pull failed: error: could not lock config file/)
+    end
 
-      FileUtils.rm_rf(temp_dir)
+    it 'includes the stderr output in the raised error message' do
+      allow(Open3).to receive(:capture3)
+        .and_return(['', 'CONFLICT (content): Merge conflict in file.rb', failing_status])
+
+      expect { runner.pull_repo('/tmp/local-pack') }
+        .to raise_error(RuntimeError, /Merge conflict/)
     end
   end
 end

--- a/spec/lib/rails_ai_bridge/registry/source_parser_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/source_parser_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::Registry::SourceParser do
+  describe '.parse' do
+    subject(:parsed) { described_class.parse(source) }
+
+    # ── local paths ─────────────────────────────────────────────────────────
+
+    context 'with an absolute local path' do
+      let(:source) { '/Users/alice/skills/my-pack' }
+
+      it { is_expected.to have_attributes(type: :local_path, resolved_url: source) }
+    end
+
+    context 'with a relative ./ path' do
+      let(:source) { './local/skills' }
+
+      it { is_expected.to have_attributes(type: :local_path, resolved_url: source) }
+    end
+
+    context 'with a relative ../ path' do
+      let(:source) { '../shared/skills' }
+
+      it { is_expected.to have_attributes(type: :local_path, resolved_url: source) }
+    end
+
+    # ── full git URLs ────────────────────────────────────────────────────────
+
+    context 'with an https:// git URL' do
+      let(:source) { 'https://github.com/myorg/my-skills.git' }
+
+      it { is_expected.to have_attributes(type: :git_url, resolved_url: source) }
+    end
+
+    context 'with an https:// URL without .git suffix' do
+      let(:source) { 'https://gitlab.com/myorg/skills' }
+
+      it { is_expected.to have_attributes(type: :git_url, resolved_url: source) }
+    end
+
+    context 'with a git@ SSH URL' do
+      let(:source) { 'git@github.com:myorg/my-skills.git' }
+
+      it { is_expected.to have_attributes(type: :git_url, resolved_url: source) }
+    end
+
+    # ── GitHub shorthand ────────────────────────────────────────────────────
+
+    context 'with owner/repo shorthand' do
+      let(:source) { 'igmarin/ruby-core-skills' }
+
+      it { is_expected.to have_attributes(type: :github_shorthand) }
+
+      it 'expands to a github https URL' do
+        expect(parsed.resolved_url).to eq('https://github.com/igmarin/ruby-core-skills.git')
+      end
+    end
+
+    context 'with owner/repo containing dots and underscores' do
+      let(:source) { 'my-org/my_pack.v2' }
+
+      it { is_expected.to have_attributes(type: :github_shorthand) }
+    end
+
+    # ── invalid formats ─────────────────────────────────────────────────────
+
+    context 'with a bare word (no slashes)' do
+      let(:source) { 'not-a-source' }
+
+      it 'raises ResolutionError naming the three valid forms' do
+        expect { parsed }.to raise_error(
+          RailsAiBridge::Registry::SkillSourceResolver::ResolutionError,
+          %r{local path.*https?://.*owner/repo}im
+        )
+      end
+    end
+
+    context 'with empty string' do
+      let(:source) { '' }
+
+      it 'raises ResolutionError' do
+        expect { parsed }.to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError)
+      end
+    end
+
+    context 'with too many path segments' do
+      let(:source) { 'org/repo/extra' }
+
+      it 'raises ResolutionError' do
+        expect { parsed }.to raise_error(RailsAiBridge::Registry::SkillSourceResolver::ResolutionError)
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/registry_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+RSpec.describe RailsAiBridge::Registry do
+  describe '.build_resolver' do
+    let(:config) { RailsAiBridge::Config::Registry.new }
+
+    # Each example uses a fresh config pointing at different paths.
+    # The module-level cache is keyed by the single cached Resolver, not by config,
+    # so we must invalidate between examples to prevent cross-test pollution.
+    before { described_class.invalidate_resolver_cache! }
+    after  { described_class.invalidate_resolver_cache! }
+
+    context 'when manifest file does not exist' do
+      it 'returns nil' do
+        config.registry_manifest_path = '/nonexistent/path/registry.json'
+
+        expect(described_class.build_resolver(config)).to be_nil
+      end
+    end
+
+    context 'when manifest file exists' do
+      let(:tmp_dir) { Dir.mktmpdir }
+      let(:manifest_path) { File.join(tmp_dir, 'registry.json') }
+      let(:cache_dir) { File.join(tmp_dir, 'cache') }
+
+      after { FileUtils.rm_rf(tmp_dir) }
+
+      before do
+        config.registry_manifest_path = manifest_path
+        config.skill_cache_dir = cache_dir
+        config.skill_packs = nil
+        config.local_registry_paths = []
+        # Prevent auto-detection from picking up this project's own Gemfile
+        allow(RailsAiBridge::Registry::PackDetector).to receive(:detect).and_return([])
+      end
+
+      context 'with an empty manifest (no packs)' do
+        before do
+          File.write(manifest_path, JSON.generate({
+                                                    'version' => '1.0.0',
+                                                    'packs' => {},
+                                                    'default_stack' => []
+                                                  }))
+        end
+
+        it 'returns a Resolver instance' do
+          result = described_class.build_resolver(config)
+
+          expect(result).to be_a(RailsAiBridge::Registry::Resolver)
+        end
+
+        it 'returns a resolver with no active packs' do
+          result = described_class.build_resolver(config)
+
+          expect(result.active_packs).to be_empty
+        end
+      end
+
+      context 'with local_registry_paths set' do
+        let(:local_dir) { File.join(tmp_dir, 'local_pack') }
+
+        before do
+          FileUtils.mkdir_p(local_dir)
+          File.write(File.join(local_dir, 'directory.json'), JSON.generate({
+                                                                             'name' => 'local-test-pack',
+                                                                             'version' => '0.1.0',
+                                                                             'summary' => 'Local test pack',
+                                                                             'depends_on' => [],
+                                                                             'skills' => {},
+                                                                             'agents' => {},
+                                                                             'deprecated_skills' => {}
+                                                                           }))
+          File.write(manifest_path, JSON.generate({
+                                                    'version' => '1.0.0',
+                                                    'packs' => {},
+                                                    'default_stack' => []
+                                                  }))
+          config.local_registry_paths = [local_dir]
+        end
+
+        it 'returns a resolver with the local pack loaded' do
+          result = described_class.build_resolver(config)
+
+          expect(result).to be_a(RailsAiBridge::Registry::Resolver)
+          expect(result.active_packs.length).to eq(1)
+          expect(result.active_packs.first.priority).to eq(0)
+        end
+      end
+
+      context 'when local_registry_paths is empty' do
+        before do
+          File.write(manifest_path, JSON.generate({
+                                                    'version' => '1.0.0',
+                                                    'packs' => {},
+                                                    'default_stack' => []
+                                                  }))
+        end
+
+        it 'passes nil to PackResolver (not an empty array)' do
+          # Spy on PackResolver by injecting a recording double that delegates to a real instance
+          received_local_paths = :not_called
+          real_pack_resolver = RailsAiBridge::Registry::PackResolver.new(
+            RailsAiBridge::Registry::SkillSourceResolver.new(cache_dir)
+          )
+          spy_resolver = instance_double(RailsAiBridge::Registry::PackResolver)
+          allow(spy_resolver).to receive(:resolve) do |manifest, packs, local_paths|
+            received_local_paths = local_paths
+            real_pack_resolver.resolve(manifest, packs, local_paths)
+          end
+          allow(RailsAiBridge::Registry::PackResolver).to receive(:new).and_return(spy_resolver)
+
+          described_class.build_resolver(config)
+
+          expect(received_local_paths).to be_nil
+        end
+      end
+    end
+
+    context 'when called with default config' do
+      it 'uses RailsAiBridge.configuration.registry by default' do
+        default_path = RailsAiBridge.configuration.registry.registry_manifest_path
+        # Default manifest does not exist in test env — should return nil gracefully
+        result = described_class.build_resolver
+
+        expect(result).to be_nil unless File.exist?(default_path)
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/registry_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'tmpdir'
+require 'json'
 
 RSpec.describe RailsAiBridge::Registry do
   describe '.build_resolver' do
@@ -119,13 +120,34 @@ RSpec.describe RailsAiBridge::Registry do
       end
     end
 
-    context 'when called with default config' do
-      it 'uses RailsAiBridge.configuration.registry by default' do
-        default_path = RailsAiBridge.configuration.registry.registry_manifest_path
-        # Default manifest does not exist in test env — should return nil gracefully
+    context 'when called with default config and no manifest file present' do
+      it 'returns nil gracefully' do
+        allow(RailsAiBridge.configuration.registry).to receive(:registry_manifest_path)
+          .and_return('/nonexistent/path/registry.json')
+
         result = described_class.build_resolver
 
-        expect(result).to be_nil unless File.exist?(default_path)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when called with default config and manifest file present' do
+      it 'returns a non-nil resolver' do
+        Dir.mktmpdir do |dir|
+          manifest_path = File.join(dir, 'registry.json')
+          File.write(manifest_path, JSON.generate(
+                                      version: '1.0.0',
+                                      packs: {},
+                                      default_stack: []
+                                    ))
+
+          config = RailsAiBridge.configuration.registry.dup
+          allow(config).to receive_messages(registry_manifest_path: manifest_path, local_registry_paths: [], skill_packs: [])
+
+          result = described_class.build_resolver(config)
+
+          expect(result).not_to be_nil
+        end
       end
     end
   end

--- a/spec/lib/rails_ai_bridge/serializers/formatters/sections/migrations_formatter_spec.rb
+++ b/spec/lib/rails_ai_bridge/serializers/formatters/sections/migrations_formatter_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RailsAiBridge::Serializers::Formatters::Sections::MigrationsForma
       result = described_class.new({ migrations: { total: 1, recent: recent } }).call
       expect(result).to include('### Recent Migrations')
       expect(result).to include('`20240101000000` CreateUsers')
-      expect(result).not_to match(/CreateUsers \(/)
+      expect(result).not_to include('CreateUsers (')
     end
 
     it 'renders Recent Migrations with actions when present' do

--- a/spec/lib/rails_ai_bridge/services/file_management_service_spec.rb
+++ b/spec/lib/rails_ai_bridge/services/file_management_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RailsAiBridge::Services::FileManagementService do
       result = described_class.call(:read, path: missing)
 
       expect(result.failure?).to be(true)
-      expect(result.errors.first).to match(/No such file or directory/)
+      expect(result.errors.first).to include('No such file or directory')
     end
 
     it 'handles permission errors gracefully' do
@@ -60,7 +60,7 @@ RSpec.describe RailsAiBridge::Services::FileManagementService do
       result = described_class.call(:write, path: probe, content: 'content')
 
       expect(result.failure?).to be(true)
-      expect(result.errors.first).to match(/Permission denied/)
+      expect(result.errors.first).to include('Permission denied')
     end
 
     it 'returns failure when operation is nil' do
@@ -146,7 +146,7 @@ RSpec.describe RailsAiBridge::Services::FileManagementService do
       result = described_class.call(:write, path: nested, content: 'content')
 
       expect(result.failure?).to be(true)
-      expect(result.errors.first).to match(/Permission denied/)
+      expect(result.errors.first).to include('Permission denied')
     end
   end
 
@@ -155,14 +155,14 @@ RSpec.describe RailsAiBridge::Services::FileManagementService do
       result = described_class.call(:read, path: '/etc/passwd')
 
       expect(result.failure?).to be(true)
-      expect(result.errors.first).to match(/Path not allowed/)
+      expect(result.errors.first).to include('Path not allowed')
     end
 
     it 'rejects relative paths that resolve outside the allowed base' do
       result = described_class.call(:read, path: '../../../config/database.yml')
 
       expect(result.failure?).to be(true)
-      expect(result.errors.first).to match(/Path not allowed/)
+      expect(result.errors.first).to include('Path not allowed')
     end
 
     it 'rejects symlinks pointing outside the allowed base' do
@@ -175,7 +175,7 @@ RSpec.describe RailsAiBridge::Services::FileManagementService do
       begin
         result = described_class.call(:read, path: symlink_path)
         expect(result.failure?).to be(true)
-        expect(result.errors.first).to match(/Path not allowed/)
+        expect(result.errors.first).to include('Path not allowed')
       ensure
         FileUtils.rm_f(outside_file)
         FileUtils.rm_f(symlink_path)
@@ -194,7 +194,7 @@ RSpec.describe RailsAiBridge::Services::FileManagementService do
       begin
         result = described_class.call(:write, path: nested_path, content: 'should fail')
         expect(result.failure?).to be(true)
-        expect(result.errors.first).to match(/Path not allowed/)
+        expect(result.errors.first).to include('Path not allowed')
       ensure
         FileUtils.rm_rf(outside_dir)
         FileUtils.rm_f(symlink_dir)
@@ -205,7 +205,7 @@ RSpec.describe RailsAiBridge::Services::FileManagementService do
       result = described_class.call(:read, path: '')
 
       expect(result.failure?).to be(true)
-      expect(result.errors.first).to match(/path must be non-empty/)
+      expect(result.errors.first).to include('path must be non-empty')
     end
 
     it 'allows paths relative to Rails.root' do

--- a/spec/lib/rails_ai_bridge/tools/list_registry_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/list_registry_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_ai_bridge/registry/tile_manifest'
+
+RSpec.describe RailsAiBridge::Tools::ListRegistry do
+  let(:response) { described_class.call(**params) }
+  let(:content)  { response.content.first[:text] }
+
+  def build_tile(name:, version:, summary:)
+    RailsAiBridge::Registry::TileManifest.new(
+      name: name,
+      version: version,
+      summary: summary,
+      depends_on: [],
+      skills: {},
+      agents: {},
+      deprecated_skills: {}
+    )
+  end
+
+  # ── setup message (no manifest) ────────────────────────────────────────────
+
+  shared_examples 'returns setup message' do
+    before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(nil) }
+
+    it 'mentions registry manifest' do
+      expect(content).to include('registry manifest')
+    end
+
+    it 'mentions the default manifest path' do
+      expect(content).to include('config/rails_ai_bridge_registry.json')
+    end
+
+    it 'includes a quick-start JSON snippet' do
+      expect(content).to include('"version"')
+    end
+  end
+
+  # ── type: skills ────────────────────────────────────────────────────────────
+
+  describe 'type: skills' do
+    context 'when manifest is missing' do
+      let(:params) { { type: 'skills' } }
+
+      it_behaves_like 'returns setup message'
+    end
+
+    context 'when skills are available' do
+      let(:skills) do
+        [
+          RailsAiBridge::Registry::SkillSummary.new(name: 'code-review',  pack: 'rails', description: 'Review Rails code.'),
+          RailsAiBridge::Registry::SkillSummary.new(name: 'write-tests',  pack: 'core',  description: 'Write RSpec tests.')
+        ]
+      end
+      let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver, list_skills: skills) }
+
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver) }
+
+      context 'with no pack filter' do
+        let(:params) { { type: 'skills' } }
+
+        it 'returns a markdown header' do
+          expect(content).to include('# Available Skills')
+        end
+
+        it 'lists all skills with name and pack' do
+          expect(content).to include('code-review')
+          expect(content).to include('rails')
+          expect(content).to include('write-tests')
+          expect(content).to include('core')
+        end
+
+        it 'includes descriptions' do
+          expect(content).to include('Review Rails code.')
+        end
+      end
+
+      context 'with a matching pack filter' do
+        let(:params) { { type: 'skills', pack: 'rails' } }
+
+        it 'shows only skills from that pack' do
+          expect(content).to include('code-review')
+          expect(content).not_to include('write-tests')
+        end
+      end
+
+      context 'with a non-matching pack filter' do
+        let(:params) { { type: 'skills', pack: 'hanami' } }
+
+        it 'returns a no-skills-found message naming the pack' do
+          expect(content).to include('No skills found')
+          expect(content).to include('hanami')
+        end
+      end
+    end
+
+    context 'when resolver has no skills' do
+      let(:params) { { type: 'skills' } }
+      let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver, list_skills: []) }
+
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver) }
+
+      it 'returns an empty message' do
+        expect(content).to include('No skills')
+      end
+    end
+  end
+
+  # ── type: agents ────────────────────────────────────────────────────────────
+
+  describe 'type: agents' do
+    context 'when manifest is missing' do
+      let(:params) { { type: 'agents' } }
+
+      it_behaves_like 'returns setup message'
+    end
+
+    context 'when agents are available' do
+      let(:agents) do
+        [
+          RailsAiBridge::Registry::SkillSummary.new(name: 'tdd-workflow',    pack: 'rails', description: 'Full TDD cycle.'),
+          RailsAiBridge::Registry::SkillSummary.new(name: 'review-workflow', pack: 'core',  description: 'PR review cycle.')
+        ]
+      end
+      let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver, list_agents: agents) }
+
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver) }
+
+      context 'with no pack filter' do
+        let(:params) { { type: 'agents' } }
+
+        it 'returns a markdown header' do
+          expect(content).to include('# Available Agents')
+        end
+
+        it 'lists all agents' do
+          expect(content).to include('tdd-workflow')
+          expect(content).to include('review-workflow')
+        end
+      end
+
+      context 'with a matching pack filter' do
+        let(:params) { { type: 'agents', pack: 'core' } }
+
+        it 'shows only agents from that pack' do
+          expect(content).to include('review-workflow')
+          expect(content).not_to include('tdd-workflow')
+        end
+      end
+
+      context 'with a non-matching pack filter' do
+        let(:params) { { type: 'agents', pack: 'hanami' } }
+
+        it 'returns a no-agents-found message naming the pack' do
+          expect(content).to include('No agents found')
+          expect(content).to include('hanami')
+        end
+      end
+    end
+
+    context 'when resolver has no agents' do
+      let(:params) { { type: 'agents' } }
+      let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver, list_agents: []) }
+
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver) }
+
+      it 'returns an empty message' do
+        expect(content).to include('No agents')
+      end
+    end
+  end
+
+  # ── type: packs ─────────────────────────────────────────────────────────────
+
+  describe 'type: packs' do
+    context 'when manifest is missing' do
+      let(:params) { { type: 'packs' } }
+
+      it_behaves_like 'returns setup message'
+    end
+
+    context 'when packs are loaded' do
+      let(:active_packs) do
+        [
+          RailsAiBridge::Registry::LoadedPack.new(
+            name: 'rails',
+            tile: build_tile(name: 'rails', version: '1.2.0', summary: 'Rails-specific skills.'),
+            base_path: '/tmp/rails',
+            priority: 10
+          ),
+          RailsAiBridge::Registry::LoadedPack.new(
+            name: 'core',
+            tile: build_tile(name: 'core', version: '2.0.0', summary: 'Core Ruby skills.'),
+            base_path: '/tmp/core',
+            priority: 20
+          )
+        ]
+      end
+      let(:params) { { type: 'packs' } }
+      let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver, active_packs: active_packs) }
+
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver) }
+
+      it 'returns a markdown header' do
+        expect(content).to include('# Active Skill Packs')
+      end
+
+      it 'shows each pack with name, version, priority, and summary' do
+        expect(content).to include('rails').and include('1.2.0').and include('10')
+        expect(content).to include('core').and  include('2.0.0').and include('20')
+        expect(content).to include('Rails-specific skills.')
+      end
+
+      it 'includes total pack count' do
+        expect(content).to include('2')
+      end
+
+      it 'includes a priority legend' do
+        expect(content).to include('Priority:')
+      end
+    end
+
+    context 'when no packs are loaded' do
+      let(:params) { { type: 'packs' } }
+      let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver, active_packs: []) }
+
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver) }
+
+      it 'returns a no-packs message' do
+        expect(content).to include('No packs')
+      end
+    end
+  end
+
+  # ── invalid type ────────────────────────────────────────────────────────────
+
+  describe 'invalid type' do
+    let(:params) { { type: 'bananas' } }
+
+    before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(double) }
+
+    it 'returns a clear error message' do
+      expect(content).to include('Unknown type')
+      expect(content).to include('bananas')
+      expect(content).to include('skills')
+      expect(content).to include('agents')
+      expect(content).to include('packs')
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/tools/search_code/ripgrep_search_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/search_code/ripgrep_search_spec.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe RailsAiBridge::Tools::SearchCode::RipgrepSearch do
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:root) { tmpdir }
+
+  after { FileUtils.remove_entry(tmpdir) }
+
+  def write_file(relative_path, content)
+    full_path = File.join(tmpdir, relative_path)
+    FileUtils.mkdir_p(File.dirname(full_path))
+    File.write(full_path, content)
+    full_path
+  end
+
+  def make_searcher(pattern:, search_path: nil, file_type: nil, max_results: 50)
+    described_class.new(
+      pattern: pattern,
+      search_path: search_path || tmpdir,
+      file_type: file_type,
+      max_results: max_results,
+      root: root
+    )
+  end
+
+  describe '#call' do
+    # RipgrepSearch delegates to the rg binary via Open3. We stub Open3.capture2
+    # throughout this describe block so the suite does not depend on rg being
+    # installed in CI. Tests that verify the *command shape* live in CommandBuilder.
+
+    let(:user_rb_path) { File.join(tmpdir, 'app/models/user.rb') }
+
+    before do
+      write_file('app/models/user.rb', "class User < ApplicationRecord\nend\n")
+      write_file('app/models/admin.rb', "class Admin < User; end\n")
+    end
+
+    context 'when ripgrep returns matching results' do
+      before do
+        rg_output = "#{user_rb_path}:1:class User < ApplicationRecord\n"
+        allow(Open3).to receive(:capture2).and_return([rg_output, double(success?: true)])
+      end
+
+      it 'returns structured result hashes' do
+        results = make_searcher(pattern: 'ApplicationRecord').call
+
+        expect(results).not_to be_empty
+        expect(results.first).to include(:file, :line_number, :content)
+      end
+
+      it 'strips the root prefix from file paths' do
+        results = make_searcher(pattern: 'ApplicationRecord').call
+
+        expect(results.first[:file]).not_to start_with('/')
+        expect(results.first[:file]).to eq('app/models/user.rb')
+      end
+
+      it 'returns the correct line number as an integer' do
+        results = make_searcher(pattern: 'ApplicationRecord').call
+
+        expect(results.first[:line_number]).to eq(1)
+        expect(results.first[:line_number]).to be_an(Integer)
+      end
+
+      it 'returns the matching line content' do
+        results = make_searcher(pattern: 'ApplicationRecord').call
+
+        expect(results.first[:content]).to include('ApplicationRecord')
+      end
+    end
+
+    context 'when there are no matches' do
+      before do
+        allow(Open3).to receive(:capture2).and_return(['', double(success?: true)])
+      end
+
+      it 'returns an empty array' do
+        results = make_searcher(pattern: 'ZZZ_IMPOSSIBLE_MATCH_XYZ').call
+
+        expect(results).to eq([])
+      end
+    end
+
+    context 'when Open3 raises a StandardError' do
+      before do
+        allow(Open3).to receive(:capture2).and_raise(StandardError, 'rg not found')
+      end
+
+      it 'returns a single error result hash' do
+        results = make_searcher(pattern: 'anything').call
+
+        expect(results.length).to eq(1)
+        expect(results.first[:file]).to eq('error')
+        expect(results.first[:line_number]).to eq(0)
+        expect(results.first[:content]).to eq('rg not found')
+      end
+    end
+
+    context 'with multiple matching files' do
+      before do
+        admin_rb_path = File.join(tmpdir, 'app/models/admin.rb')
+        rg_output = "#{user_rb_path}:1:class User\n#{admin_rb_path}:1:class Admin < User\n"
+        allow(Open3).to receive(:capture2).and_return([rg_output, double(success?: true)])
+      end
+
+      it 'returns one result per matching line' do
+        results = make_searcher(pattern: 'User').call
+
+        expect(results.length).to eq(2)
+        expect(results.pluck(:file)).to contain_exactly('app/models/user.rb', 'app/models/admin.rb')
+      end
+    end
+
+    context 'when output contains lines without the expected format' do
+      before do
+        # Mix of valid and unparseable lines
+        rg_output = "#{user_rb_path}:1:class User\nnot-a-valid-rg-line\n"
+        allow(Open3).to receive(:capture2).and_return([rg_output, double(success?: true)])
+      end
+
+      it 'silently skips malformed lines' do
+        results = make_searcher(pattern: 'User').call
+
+        expect(results.length).to eq(1)
+        expect(results.first[:file]).to eq('app/models/user.rb')
+      end
+    end
+  end
+
+  describe RailsAiBridge::Tools::SearchCode::RipgrepSearch::CommandBuilder do
+    subject(:builder) do
+      described_class.new(
+        pattern: pattern,
+        search_path: search_path,
+        file_type: file_type,
+        max_results: max_results
+      )
+    end
+
+    let(:pattern) { 'class User' }
+    let(:search_path) { '/rails/app/models' }
+    let(:file_type) { nil }
+    let(:max_results) { 50 }
+
+    describe '#build' do
+      it 'starts with the rg binary and core flags' do
+        cmd = builder.build
+
+        expect(cmd.first).to eq('rg')
+        expect(cmd).to include('--no-heading', '--line-number', '--max-count')
+      end
+
+      it 'includes the pattern as second-to-last token' do
+        cmd = builder.build
+
+        expect(cmd[-2]).to eq(pattern)
+      end
+
+      it 'includes the search path as the last token' do
+        cmd = builder.build
+
+        expect(cmd.last).to eq(search_path)
+      end
+
+      it 'includes the max_results value after --max-count' do
+        cmd = builder.build
+        idx = cmd.index('--max-count')
+
+        expect(cmd[idx + 1]).to eq('50')
+      end
+
+      context 'when file_type is nil' do
+        it 'includes --glob flags for each default allowed extension' do
+          cmd = builder.build
+          allowed = RailsAiBridge::Tools::SearchCode::DEFAULT_ALLOWED_FILE_TYPES
+
+          allowed.each do |ext|
+            expect(cmd).to include("*.#{ext}")
+          end
+        end
+
+        it 'does not include --type-add or --type flags' do
+          cmd = builder.build
+
+          expect(cmd).not_to include('--type-add')
+          expect(cmd).not_to include('--type')
+        end
+      end
+
+      context 'when file_type is specified' do
+        let(:file_type) { 'rb' }
+
+        it 'includes --type-add and --type custom flags' do
+          cmd = builder.build
+
+          expect(cmd).to include('--type-add')
+          expect(cmd).to include('--type')
+          expect(cmd).to include('custom:*.rb')
+          expect(cmd).to include('custom')
+        end
+
+        it 'does not add per-extension --glob flags' do
+          cmd = builder.build
+
+          expect(cmd).not_to include('*.erb')
+        end
+      end
+
+      context 'secret file exclusions' do
+        it 'includes --glob exclusion for .env files' do
+          cmd = builder.build
+
+          expect(cmd).to include('!.env')
+        end
+
+        it 'includes --glob exclusion for .pem files' do
+          cmd = builder.build
+
+          expect(cmd).to include('!*.pem')
+        end
+
+        it 'includes --glob exclusion for .key files' do
+          cmd = builder.build
+
+          expect(cmd).to include('!*.key')
+        end
+
+        it 'excludes all SECRET_EXCLUDES globs' do
+          cmd = builder.build
+          excludes = RailsAiBridge::Tools::SearchCode::RipgrepSearch::CommandBuilder::SECRET_EXCLUDES
+
+          excludes.each do |glob|
+            expect(cmd).to include("!#{glob}"), "expected cmd to exclude #{glob}"
+          end
+        end
+      end
+
+      context 'excluded_paths from configuration' do
+        it 'adds --glob exclusion for each configured excluded path' do
+          allow(RailsAiBridge.configuration).to receive(:excluded_paths).and_return(%w[vendor/ node_modules])
+
+          cmd = builder.build
+
+          expect(cmd).to include('!vendor/')
+          expect(cmd).to include('!node_modules')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/tools_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'MCP Tool Integration' do
     end
 
     it 'builds with all tools registered' do
-      expect(server.tools.size).to eq(12)
+      expect(server.tools.size).to eq(13)
       expect(server.tools.keys).to contain_exactly(
         'rails_get_schema',
         'rails_get_routes',
@@ -50,7 +50,8 @@ RSpec.describe 'MCP Tool Integration' do
         'rails_get_config',
         'rails_get_test_info',
         'rails_get_view',
-        'rails_get_stimulus'
+        'rails_get_stimulus',
+        'rails_list_registry'
       )
     end
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/igmarin/rails-ai-bridge/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill pack registry with in-memory resolver caching (configurable TTL) and explicit invalidation (including on dev reload)
  * CLI/MCP tooling: rails_list_registry tool and rake tasks to list, resolve, and clear registry cache
  * Git-backed packs: ref pinning, per-pack pull freshness TTL, git timeouts, and stable local pack naming

* **Documentation**
  * New guides: registry guide, resolver reference, offline-mode plan, and related docs

* **Bug Fixes**
  * Reject plain http:// sources and warn on missing pack dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->