### PR TITLE
feat(tools): add optional JSON output to routes and model tools

### DIFF
--- a/lib/rails_ai_bridge/tools/get_model_details.rb
+++ b/lib/rails_ai_bridge/tools/get_model_details.rb
@@ -21,6 +21,11 @@ module RailsAiBridge
             enum: %w[summary standard full],
             description: 'Detail level for model listing. summary: names only. standard: names + association/validation counts (default). full: names + full association list.
             Ignored when specific model is given (always returns full).'
+          },
+          format: {
+            type: 'string',
+            enum: %w[json markdown],
+            description: 'Output format. Default: markdown.'
           }
         }
       )
@@ -37,13 +42,13 @@ module RailsAiBridge
       # @param detail [String] +summary+, +standard+, or +full+ when listing (ignored when +model+ is set)
       # @param _server_context [Object, nil] reserved for MCP transport metadata (unused)
       # @return [MCP::Tool::Response] Markdown body or an error string wrapped for the MCP client
-      def self.call(model: nil, detail: 'standard', _server_context: nil)
+      def self.call(model: nil, detail: 'standard', format: 'markdown', _server_context: nil)
         models = cached_section(:models)
         return text_response('Model introspection not available. Add :models to introspectors.') unless models
         return text_response("Model introspection failed: #{models[:error]}") if models[:error]
 
         non_ar = cached_section(:non_ar_models)
-        formatter = ResponseFormatter.new(models, model: model, detail: detail, non_ar_models: non_ar)
+        formatter = ResponseFormatter.new(models, model: model, detail: detail, format: format, non_ar_models: non_ar)
         return text_response(formatter.model_not_found_message) if formatter.model_not_found?
         return text_response(formatter.model_error_message) if formatter.model_error?
 
@@ -57,10 +62,11 @@ module RailsAiBridge
         # @param model [String, nil] requested single-model name
         # @param detail [String] list detail level when +model+ is +nil+
         # @param non_ar_models [Hash, nil] +:non_ar_models+ introspection section (may be +nil+ if disabled)
-        def initialize(models, model:, detail:, non_ar_models: nil)
+        def initialize(models, model:, detail:, format:, non_ar_models: nil)
           @models = models
           @model = model
           @detail = detail
+          @format = format
           @non_ar_models = non_ar_models
         end
 
@@ -89,8 +95,10 @@ module RailsAiBridge
           "Error inspecting #{model_key}: #{model_data[:error]}"
         end
 
-        # @return [String] Markdown for one model, POJO stub, or full listing
+        # @return [String] Markdown/JSON for one model, POJO stub, or full listing
         def format
+          return json_payload if @format == 'json'
+
           if @model
             return pojo_detail_markdown if pojo_entry && !model_data
 
@@ -106,6 +114,16 @@ module RailsAiBridge
         end
 
         private
+
+        def json_payload
+          if @model
+            return pojo_entry.to_h.to_json if pojo_entry && !model_data
+
+            model_data.to_json
+          else
+            @models.to_json
+          end
+        end
 
         def pojo_entry
           return @pojo_entry if defined?(@pojo_entry)

--- a/lib/rails_ai_bridge/tools/get_routes.rb
+++ b/lib/rails_ai_bridge/tools/get_routes.rb
@@ -26,6 +26,11 @@ module RailsAiBridge
           offset: {
             type: 'integer',
             description: 'Skip routes for pagination. Default: 0.'
+          },
+          format: {
+            type: 'string',
+            enum: %w[json markdown],
+            description: 'Output format. Default: markdown.'
           }
         }
       )
@@ -38,12 +43,13 @@ module RailsAiBridge
       # @param offset [Integer] pagination offset
       # @param _server_context [Object, nil] reserved for MCP transport metadata (unused)
       # @return [MCP::Tool::Response] markdown routes output or an error message
-      def self.call(controller: nil, detail: 'standard', limit: nil, offset: 0, _server_context: nil)
+      def self.call(controller: nil, detail: 'standard', limit: nil, offset: 0, format: 'markdown', _server_context: nil)
         routes = cached_section(:routes)
         return text_response('Route introspection not available. Add :routes to introspectors.') unless routes
         return text_response("Route introspection failed: #{routes[:error]}") if routes[:error]
 
-        formatter = ResponseFormatter.new(routes, controller: controller, detail: detail, limit: limit, offset: offset)
+        formatter = ResponseFormatter.new(routes, controller: controller, detail: detail, limit: limit, offset: offset,
+                                                  format: format)
         return text_response(formatter.filter_error_message) if formatter.filter_error?
 
         text_response(formatter.format)
@@ -52,12 +58,13 @@ module RailsAiBridge
       # @private
       # Formats +:routes+ introspection for {GetRoutes}.
       class ResponseFormatter
-        def initialize(routes, controller:, detail:, limit:, offset:)
+        def initialize(routes, controller:, detail:, limit:, offset:, format:)
           @routes = routes
           @controller = controller
           @detail = detail
           @limit = limit
           @offset = [offset.to_i, 0].max
+          @format = format
           @by_controller = filter_by_controller
         end
 
@@ -70,6 +77,8 @@ module RailsAiBridge
         end
 
         def format
+          return json_payload if @format == 'json'
+
           case @detail
           when 'summary' then format_summary
           when 'standard' then format_standard
@@ -79,6 +88,14 @@ module RailsAiBridge
         end
 
         private
+
+        def json_payload
+          {
+            total: route_count,
+            offset: @offset,
+            controllers: @by_controller.sort.to_h
+          }.to_json
+        end
 
         def filter_by_controller
           return @routes[:by_controller] || {} unless @controller

--- a/spec/lib/rails_ai_bridge/tools/get_model_details_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_model_details_spec.rb
@@ -121,5 +121,42 @@ RSpec.describe RailsAiBridge::Tools::GetModelDetails do
         expect(content).to include('[POJO/Service]')
       end
     end
+
+    context "with format: 'json'" do
+      let(:params) { { format: 'json' } }
+
+      it 'returns all models as JSON' do
+        parsed = JSON.parse(content)
+        expect(parsed.keys).to contain_exactly('User', 'Post')
+        expect(parsed['User']['table_name']).to eq('users')
+      end
+    end
+
+    context "with format: 'json' for a specific model" do
+      let(:params) { { model: 'User', format: 'json' } }
+
+      it 'returns the model data as JSON' do
+        parsed = JSON.parse(content)
+        expect(parsed['table_name']).to eq('users')
+        expect(parsed['associations'].first['name']).to eq('posts')
+      end
+    end
+
+    context "with format: 'json' for a non-AR model" do
+      let(:non_ar_empty) do
+        {
+          non_ar_models: [
+            { name: 'OrderCalculator', relative_path: 'app/models/order_calculator.rb', tag: 'POJO/Service' }
+          ]
+        }
+      end
+      let(:params) { { model: 'OrderCalculator', format: 'json' } }
+
+      it 'returns the POJO entry as JSON' do
+        parsed = JSON.parse(content)
+        expect(parsed['name']).to eq('OrderCalculator')
+        expect(parsed['tag']).to eq('POJO/Service')
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/tools/get_routes_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_routes_spec.rb
@@ -106,5 +106,25 @@ RSpec.describe RailsAiBridge::Tools::GetRoutes do
         expect(content).to include('Route introspection failed: Something went wrong')
       end
     end
+
+    context "with format: 'json'" do
+      let(:params) { { format: 'json' } }
+
+      it 'returns the routes payload as JSON' do
+        parsed = JSON.parse(content)
+        expect(parsed['total']).to eq(4)
+        expect(parsed['controllers']).to include('posts', 'api/v1/users')
+      end
+    end
+
+    context "with format: 'json' and controller filter" do
+      let(:params) { { controller: 'posts', format: 'json' } }
+
+      it 'returns only the filtered routes as JSON' do
+        parsed = JSON.parse(content)
+        expect(parsed['controllers'].keys).to eq(['posts'])
+        expect(parsed['controllers']['posts'].size).to eq(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Adds optional `format: "json"` output to `rails_get_routes` and `rails_get_model_details`, matching the existing JSON support in `rails_get_schema`.

## Why

Programmatic consumers (scripts, IDEs, agents that prefer structured data) can now request raw introspection hashes instead of parsing markdown.

## Changes

- `lib/rails_ai_bridge/tools/get_routes.rb`: new `format` parameter; returns filtered routes payload as JSON when requested.
- `lib/rails_ai_bridge/tools/get_model_details.rb`: new `format` parameter; returns model data or full listing as JSON when requested.
- Tests for JSON output, controller filtering, single-model lookup, and non-AR POJO entries.

## Backward compatibility

Default remains `format: "markdown"`. No existing behavior changes.

## Verification

- `bundle exec rspec` → 2105 examples, 0 failures
- `bundle exec rubocop` → no offenses
- `bundle audit` → no vulnerabilities

Closes #68
