### PR TITLE
security(http): log authorize lambda denials

### DIFF
--- a/lib/rails_ai_bridge/http_transport_app.rb
+++ b/lib/rails_ai_bridge/http_transport_app.rb
@@ -35,13 +35,16 @@ module RailsAiBridge
 
           authorize = RailsAiBridge.configuration.mcp.authorize
           if authorize
-            authorized = begin
-              authorize.call(auth_result.context, request)
+            begin
+              authorized = authorize.call(auth_result.context, request)
             rescue StandardError => error
-              Rails.logger.error("rails_ai_bridge: authorize lambda raised #{error.class}: #{error.message}") if defined?(Rails)
-              false
+              Rails.logger.error("rails_ai_bridge: authorize lambda raised #{error.class}: #{error.message}") if defined?(Rails) && Rails.logger
+              Mcp::HttpStructuredLog.emit(request: request, event: :forbidden, http_status: 403)
+              return [403, { 'Content-Type' => 'application/json' }, ['{"error":"Forbidden"}']]
             end
+
             unless authorized
+              Rails.logger.warn("rails_ai_bridge: authorize lambda denied access for #{request.ip} at #{request.path}") if defined?(Rails) && Rails.logger
               Mcp::HttpStructuredLog.emit(request: request, event: :forbidden, http_status: 403)
               return [403, { 'Content-Type' => 'application/json' }, ['{"error":"Forbidden"}']]
             end

--- a/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
+++ b/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'mcp'
 
 RSpec.describe RailsAiBridge::HttpTransportApp do
   let(:transport) { instance_double(MCP::Server::Transports::StreamableHTTPTransport) }
@@ -111,13 +112,16 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
       env = Rack::MockRequest.env_for(
         '/mcp',
         method: 'POST',
-        'HTTP_AUTHORIZATION' => 'Bearer secret'
+        'HTTP_AUTHORIZATION' => 'Bearer secret',
+        'REMOTE_ADDR' => '10.0.0.5'
       )
 
+      allow(Rails.logger).to receive(:warn)
       status, _headers, body = app.call(env)
 
       expect(status).to eq(403)
       expect(body.first).to include('Forbidden')
+      expect(Rails.logger).to have_received(:warn).with(%r{authorize lambda denied access for 10\.0\.0\.5 at /mcp})
     end
 
     it 'returns 403 when authorize lambda raises' do
@@ -132,11 +136,13 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
       )
 
       allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
       status, _headers, body = app.call(env)
 
       expect(status).to eq(403)
       expect(body.first).to include('Forbidden')
       expect(Rails.logger).to have_received(:error).with(/authorize lambda raised/)
+      expect(Rails.logger).not_to have_received(:warn)
     end
 
     it 'emits a structured log when http_log_json is enabled' do


### PR DESCRIPTION
## What

Adds a `Rails.logger.warn` entry when the configured MCP `authorize` lambda returns a falsey value. Previously only raised exceptions were logged; falsey returns silently produced HTTP 403, making it hard to debug access-denied requests in production.

The log line intentionally includes only the client IP and request path — no tokens, auth context, or PII.

## Why

Closes #64.

## Changes

- `lib/rails_ai_bridge/http_transport_app.rb`: warn when `authorize` denies access.
- `spec/lib/rails_ai_bridge/http_transport_app_spec.rb`: assert the warning and add `require 'mcp'` so the spec is self-contained.

## Verification

- `bundle exec rspec` → 2100 examples, 0 failures
- `bundle exec rubocop` → 412 files inspected, no offenses detected
- `bundle audit` → No vulnerabilities found


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning log when access is denied by authorization, including the request IP and path when logging is available.
  * Existing denied-request behavior still returns the same 403 response and structured log entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->