### PR TITLE
feat(security): warn when HTTP MCP starts without authentication

### DIFF
--- a/docs/mcp-security.md
+++ b/docs/mcp-security.md
@@ -10,6 +10,8 @@ A valid Bearer token (or JWT accepted by your decoder) grants access to read-onl
 
 By default, HTTP MCP allows anonymous access when no auth strategy is configured (backward compatible for local development). For servers reachable beyond localhost, set `config.mcp.require_http_auth = true` so unconfigured deployments return `401`, or configure `http_mcp_token`, `mcp_token_resolver`, or `mcp_jwt_decoder`. In production, also use `validate_http_mcp_server_in_production!` / `require_auth_in_production` as documented in the main README.
 
+In non-production environments, the standalone HTTP MCP server prints a one-time stderr warning when it starts without authentication to make the default behavior visible.
+
 ## Rate limiting and proxies
 
 Built-in rate limiting keys off the Rack request IP. Behind reverse proxies, configure Rails `trusted_proxies` so `request.ip` reflects the real client; otherwise limits may apply to the wrong address or be bypassed.

--- a/lib/generators/rails_ai_bridge/install/install_generator.rb
+++ b/lib/generators/rails_ai_bridge/install/install_generator.rb
@@ -185,6 +185,11 @@ module RailsAiBridge
             #      config.http_mcp_token = "generate-a-long-random-secret"
             #      # ENV["RAILS_AI_BRIDGE_MCP_TOKEN"] takes precedence when set
             #
+            # Require authentication on every HTTP MCP request. When true, requests
+            # return 401 unless one of the auth mechanisms above is configured.
+            # Default is false for backward compatibility with local development.
+            # config.mcp.require_http_auth = true
+            #
             # Timing-safe token comparison is built in, but add rate limiting too
             # (e.g. Rack::Attack throttle on config.http_path) to prevent brute-force.
             #

--- a/lib/rails_ai_bridge/server.rb
+++ b/lib/rails_ai_bridge/server.rb
@@ -22,6 +22,11 @@ module RailsAiBridge
     # Error message template for unknown transport types
     UNKNOWN_TRANSPORT_ERROR = 'Unknown transport: %s. Use :stdio, :http, or :streamable_http'
 
+    # Warning printed when HTTP MCP starts without authentication in non-production environments.
+    HTTP_AUTH_WARNING = '[rails-ai-bridge] WARNING: HTTP MCP is running without authentication. ' \
+                        'Set config.mcp.require_http_auth = true or configure http_mcp_token, ' \
+                        'mcp_token_resolver, or mcp_jwt_decoder before exposing this endpoint.'
+
     # Built-in MCP tools that are always available
     # These tools provide Rails application introspection capabilities
     TOOLS = [
@@ -119,6 +124,7 @@ module RailsAiBridge
       transport = create_http_transport(server)
       rack_app = build_rack_app(transport, config.http_path)
 
+      warn_if_http_mcp_unauthenticated
       log_http_startup(config)
       run_rack_server(rack_app, config)
     end
@@ -156,6 +162,18 @@ module RailsAiBridge
     def log_http_startup(config)
       warn format(HTTP_STARTUP_MESSAGE, config.http_bind, config.http_port, config.http_path)
       warn TOOLS_LIST_MESSAGE % tool_classes.map(&:tool_name).join(', ')
+    end
+
+    # Emits a one-time stderr warning when HTTP MCP starts without authentication
+    # in non-production environments. Production deployments either raise during
+    # validation or are assumed to be deliberately configured.
+    #
+    # @return [void]
+    def warn_if_http_mcp_unauthenticated
+      return if defined?(Rails) && Rails.env.production?
+      return if Mcp::Authenticator.any_configured?
+
+      warn HTTP_AUTH_WARNING
     end
 
     # Runs the Rack server with fallback for older Rack versions.

--- a/spec/lib/rails_ai_bridge/server_spec.rb
+++ b/spec/lib/rails_ai_bridge/server_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe RailsAiBridge::Server do
         allow(http_server).to receive_messages(create_http_transport: double, build_rack_app: double)
         allow(http_server).to receive(:log_http_startup)
         allow(http_server).to receive(:run_rack_server)
+        allow(RailsAiBridge::Mcp::Authenticator).to receive(:any_configured?).and_return(true)
       end
 
       it 'validates HTTP server in production' do
@@ -207,6 +208,30 @@ RSpec.describe RailsAiBridge::Server do
         http_server.send(:start_http, mcp_server)
 
         expect(http_server).to have_received(:run_rack_server).with(rack_app, RailsAiBridge.configuration)
+      end
+
+      it 'warns when HTTP MCP starts without authentication in non-production' do
+        mcp_server = double
+        allow(Rails.env).to receive(:production?).and_return(false)
+        allow(RailsAiBridge::Mcp::Authenticator).to receive(:any_configured?).and_return(false)
+
+        expect { http_server.send(:start_http, mcp_server) }.to output(/WARNING: HTTP MCP is running without authentication/).to_stderr
+      end
+
+      it 'does not warn when an auth strategy is configured' do
+        mcp_server = double
+        allow(Rails.env).to receive(:production?).and_return(false)
+        allow(RailsAiBridge::Mcp::Authenticator).to receive(:any_configured?).and_return(true)
+
+        expect { http_server.send(:start_http, mcp_server) }.not_to output.to_stderr
+      end
+
+      it 'does not warn in production' do
+        mcp_server = double
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow(RailsAiBridge::Mcp::Authenticator).to receive(:any_configured?).and_return(false)
+
+        expect { http_server.send(:start_http, mcp_server) }.not_to output.to_stderr
       end
     end
 


### PR DESCRIPTION
Implements #60.

Adds a one-time stderr warning when the standalone HTTP MCP server boots in a non-production environment without an authentication strategy. Also makes `config.mcp.require_http_auth` more prominent in the generated initializer and security docs.

Changes:
- `Server#warn_if_http_mcp_unauthenticated` + `HTTP_AUTH_WARNING`
- Generated initializer now documents `config.mcp.require_http_auth = true`
- Updated `docs/mcp-security.md`
- Specs for warning/no-warning behavior

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a startup warning in non-production environments when the HTTP MCP server is running without authentication configured.
  * Production environments remain unaffected, and no warning is shown when authentication is already set up.

* **Documentation**
  * Updated setup guidance to highlight how to require authentication for HTTP MCP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->