### PR TITLE
feat(mcp): pluggable and distributed HTTP rate limiting

### DIFF
--- a/lib/rails_ai_bridge/config/mcp.rb
+++ b/lib/rails_ai_bridge/config/mcp.rb
@@ -79,6 +79,19 @@ module RailsAiBridge
       # @return [Integer]
       attr_accessor :tool_result_cache_ttl
 
+      # Optional custom rate limiter for MCP HTTP requests.
+      #
+      # When set, it takes precedence over the in-memory {Mcp::HttpRateLimiter}.
+      # The object must respond to +allow?(ip)+ (preferred) or +call(ip)+ and return a truthy/falsey value.
+      # This enables distributed backends such as Redis, Rails.cache, or an external service.
+      #
+      # @return [#allow?, #call, nil]
+      attr_accessor :rate_limiter
+
+      # Key prefix used by the optional {Mcp::CacheRateLimiter} distributed rate limiter.
+      # @return [String]
+      attr_accessor :rate_limiter_key_prefix
+
       def initialize
         @mode                     = :hybrid
         @security_profile         = :balanced
@@ -90,6 +103,8 @@ module RailsAiBridge
         @require_http_auth          = false
         @cors_origins             = nil
         @tool_result_cache_ttl    = 0
+        @rate_limiter             = nil
+        @rate_limiter_key_prefix  = 'rab:rl'
       end
 
       # @return [Boolean] whether tool call results should be cached

--- a/lib/rails_ai_bridge/configuration.rb
+++ b/lib/rails_ai_bridge/configuration.rb
@@ -116,7 +116,9 @@ module RailsAiBridge
                    :http_log_json, :http_log_json=,
                    :require_http_auth, :require_http_auth=,
                    :tool_result_cache_ttl, :tool_result_cache_ttl=,
-                   :tool_result_cache_enabled?
+                   :tool_result_cache_enabled?,
+                   :rate_limiter, :rate_limiter=,
+                   :rate_limiter_key_prefix, :rate_limiter_key_prefix=
 
     # -- Config::Rubydex --------------------------------------------------------
     def_delegators :@rubydex,

--- a/lib/rails_ai_bridge/http_transport_app.rb
+++ b/lib/rails_ai_bridge/http_transport_app.rb
@@ -12,10 +12,8 @@ module RailsAiBridge
         mcp_cfg    = RailsAiBridge.configuration.mcp
         max_reqs   = mcp_cfg.effective_http_rate_limit_max_requests
         window_sec = mcp_cfg.effective_http_rate_limit_window_seconds
-        limiter    = if max_reqs.positive?
-                       Mcp::HttpRateLimiter.new(max_requests: max_reqs,
-                                                window_seconds: window_sec)
-                     end
+        limiter    = mcp_cfg.rate_limiter || build_default_rate_limiter(max_requests: max_reqs,
+                                                                        window_seconds: window_sec)
         cors_origins = Array(mcp_cfg.cors_origins).reject(&:empty?)
 
         lambda do |env|
@@ -54,7 +52,7 @@ module RailsAiBridge
             end
           end
 
-          if limiter && !limiter.allow?(request.ip)
+          if limiter && !rate_limiter_allow?(limiter, request)
             Mcp::HttpStructuredLog.emit(request: request, event: :rate_limited, http_status: 429)
             return [429, { 'Content-Type' => 'application/json', 'Retry-After' => window_sec.to_s },
                     ['{"error":"Too many requests"}']]
@@ -68,6 +66,28 @@ module RailsAiBridge
       end
 
       private
+
+      def build_default_rate_limiter(max_requests:, window_seconds:)
+        return nil unless max_requests.positive?
+
+        Mcp::HttpRateLimiter.new(max_requests: max_requests, window_seconds: window_seconds)
+      end
+
+      # Asks a configured rate limiter whether a request may proceed.
+      # Supports objects that expose +allow?(ip)+ (preferred) or +call(ip)+.
+      #
+      # @param limiter [#allow?, #call]
+      # @param request [Rack::Request]
+      # @return [Boolean]
+      def rate_limiter_allow?(limiter, request)
+        if limiter.respond_to?(:allow?)
+          limiter.allow?(request.ip)
+        elsif limiter.respond_to?(:call)
+          limiter.call(request.ip)
+        else
+          true
+        end
+      end
 
       # Builds CORS response headers when the request origin is allowed.
       #

--- a/lib/rails_ai_bridge/mcp/cache_rate_limiter.rb
+++ b/lib/rails_ai_bridge/mcp/cache_rate_limiter.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Mcp
+    # Distributed, fixed-window rate limiter backed by +Rails.cache+ (or any
+    # +ActiveSupport::Cache::Store+). Use it when the MCP HTTP endpoint runs
+    # behind multiple processes and the default in-memory limiter is insufficient.
+    #
+    # The limiter relies on the cache's +increment+ operation when available and
+    # falls back to read/write for stores that do not support atomic increments.
+    class CacheRateLimiter
+      # @param max_requests [Integer] allowed hits per window per client IP
+      # @param window_seconds [Integer] TTL for each client's counter
+      # @param cache [Object, nil] +ActiveSupport::Cache::Store+; defaults to +Rails.cache+
+      # @param key_prefix [String] prefix for cache keys
+      def initialize(max_requests:, window_seconds:, cache: nil, key_prefix: 'rab:rl')
+        @max_requests = max_requests
+        @window_seconds = window_seconds.to_i
+        @cache = cache
+        @key_prefix = key_prefix
+      end
+
+      # @param ip [String, nil] client identifier (blank values share the +unknown+ bucket)
+      # @return [Boolean] +true+ if the request may proceed
+      def allow?(ip)
+        store = cache_store
+        return true unless store
+
+        key = cache_key(ip)
+        count = increment(store, key)
+        count <= @max_requests
+      end
+
+      private
+
+      def cache_store
+        @cache || (defined?(Rails) && Rails.cache)
+      end
+
+      def cache_key(ip)
+        client = ip.to_s.presence || 'unknown'
+        "#{@key_prefix}:#{client}"
+      end
+
+      def increment(store, key)
+        if store.respond_to?(:increment)
+          store.increment(key, 1, expires_in: @window_seconds) || fallback_increment(store, key)
+        else
+          fallback_increment(store, key)
+        end
+      rescue StandardError
+        fallback_increment(store, key)
+      end
+
+      def fallback_increment(store, key)
+        if store.respond_to?(:increment)
+          store.write(key, 0, expires_in: @window_seconds, unless_exist: true)
+          store.increment(key, 1) || (store.read(key).to_i + 1)
+        else
+          store.write(key, store.read(key).to_i + 1, expires_in: @window_seconds)
+          store.read(key).to_i
+        end
+      rescue StandardError
+        1
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
+++ b/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
     saved_authorize = RailsAiBridge.configuration.mcp.authorize
     saved_require_http_auth = RailsAiBridge.configuration.mcp.require_http_auth
     saved_cors_origins = RailsAiBridge.configuration.mcp.cors_origins
+    saved_rate_limiter = RailsAiBridge.configuration.mcp.rate_limiter
     example.run
   ensure
     RailsAiBridge.configuration.http_mcp_token = saved_token
@@ -21,6 +22,7 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
     RailsAiBridge.configuration.mcp.authorize = saved_authorize
     RailsAiBridge.configuration.mcp.require_http_auth = saved_require_http_auth
     RailsAiBridge.configuration.mcp.cors_origins = saved_cors_origins
+    RailsAiBridge.configuration.mcp.rate_limiter = saved_rate_limiter
   end
 
   describe '.build' do
@@ -104,6 +106,75 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
       expect(status).to eq(429)
       expect(headers['Retry-After']).to eq('60')
       expect(body.first).to include('Too many requests')
+    end
+
+    it 'uses a configured rate_limiter object' do
+      custom = double('limiter')
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.rate_limiter = custom
+      RailsAiBridge.configuration.mcp.rate_limit_max_requests = 0
+      app = described_class.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for(
+        '/mcp',
+        method: 'POST',
+        'HTTP_AUTHORIZATION' => 'Bearer secret',
+        'REMOTE_ADDR' => '1.2.3.4'
+      )
+
+      allow(transport).to receive(:handle_request).and_return([200, {}, ['OK']])
+      expect(custom).to receive(:allow?).with('1.2.3.4').and_return(true, false)
+
+      expect(app.call(env).first).to eq(200)
+
+      status, headers, body = app.call(env)
+      expect(status).to eq(429)
+      expect(headers['Retry-After']).to eq('60')
+      expect(body.first).to include('Too many requests')
+    end
+
+    it 'uses a configured rate_limiter proc' do
+      allowed = { '1.2.3.4' => true }
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.rate_limiter = ->(ip) { allowed[ip] }
+      RailsAiBridge.configuration.mcp.rate_limit_max_requests = 0
+      app = described_class.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for(
+        '/mcp',
+        method: 'POST',
+        'HTTP_AUTHORIZATION' => 'Bearer secret',
+        'REMOTE_ADDR' => '1.2.3.4'
+      )
+
+      allow(transport).to receive(:handle_request).and_return([200, {}, ['OK']])
+      expect(app.call(env).first).to eq(200)
+
+      allowed['1.2.3.4'] = false
+      expect(app.call(env).first).to eq(429)
+    end
+
+    it 'uses CacheRateLimiter when configured' do
+      cache = ActiveSupport::Cache::MemoryStore.new
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.rate_limiter = RailsAiBridge::Mcp::CacheRateLimiter.new(
+        max_requests: 1,
+        window_seconds: 60,
+        cache: cache
+      )
+      RailsAiBridge.configuration.mcp.rate_limit_max_requests = 0
+      app = described_class.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for(
+        '/mcp',
+        method: 'POST',
+        'HTTP_AUTHORIZATION' => 'Bearer secret',
+        'REMOTE_ADDR' => '1.2.3.4'
+      )
+
+      allow(transport).to receive(:handle_request).and_return([200, {}, ['OK']])
+      expect(app.call(env).first).to eq(200)
+      expect(app.call(env).first).to eq(429)
     end
 
     it 'returns 403 when authorize lambda returns falsey' do

--- a/spec/lib/rails_ai_bridge/mcp/cache_rate_limiter_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/cache_rate_limiter_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::Mcp::CacheRateLimiter do
+  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+
+  describe '#allow?' do
+    it 'allows requests under the limit' do
+      limiter = described_class.new(max_requests: 3, window_seconds: 60, cache: cache)
+
+      3.times do
+        expect(limiter.allow?('1.2.3.4')).to be true
+      end
+    end
+
+    it 'denies when the limit is reached within the window' do
+      limiter = described_class.new(max_requests: 2, window_seconds: 60, cache: cache)
+
+      expect(limiter.allow?('1.2.3.4')).to be true
+      expect(limiter.allow?('1.2.3.4')).to be true
+      expect(limiter.allow?('1.2.3.4')).to be false
+    end
+
+    it 'tracks keys independently per IP' do
+      limiter = described_class.new(max_requests: 1, window_seconds: 60, cache: cache)
+
+      expect(limiter.allow?('10.0.0.1')).to be true
+      expect(limiter.allow?('10.0.0.2')).to be true
+    end
+
+    it 'resets the counter after the cache entry expires' do
+      limiter = described_class.new(max_requests: 1, window_seconds: 60, cache: cache)
+
+      expect(limiter.allow?('1.2.3.4')).to be true
+      expect(limiter.allow?('1.2.3.4')).to be false
+
+      cache.delete('rab:rl:1.2.3.4')
+
+      expect(limiter.allow?('1.2.3.4')).to be true
+    end
+
+    it 'uses the configured key prefix' do
+      limiter = described_class.new(max_requests: 1, window_seconds: 60, cache: cache, key_prefix: 'custom')
+
+      limiter.allow?('1.2.3.4')
+
+      expect(cache.exist?('custom:1.2.3.4')).to be true
+    end
+
+    it 'uses unknown bucket for blank IP' do
+      limiter = described_class.new(max_requests: 1, window_seconds: 60, cache: cache)
+
+      expect(limiter.allow?('')).to be true
+      expect(limiter.allow?(nil)).to be false
+    end
+
+    it 'falls back to read/write when the cache does not support increment' do
+      store = double('cache')
+      allow(store).to receive(:respond_to?).with(:increment).and_return(false)
+      allow(store).to receive(:write)
+      allow(store).to receive(:read).and_return(0, 1)
+
+      limiter = described_class.new(max_requests: 2, window_seconds: 60, cache: store)
+
+      expect(limiter.allow?('1.2.3.4')).to be true
+      expect(store).to have_received(:write).with('rab:rl:1.2.3.4', 1, expires_in: 60)
+    end
+
+    it 'allows all requests when no cache is available' do
+      allow(Rails).to receive(:cache).and_return(nil)
+      limiter = described_class.new(max_requests: 1, window_seconds: 60, cache: nil)
+
+      expect(limiter.allow?('1.2.3.4')).to be true
+      expect(limiter.allow?('1.2.3.4')).to be true
+    end
+  end
+end


### PR DESCRIPTION
Implements #69.

Makes the MCP HTTP rate limiter pluggable so deployments behind multiple processes can share a distributed backend.

Changes:
- New `config.mcp.rate_limiter` setting (object with `allow?(ip)` or `call(ip)`)
- New `RailsAiBridge::Mcp::CacheRateLimiter` backed by `Rails.cache` (works with Redis, Memcached, etc.)
- `HttpTransportApp` uses the configured limiter when present, otherwise keeps the in-memory sliding-window limiter
- Adds `rate_limiter_key_prefix` configuration
- Adds specs for custom limiters and cache-backed limiting

Closes #69