### PR TITLE
ci: add bundler-audit job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,22 @@ jobs:
 
       - name: Run perf specs
         run: bundle exec rspec --tag perf
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Update bundler-audit advisory database
+        run: bundle exec bundle-audit update
+
+      - name: Run bundler-audit
+        run: bundle exec bundle-audit check

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'bundler-audit', '~> 0.9'
   gem 'combustion', '~> 1.3'
   gem 'rails', '~> 8.1'
   gem 'reek', '~> 6.1'


### PR DESCRIPTION
## What

Adds a `bundle-audit` job to the CI workflow so dependency vulnerabilities are caught automatically on every push and PR.

## Changes

- Adds `bundler-audit` to the `:development, :test` Gemfile group (already resolved in lockfile).
- New `audit` job in `.github/workflows/ci.yml` that updates the advisory DB and runs `bundle-audit check`.

## Verification

- `bundle exec bundle-audit check` → No vulnerabilities found
- `bundle exec rspec` → 2109 examples, 0 failures
- `bundle exec rubocop` → no offenses

Closes #74
