### PR TITLE
fix(security): harden rails_search_code ripgrep command

### DIFF
--- a/lib/rails_ai_bridge/doctor/checkers/ripgrep_checker.rb
+++ b/lib/rails_ai_bridge/doctor/checkers/ripgrep_checker.rb
@@ -9,9 +9,15 @@ module RailsAiBridge
       class RipgrepChecker < BaseChecker
         # @return [Doctor::Check] +:pass+ when +rg+ is found; +:warn+ otherwise
         def call
+          available = begin
+            Open3.capture2('rg', '--version').last.success?
+          rescue Errno::ENOENT
+            false
+          end
+
           check(
             'ripgrep',
-            Open3.capture2('rg', '--version').last.success?,
+            available,
             pass: { message: 'rg available for code search' },
             fail: { status: :warn, message: 'ripgrep not installed (code search will use slower Ruby fallback)',
                     fix: 'Install with `brew install ripgrep` or `apt install ripgrep`' }

--- a/lib/rails_ai_bridge/doctor/checkers/ripgrep_checker.rb
+++ b/lib/rails_ai_bridge/doctor/checkers/ripgrep_checker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 module RailsAiBridge
   class Doctor
     module Checkers
@@ -9,7 +11,7 @@ module RailsAiBridge
         def call
           check(
             'ripgrep',
-            system('which rg > /dev/null 2>&1'),
+            Open3.capture2('rg', '--version').last.success?,
             pass: { message: 'rg available for code search' },
             fail: { status: :warn, message: 'ripgrep not installed (code search will use slower Ruby fallback)',
                     fix: 'Install with `brew install ripgrep` or `apt install ripgrep`' }

--- a/lib/rails_ai_bridge/tools/search_code.rb
+++ b/lib/rails_ai_bridge/tools/search_code.rb
@@ -74,6 +74,8 @@ module RailsAiBridge
         return @ripgrep_available if instance_variable_defined?(:@ripgrep_available)
 
         @ripgrep_available = Open3.capture2('rg', '--version').last.success?
+      rescue Errno::ENOENT
+        @ripgrep_available = false
       end
 
       def self.with_search_timeout(&)

--- a/lib/rails_ai_bridge/tools/search_code.rb
+++ b/lib/rails_ai_bridge/tools/search_code.rb
@@ -71,8 +71,9 @@ module RailsAiBridge
       end
 
       def self.ripgrep_available?
-        @ripgrep_available = system('which rg > /dev/null 2>&1') unless instance_variable_defined?(:@ripgrep_available)
-        @ripgrep_available
+        return @ripgrep_available if instance_variable_defined?(:@ripgrep_available)
+
+        @ripgrep_available = Open3.capture2('rg', '--version').last.success?
       end
 
       def self.with_search_timeout(&)

--- a/lib/rails_ai_bridge/tools/search_code/ripgrep_search.rb
+++ b/lib/rails_ai_bridge/tools/search_code/ripgrep_search.rb
@@ -78,7 +78,7 @@ module RailsAiBridge
             cmd.concat(excluded_path_flags)
             cmd.concat(secret_exclude_flags)
             cmd.concat(file_type_filters)
-            cmd.push(@pattern, @path)
+            cmd.push('--', @pattern, @path)
           end
 
           private

--- a/spec/lib/rails_ai_bridge/tools/search_code/ripgrep_search_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/search_code/ripgrep_search_spec.rb
@@ -154,10 +154,17 @@ RSpec.describe RailsAiBridge::Tools::SearchCode::RipgrepSearch do
         expect(cmd).to include('--no-heading', '--line-number', '--max-count')
       end
 
-      it 'includes the pattern as second-to-last token' do
+      it 'includes a -- separator before the pattern and search path' do
         cmd = builder.build
 
-        expect(cmd[-2]).to eq(pattern)
+        expect(cmd).to include('--')
+      end
+
+      it 'includes the pattern immediately after the -- separator' do
+        cmd = builder.build
+        separator_index = cmd.index('--')
+
+        expect(cmd[separator_index + 1]).to eq(pattern)
       end
 
       it 'includes the search path as the last token' do

--- a/spec/lib/rails_ai_bridge/tools/search_code_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/search_code_spec.rb
@@ -109,11 +109,12 @@ RSpec.describe RailsAiBridge::Tools::SearchCode do
 
     it 'memoizes a missing ripgrep executable' do
       described_class.remove_instance_variable(:@ripgrep_available) if described_class.instance_variable_defined?(:@ripgrep_available)
-      allow(described_class).to receive(:system).and_return(false)
+      status = instance_double(Process::Status, success?: false)
+      allow(Open3).to receive(:capture2).with('rg', '--version').and_return(['', status])
 
       2.times { described_class.send(:ripgrep_available?) }
 
-      expect(described_class).to have_received(:system).once
+      expect(Open3).to have_received(:capture2).once
     ensure
       described_class.remove_instance_variable(:@ripgrep_available) if described_class.instance_variable_defined?(:@ripgrep_available)
     end

--- a/spec/lib/rails_ai_bridge/tools/search_code_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/search_code_spec.rb
@@ -118,5 +118,14 @@ RSpec.describe RailsAiBridge::Tools::SearchCode do
     ensure
       described_class.remove_instance_variable(:@ripgrep_available) if described_class.instance_variable_defined?(:@ripgrep_available)
     end
+
+    it 'returns false when rg is not on PATH' do
+      described_class.remove_instance_variable(:@ripgrep_available) if described_class.instance_variable_defined?(:@ripgrep_available)
+      allow(Open3).to receive(:capture2).with('rg', '--version').and_raise(Errno::ENOENT)
+
+      expect(described_class.send(:ripgrep_available?)).to be false
+    ensure
+      described_class.remove_instance_variable(:@ripgrep_available) if described_class.instance_variable_defined?(:@ripgrep_available)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Adds a `--` separator before the pattern and search path in `RipgrepSearch::CommandBuilder` so ripgrep always treats them as positional arguments.
- Replaces shell-based `system('which rg ...')` with direct `Open3.capture2('rg', '--version')` detection in `SearchCode` and the `Doctor::RipgrepChecker`.
- Updates specs to assert the new command shape and ripgrep detection.

## Closes

Closes #52

## Test plan

- [x] Added failing specs first, then implemented the fix.
- [x] `bundle exec rspec spec/lib/rails_ai_bridge/tools/search_code/ripgrep_search_spec.rb spec/lib/rails_ai_bridge/tools/search_code_spec.rb` passes (36 examples, 0 failures).
- [x] `bundle exec rubocop` on the changed files passes.

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the search tool so the app more reliably recognizes when code search is available.
  * Handles missing command-line tools more gracefully and falls back cleanly when unavailable.
  * Updated search command handling to keep search patterns and paths from being interpreted as options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->