### PR TITLE
fix(security): add CSRF protection to test fixture ApplicationControllers

### DIFF
--- a/spec/fixtures/apps/hotwire_crud/app/controllers/application_controller.rb
+++ b/spec/fixtures/apps/hotwire_crud/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
 # Base browser controller for the Hotwire CRUD fixture.
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end

--- a/spec/fixtures/apps/large_schema_crm/app/controllers/application_controller.rb
+++ b/spec/fixtures/apps/large_schema_crm/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
 # Base browser controller for the large-schema CRM fixture.
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end

--- a/spec/fixtures/apps/regulated_no_domain/app/controllers/application_controller.rb
+++ b/spec/fixtures/apps/regulated_no_domain/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
 # Base browser controller for the regulated no-domain fixture.
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end

--- a/spec/internal/app/controllers/application_controller.rb
+++ b/spec/internal/app/controllers/application_controller.rb
@@ -4,4 +4,5 @@
 # This is the base controller for the entire application,
 # providing common functionality for all controllers.
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end

--- a/spec/lib/rails_ai_bridge/application_controller_csrf_spec.rb
+++ b/spec/lib/rails_ai_bridge/application_controller_csrf_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'ApplicationController CSRF protection in test fixtures' do
+  def fixture_paths
+    [
+      'spec/internal/app/controllers/application_controller.rb',
+      'spec/fixtures/apps/hotwire_crud/app/controllers/application_controller.rb',
+      'spec/fixtures/apps/large_schema_crm/app/controllers/application_controller.rb',
+      'spec/fixtures/apps/regulated_no_domain/app/controllers/application_controller.rb'
+    ]
+  end
+
+  def project_root
+    Pathname.new(__dir__).join('..', '..', '..').expand_path
+  end
+
+  it 'enables protect_from_forgery in all fixture ApplicationControllers' do
+    fixture_paths.each do |relative_path|
+      absolute_path = project_root.join(relative_path).to_s
+      expect(File.read(absolute_path)).to include('protect_from_forgery')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `protect_from_forgery with: :exception` to all four test/fixture
ApplicationController classes and adds a spec to ensure they keep the
directive.

## Closes

Closes #49

## Test plan

- [x] Added failing spec first, then implemented the fix.
- [x] `bundle exec rspec spec/lib/rails_ai_bridge/application_controller_csrf_spec.rb spec/lib/rails_ai_bridge/introspectors/controller_introspector_spec.rb` passes (15 examples, 0 failures).
- [x] `bundle exec rubocop` on the changed files passes.

Generated with [Devin](https://devin.ai)