### PR TITLE
feat(tools): cache MCP tool results by argument fingerprint

### DIFF
--- a/lib/rails_ai_bridge/config/mcp.rb
+++ b/lib/rails_ai_bridge/config/mcp.rb
@@ -74,6 +74,11 @@ module RailsAiBridge
       # @return [Array<String>, nil]
       attr_accessor :cors_origins
 
+      # TTL in seconds for MCP tool result caching by argument fingerprint.
+      # +0+ or negative disables caching. Default +0+ to keep existing behavior.
+      # @return [Integer]
+      attr_accessor :tool_result_cache_ttl
+
       def initialize
         @mode                     = :hybrid
         @security_profile         = :balanced
@@ -83,7 +88,13 @@ module RailsAiBridge
         @authorize                = nil
         @require_auth_in_production = false
         @require_http_auth          = false
-        @cors_origins = nil
+        @cors_origins             = nil
+        @tool_result_cache_ttl    = 0
+      end
+
+      # @return [Boolean] whether tool call results should be cached
+      def tool_result_cache_enabled?
+        tool_result_cache_ttl.to_i.positive?
       end
 
       # Effective rate-limit ceiling for {HttpTransportApp} (+0+ means disabled).

--- a/lib/rails_ai_bridge/configuration.rb
+++ b/lib/rails_ai_bridge/configuration.rb
@@ -114,7 +114,9 @@ module RailsAiBridge
                    :rate_limit_max_requests, :rate_limit_max_requests=,
                    :rate_limit_window_seconds, :rate_limit_window_seconds=,
                    :http_log_json, :http_log_json=,
-                   :require_http_auth, :require_http_auth=
+                   :require_http_auth, :require_http_auth=,
+                   :tool_result_cache_ttl, :tool_result_cache_ttl=,
+                   :tool_result_cache_enabled?
 
     # -- Config::Rubydex --------------------------------------------------------
     def_delegators :@rubydex,

--- a/lib/rails_ai_bridge/server.rb
+++ b/lib/rails_ai_bridge/server.rb
@@ -50,9 +50,14 @@ module RailsAiBridge
     end
 
     # Returns all available tool classes including additional configured tools.
-    # @return [Array<Class>] list of tool classes
+    # When tool result caching is enabled, built-in and additional tools are wrapped
+    # so identical argument fingerprints reuse cached +MCP::Tool::Response+ objects.
+    #
+    # @return [Array<Class, ToolResultCache::CachedTool>] list of tool classes
     def tool_classes
-      TOOLS + RailsAiBridge.configuration.additional_tools
+      (TOOLS + RailsAiBridge.configuration.additional_tools).map do |tool_class|
+        ToolResultCache.maybe_wrap(tool_class)
+      end
     end
 
     # Build and return the configured MCP::Server instance.

--- a/lib/rails_ai_bridge/tool_result_cache.rb
+++ b/lib/rails_ai_bridge/tool_result_cache.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'delegate'
+require 'digest'
+require 'json'
+require 'mcp'
+
+module RailsAiBridge
+  # Caches MCP tool call results keyed by a stable fingerprint of the arguments.
+  #
+  # The cache is in-memory, per-process, and TTL-based. It ignores +server_context+
+  # when fingerprinting so identical client requests share the same cached response.
+  #
+  # Enable by setting +config.mcp.tool_result_cache_ttl+ to a positive number of seconds.
+  class ToolResultCache
+    @cache = {}
+    @mutex = Mutex.new
+
+    # Wraps a tool class so that calls are routed through the cache.
+    class CachedTool < SimpleDelegator
+      def initialize(tool_class)
+        super
+        @tool_class = tool_class
+        @server_context_param = detect_server_context_param(tool_class.method(:call))
+      end
+
+      # @param server_context [Object, nil] passed by the MCP transport (ignored for cache keys)
+      # @param arguments [Hash] tool arguments from the client
+      # @return [MCP::Tool::Response]
+      def call(server_context: nil, **arguments)
+        ToolResultCache.fetch_response(@tool_class.tool_name, arguments) do
+          invoke_tool(arguments, server_context)
+        end
+      end
+
+      private
+
+      def invoke_tool(arguments, server_context)
+        case @server_context_param
+        when :server_context
+          @tool_class.call(**arguments, server_context: server_context)
+        when :_server_context
+          @tool_class.call(**arguments, _server_context: server_context)
+        else
+          @tool_class.call(**arguments)
+        end
+      end
+
+      def detect_server_context_param(method_object)
+        parameters = method_object.parameters
+        keyish = %i[key keyreq].freeze
+        return :server_context if parameters.any? { |type, name| name == :server_context && keyish.include?(type) }
+        return :_server_context if parameters.any? { |type, name| name == :_server_context && keyish.include?(type) }
+        return :server_context if parameters.any? { |type, _| type == :keyrest }
+
+        nil
+      end
+    end
+
+    class << self
+      # Wraps a tool class if caching is enabled; otherwise returns the class unchanged.
+      #
+      # @param tool_class [Class] an +MCP::Tool+ subclass
+      # @return [Class, CachedTool]
+      def maybe_wrap(tool_class)
+        enabled? ? wrap(tool_class) : tool_class
+      end
+
+      # Wraps a tool class so every call goes through the cache.
+      #
+      # @param tool_class [Class]
+      # @return [CachedTool]
+      def wrap(tool_class)
+        CachedTool.new(tool_class)
+      end
+
+      # Fetches a cached response or yields to compute it.
+      #
+      # @param tool_name [String]
+      # @param arguments [Hash]
+      # @yieldreturn [MCP::Tool::Response]
+      # @return [MCP::Tool::Response]
+      def fetch_response(tool_name, arguments)
+        return yield unless enabled?
+
+        key = cache_key(tool_name, arguments)
+
+        mutex.synchronize do
+          entry = cache[key]
+          return entry[:response] if entry && ttl_valid?(entry)
+        end
+
+        response = yield
+        mutex.synchronize { cache[key] = { response: response, fetched_at: monotonic_now } }
+        response
+      end
+
+      # Clears all cached tool results.
+      #
+      # @return [void]
+      def reset!
+        mutex.synchronize { @cache = {} }
+      end
+
+      # @return [Boolean] whether tool result caching is enabled
+      def enabled?
+        RailsAiBridge.configuration.mcp.tool_result_cache_ttl.to_i.positive?
+      end
+
+      private
+
+      attr_reader :cache, :mutex
+
+      def cache_key(tool_name, arguments)
+        "#{tool_name}:#{argument_fingerprint(arguments)}"
+      end
+
+      def argument_fingerprint(arguments)
+        normalized = arguments.transform_keys(&:to_s).sort.to_h
+        Digest::SHA256.hexdigest(JSON.generate(normalized))
+      end
+
+      def ttl_valid?(entry)
+        (monotonic_now - entry[:fetched_at]) < RailsAiBridge.configuration.mcp.tool_result_cache_ttl.to_i
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/server_spec.rb
+++ b/spec/lib/rails_ai_bridge/server_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe RailsAiBridge::Server do
         additional_tools: [],
         http_bind: 'localhost',
         http_port: 3000,
-        http_path: '/mcp'
+        http_path: '/mcp',
+        mcp: double(tool_result_cache_ttl: 0)
       )
     )
     allow(RailsAiBridge::Resources).to receive_messages(build_resources: [], build_templates: [])

--- a/spec/lib/rails_ai_bridge/tool_result_cache_spec.rb
+++ b/spec/lib/rails_ai_bridge/tool_result_cache_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::ToolResultCache do
+  around do |example|
+    original_ttl = RailsAiBridge.configuration.mcp.tool_result_cache_ttl
+    described_class.reset!
+    example.run
+  ensure
+    RailsAiBridge.configuration.mcp.tool_result_cache_ttl = original_ttl
+    described_class.reset!
+  end
+
+  describe '.enabled?' do
+    it 'is disabled when ttl is 0' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 0
+      expect(described_class).not_to be_enabled
+    end
+
+    it 'is enabled when ttl is positive' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      expect(described_class).to be_enabled
+    end
+  end
+
+  describe '.fetch_response' do
+    let(:response) { MCP::Tool::Response.new([{ type: 'text', text: 'hello' }]) }
+
+    it 'returns yielded response when caching is disabled' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 0
+      calls = 0
+
+      result = described_class.fetch_response('rails_test', { 'key' => 'value' }) do
+        calls += 1
+        response
+      end
+
+      expect(result).to eq(response)
+      expect(calls).to eq(1)
+
+      described_class.fetch_response('rails_test', { 'key' => 'value' }) do
+        calls += 1
+        response
+      end
+      expect(calls).to eq(2)
+    end
+
+    it 'caches yielded responses by tool name and argument fingerprint' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      calls = 0
+
+      2.times do
+        result = described_class.fetch_response('rails_test', { key: 'value' }) do
+          calls += 1
+          response
+        end
+        expect(result).to eq(response)
+      end
+
+      expect(calls).to eq(1)
+    end
+
+    it 'produces different keys for different arguments' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      calls = 0
+
+      described_class.fetch_response('rails_test', { key: 'a' }) do
+        calls += 1
+        response
+      end
+      described_class.fetch_response('rails_test', { key: 'b' }) do
+        calls += 1
+        response
+      end
+
+      expect(calls).to eq(2)
+    end
+
+    it 'produces different keys for different tools' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      calls = 0
+
+      described_class.fetch_response('rails_one', { key: 'value' }) do
+        calls += 1
+        response
+      end
+      described_class.fetch_response('rails_two', { key: 'value' }) do
+        calls += 1
+        response
+      end
+
+      expect(calls).to eq(2)
+    end
+
+    it 'expires entries after the configured ttl' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 0.01
+      calls = 0
+
+      described_class.fetch_response('rails_test', { key: 'value' }) do
+        calls += 1
+        response
+      end
+      sleep(0.02)
+      described_class.fetch_response('rails_test', { key: 'value' }) do
+        calls += 1
+        response
+      end
+
+      expect(calls).to eq(2)
+    end
+  end
+
+  describe '.maybe_wrap' do
+    let(:tool_class) do
+      Class.new(RailsAiBridge::Tools::BaseTool) do
+        tool_name 'rails_cached_demo'
+        description 'Demo'
+        input_schema(properties: {})
+
+        def self.call(**)
+          MCP::Tool::Response.new([{ type: 'text', text: 'ok' }])
+        end
+      end
+    end
+
+    it 'returns the original class when caching is disabled' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 0
+      expect(described_class.maybe_wrap(tool_class)).to eq(tool_class)
+    end
+
+    it 'returns a cached wrapper when caching is enabled' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      wrapped = described_class.maybe_wrap(tool_class)
+
+      expect(wrapped).to be_a(described_class::CachedTool)
+      expect(wrapped.tool_name).to eq('rails_cached_demo')
+    end
+
+    it 'caches calls through the wrapper' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      wrapped = described_class.maybe_wrap(tool_class)
+      calls = 0
+
+      allow(tool_class).to receive(:call).and_wrap_original do
+        calls += 1
+        MCP::Tool::Response.new([{ type: 'text', text: 'ok' }])
+      end
+
+      2.times { wrapped.call(key: 'value') }
+
+      expect(calls).to eq(1)
+    end
+
+    it 'passes server_context when the wrapped tool accepts it' do
+      ctx_tool = Class.new(RailsAiBridge::Tools::BaseTool) do
+        tool_name 'rails_ctx_demo'
+        description 'Demo'
+        input_schema(properties: {})
+
+        def self.call(server_context: nil, **)
+          MCP::Tool::Response.new([{ type: 'text', text: server_context.to_s }])
+        end
+      end
+
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      wrapped = described_class.maybe_wrap(ctx_tool)
+      context = { request_id: '123' }
+
+      result = wrapped.call(server_context: context)
+
+      expect(result.content.first[:text]).to eq(context.to_s)
+    end
+
+    it 'translates server_context for tools that use _server_context' do
+      underscore_tool = Class.new(RailsAiBridge::Tools::BaseTool) do
+        tool_name 'rails_underscore_demo'
+        description 'Demo'
+        input_schema(properties: {})
+
+        def self.call(ctx: nil, **)
+          MCP::Tool::Response.new([{ type: 'text', text: ctx.to_s }])
+        end
+      end
+
+      allow(underscore_tool).to receive(:method).with(:call).and_return(
+        double(parameters: [%i[key _server_context], %i[keyrest kwargs]])
+      )
+
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      wrapped = described_class.maybe_wrap(underscore_tool)
+      context = { request_id: '456' }
+
+      expect(underscore_tool).to receive(:call).with(_server_context: context).and_return(
+        MCP::Tool::Response.new([{ type: 'text', text: context.to_s }])
+      )
+
+      result = wrapped.call(server_context: context)
+
+      expect(result.content.first[:text]).to eq(context.to_s)
+    end
+  end
+end


### PR DESCRIPTION
Implements #71.

Adds an opt-in, TTL-based cache for MCP tool call results keyed by a SHA256 fingerprint of the tool arguments. The cache is disabled by default (`config.mcp.tool_result_cache_ttl = 0`).

Changes:
- New `RailsAiBridge::ToolResultCache` with `CachedTool` delegator
- Wraps built-in and additional tools in `Server#tool_classes` when enabled
- Preserves `server_context` forwarding for tools that accept it (including `_server_context`)
- Adds configuration attribute and full spec coverage

Closes #71