### PR TITLE
docs(release): update SECURITY.md and CHANGELOG for v3.5.1, bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.1]
+
+### Security
+
+- Harden `DefaultGitRunner` git commands against option injection by validating clone URL/destination and using `--` separators for `git clone`; add `nosemgrep` suppressions for documented false positives in `git pull` and `git checkout`.
+- Add `protect_from_forgery` to all test/fixture `ApplicationController` classes.
+- Replace `content_tag` with `tag.h1` in the internal test `ApplicationHelper` and rename the misleading `raw` variable in `Config::Mcp`.
+- Add `nosemgrep` comments with explanatory notes for unscoped-find false positives in internal test controllers.
+- Harden `rails_search_code` ripgrep command with a `--` separator and replace shell-based `which rg` detection with direct `rg --version` checks.
 
 ### Added
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ please report it responsibly:
   credentials are omitted from introspection and the `rails://config` resource by
   default; set `config.expose_credentials_key_names = true` only if you accept
   that metadata exposure.
-- The gem does not make any outbound network requests.
+- The gem does not make outbound network requests except when the skill-pack registry is configured with a git source, in which case `git clone` / `git pull` fetches remote pack repositories.
 - The main risk is **information exposure**, not mutation: schema names, routes,
   controller structure, and code excerpts may still be sensitive in some environments.
 

--- a/lib/rails_ai_bridge/version.rb
+++ b/lib/rails_ai_bridge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiBridge
-  VERSION = '3.5.0'
+  VERSION = '3.5.1'
 end


### PR DESCRIPTION
## Summary

- Corrects `SECURITY.md` to state that outbound network requests only occur when git skill-pack sources are configured.
- Adds the [3.5.1] CHANGELOG section with a Security summary covering all v3.5.1 remediation work.
- Bumps the gem version to `3.5.1`.

## Closes

Closes #53

## Test plan

- [x] Verified `RailsAiBridge::VERSION == '3.5.1'`.
- [x] `bundle exec rubocop lib/rails_ai_bridge/version.rb` passes.

Generated with [Devin](https://devin.ai)