### PR TITLE
security(http): add CORS support to MCP HTTP endpoint

### DIFF
--- a/lib/generators/rails_ai_bridge/install/install_generator.rb
+++ b/lib/generators/rails_ai_bridge/install/install_generator.rb
@@ -188,6 +188,11 @@ module RailsAiBridge
             # Timing-safe token comparison is built in, but add rate limiting too
             # (e.g. Rack::Attack throttle on config.http_path) to prevent brute-force.
             #
+            # CORS for browser-based AI clients connecting over SSE.
+            # Default is nil (no CORS headers). Set to ['*'] to allow any origin,
+            # or to a list of exact origins such as ['https://app.example.com'].
+            # config.mcp.cors_origins = ['https://app.example.com']
+            #
             # config.auto_mount = false
             # config.allow_auto_mount_in_production = false
             # config.http_path = "/mcp"

--- a/lib/rails_ai_bridge/config/mcp.rb
+++ b/lib/rails_ai_bridge/config/mcp.rb
@@ -68,6 +68,12 @@ module RailsAiBridge
       # @return [Boolean]
       attr_accessor :require_http_auth
 
+      # Allowed origins for CORS on the HTTP MCP endpoint.
+      # +nil+ or empty array disables CORS headers (default). Pass +['*']+ to allow any origin,
+      # or a list of exact origins such as +['https://app.example.com']+.
+      # @return [Array<String>, nil]
+      attr_accessor :cors_origins
+
       def initialize
         @mode                     = :hybrid
         @security_profile         = :balanced
@@ -77,6 +83,7 @@ module RailsAiBridge
         @authorize                = nil
         @require_auth_in_production = false
         @require_http_auth          = false
+        @cors_origins = nil
       end
 
       # Effective rate-limit ceiling for {HttpTransportApp} (+0+ means disabled).

--- a/lib/rails_ai_bridge/http_transport_app.rb
+++ b/lib/rails_ai_bridge/http_transport_app.rb
@@ -16,11 +16,15 @@ module RailsAiBridge
                        Mcp::HttpRateLimiter.new(max_requests: max_reqs,
                                                 window_seconds: window_sec)
                      end
+        cors_origins = Array(mcp_cfg.cors_origins).reject(&:empty?)
 
         lambda do |env|
           return [404, { 'Content-Type' => 'application/json' }, ['{"error":"Not found"}']] unless [path, "#{path}/"].include?(env['PATH_INFO'])
 
           request = Rack::Request.new(env)
+          cors_headers = build_cors_headers(request.get_header('HTTP_ORIGIN'), cors_origins)
+
+          return [204, cors_headers, ['']] if request.request_method == 'OPTIONS' && cors_headers
 
           if mcp_cfg.require_http_auth && !Mcp::Authenticator.any_configured?
             Mcp::HttpStructuredLog.emit(request: request, event: :unauthorized, http_status: 401)
@@ -58,8 +62,28 @@ module RailsAiBridge
 
           response = transport.handle_request(request)
           Mcp::HttpStructuredLog.emit(request: request, event: :handled, http_status: response.first)
+          response[1].merge!(cors_headers) if cors_headers
           response
         end
+      end
+
+      private
+
+      # Builds CORS response headers when the request origin is allowed.
+      #
+      # @param origin [String, nil] value of the Origin header
+      # @param cors_origins [Array<String>] configured allowed origins
+      # @return [Hash{String => String}, nil] headers to add, or +nil+ when CORS is disabled/unmatched
+      def build_cors_headers(origin, cors_origins)
+        return nil if cors_origins.empty?
+        return nil if origin.blank?
+        return nil unless cors_origins.include?('*') || cors_origins.include?(origin)
+
+        {
+          'Access-Control-Allow-Origin' => origin,
+          'Access-Control-Allow-Methods' => 'GET, POST, OPTIONS',
+          'Access-Control-Allow-Headers' => 'Authorization, Content-Type'
+        }
       end
     end
   end

--- a/spec/lib/rails_ai_bridge/config/mcp_spec.rb
+++ b/spec/lib/rails_ai_bridge/config/mcp_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe RailsAiBridge::Config::Mcp do
       expect(config.authorize).to be_nil
       expect(config.require_auth_in_production).to be(false)
       expect(config.require_http_auth).to be(false)
+      expect(config.cors_origins).to be_nil
     end
   end
 

--- a/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
+++ b/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
     saved_log      = RailsAiBridge.configuration.mcp.http_log_json
     saved_authorize = RailsAiBridge.configuration.mcp.authorize
     saved_require_http_auth = RailsAiBridge.configuration.mcp.require_http_auth
+    saved_cors_origins = RailsAiBridge.configuration.mcp.cors_origins
     example.run
   ensure
     RailsAiBridge.configuration.http_mcp_token = saved_token
@@ -19,6 +20,7 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
     RailsAiBridge.configuration.mcp.http_log_json = saved_log
     RailsAiBridge.configuration.mcp.authorize = saved_authorize
     RailsAiBridge.configuration.mcp.require_http_auth = saved_require_http_auth
+    RailsAiBridge.configuration.mcp.cors_origins = saved_cors_origins
   end
 
   describe '.build' do
@@ -159,6 +161,79 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
 
       allow(Rails.logger).to receive(:info).at_least(:once)
       app.call(env)
+    end
+
+    it 'returns no CORS headers by default' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      allow(transport).to receive(:handle_request).and_return([200, {}, ['OK']])
+      app = described_class.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for(
+        '/mcp',
+        method: 'POST',
+        'HTTP_AUTHORIZATION' => 'Bearer secret',
+        'HTTP_ORIGIN' => 'https://example.com'
+      )
+
+      _status, headers, = app.call(env)
+
+      expect(headers).not_to have_key('Access-Control-Allow-Origin')
+    end
+
+    it 'adds CORS headers for allowed origins' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.cors_origins = ['https://example.com']
+      allow(transport).to receive(:handle_request).and_return([200, {}, ['OK']])
+      app = described_class.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for(
+        '/mcp',
+        method: 'POST',
+        'HTTP_AUTHORIZATION' => 'Bearer secret',
+        'HTTP_ORIGIN' => 'https://example.com'
+      )
+
+      _status, headers, = app.call(env)
+
+      expect(headers['Access-Control-Allow-Origin']).to eq('https://example.com')
+      expect(headers['Access-Control-Allow-Methods']).to eq('GET, POST, OPTIONS')
+    end
+
+    it 'handles CORS preflight requests without auth' do
+      RailsAiBridge.configuration.mcp.cors_origins = ['https://example.com']
+      allow(transport).to receive(:handle_request)
+      app = described_class.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for(
+        '/mcp',
+        method: 'OPTIONS',
+        'HTTP_ORIGIN' => 'https://example.com'
+      )
+
+      status, headers, body = app.call(env)
+
+      expect(status).to eq(204)
+      expect(headers['Access-Control-Allow-Origin']).to eq('https://example.com')
+      expect(body.first).to be_empty
+      expect(transport).not_to have_received(:handle_request)
+    end
+
+    it 'rejects CORS requests from disallowed origins' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.cors_origins = ['https://allowed.com']
+      allow(transport).to receive(:handle_request).and_return([200, {}, ['OK']])
+      app = described_class.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for(
+        '/mcp',
+        method: 'POST',
+        'HTTP_AUTHORIZATION' => 'Bearer secret',
+        'HTTP_ORIGIN' => 'https://denied.com'
+      )
+
+      _status, headers, = app.call(env)
+
+      expect(headers).not_to have_key('Access-Control-Allow-Origin')
     end
   end
 end


### PR DESCRIPTION
## What

Adds CORS support to the MCP HTTP endpoint so browser-based AI clients (SSE) can connect without a reverse-proxy workaround.

## Changes

- `lib/rails_ai_bridge/config/mcp.rb`: new `cors_origins` accessor (default `nil` = disabled).
- `lib/rails_ai_bridge/http_transport_app.rb`: handles OPTIONS preflight and injects `Access-Control-Allow-*` headers when the origin is allowed.
- `lib/generators/rails_ai_bridge/install/install_generator.rb`: documents `config.mcp.cors_origins` in the generated initializer.
- Tests for defaults, allowed origins, disallowed origins, preflight, and response headers.

## Behavior

- `nil` or empty → no CORS headers (existing behavior).
- `['*']` → allow any origin.
- `['https://app.example.com']` → allow only that exact origin.

## Verification

- `bundle exec rspec` → 2104 examples, 0 failures
- `bundle exec rubocop` → no offenses
- `bundle audit` → no vulnerabilities

Closes #63
