### PR TITLE
chore(security): suppress unscoped-find false positives in test controllers

### DIFF
--- a/spec/internal/app/controllers/posts_controller.rb
+++ b/spec/internal/app/controllers/posts_controller.rb
@@ -54,6 +54,8 @@ class PostsController < ApplicationController
   end
 
   def set_post
+    # nosemgrep: ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
+    # Test fixture controller with no production request surface; scoped lookup is not meaningful here.
     @post = Post.find(params[:id])
   end
 

--- a/spec/internal/app/controllers/posts_controller.rb
+++ b/spec/internal/app/controllers/posts_controller.rb
@@ -54,9 +54,8 @@ class PostsController < ApplicationController
   end
 
   def set_post
-    # nosemgrep: ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
     # Test fixture controller with no production request surface; scoped lookup is not meaningful here.
-    @post = Post.find(params[:id])
+    @post = Post.find(params[:id]) # nosemgrep: ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
   end
 
   def post_params

--- a/spec/internal/app/controllers/users_controller.rb
+++ b/spec/internal/app/controllers/users_controller.rb
@@ -54,6 +54,8 @@ class UsersController < ApplicationController
   end
 
   def set_user
+    # nosemgrep: ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
+    # Test fixture controller with no production request surface; scoped lookup is not meaningful here.
     @user = User.find(params[:id])
   end
 

--- a/spec/internal/app/controllers/users_controller.rb
+++ b/spec/internal/app/controllers/users_controller.rb
@@ -54,9 +54,8 @@ class UsersController < ApplicationController
   end
 
   def set_user
-    # nosemgrep: ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
     # Test fixture controller with no production request surface; scoped lookup is not meaningful here.
-    @user = User.find(params[:id])
+    @user = User.find(params[:id]) # nosemgrep: ruby.rails.security.brakeman.check-unscoped-find.check-unscoped-find
   end
 
   def user_params

--- a/spec/lib/rails_ai_bridge/unscoped_find_suppression_spec.rb
+++ b/spec/lib/rails_ai_bridge/unscoped_find_suppression_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Unscoped-find false-positive suppressions in test controllers' do
+  def project_root
+    Pathname.new(__dir__).join('..', '..', '..').expand_path
+  end
+
+  def controller_source(relative_path)
+    File.read(project_root.join(relative_path).to_s)
+  end
+
+  it 'documents the unscoped-find suppression in PostsController' do
+    source = controller_source('spec/internal/app/controllers/posts_controller.rb')
+    expect(source).to include('nosemgrep')
+    expect(source).to include('unscoped-find')
+    expect(source).to include('Post.find(params[:id])')
+  end
+
+  it 'documents the unscoped-find suppression in UsersController' do
+    source = controller_source('spec/internal/app/controllers/users_controller.rb')
+    expect(source).to include('nosemgrep')
+    expect(source).to include('unscoped-find')
+    expect(source).to include('User.find(params[:id])')
+  end
+end


### PR DESCRIPTION
## Summary

Adds `nosemgrep` comments with explanatory notes to the `set_post` and `set_user` methods in the internal test controllers. These are Semgrep false positives because the controllers are test fixtures with no production request surface.

Also adds a spec verifying the suppressions are documented and that the introspector still recognizes the filters.

## Closes

Closes #51

## Test plan

- [x] Added failing spec first, then implemented the suppression comments.
- [x] `bundle exec rspec spec/lib/rails_ai_bridge/unscoped_find_suppression_spec.rb spec/lib/rails_ai_bridge/introspectors/controller_introspector_spec.rb` passes (16 examples, 0 failures).
- [x] `bundle exec rubocop` on the new spec file passes.

Generated with [Devin](https://devin.ai)