### PR TITLE
feat(security): skill pack lockfile verification

### DIFF
--- a/docs/skill-registry-guide.md
+++ b/docs/skill-registry-guide.md
@@ -154,6 +154,41 @@ When `ref` is set, rails-ai-bridge runs `git checkout <ref>` after cloning or pu
 
 ---
 
+## Lockfile verification
+
+A lockfile records the exact git commit SHA of every remote pack that was resolved the last time the registry was built. On subsequent loads, rails-ai-bridge compares the locked SHA against the actual HEAD of the cloned repository and fails closed on mismatch.
+
+This protects against:
+
+- A compromised pack repository pushing unexpected content
+- Accidental drift between environments (development vs. production)
+- Force-pushes or tag rewrites changing the content under a stable ref name
+
+### Generate the lockfile
+
+```bash
+rails ai:registry:lockfile
+```
+
+The file is written to `config/rails_ai_bridge/directory.lock` by default. Commit it alongside your manifest.
+
+### Configuration
+
+```ruby
+RailsAiBridge.configure do |config|
+  config.registry.lockfile_path = "config/rails_ai_bridge/directory.lock"
+  config.registry.lockfile_verification = :strict  # :strict (default), :warn, or :disabled
+end
+```
+
+- `:strict` — raise `ResolutionError` when the resolved commit does not match the lockfile.
+- `:warn` — log a stderr warning and continue loading.
+- `:disabled` — skip verification entirely.
+
+When no lockfile exists, verification is silently skipped so existing apps keep working.
+
+---
+
 ## The `directory.json` format
 
 Each skill pack repository should have a `directory.json` at its root. Here is an annotated example:
@@ -344,6 +379,7 @@ initializer changes take effect immediately.
 | Stale skills after pack update | Resolver cache is warm or pull TTL has not elapsed | Run `rails ai:skills:clear_cache` to force a re-clone on the next build |
 | Pack is not re-fetched even after `resolver_ttl` expired | Pack was cloned recently — `git_pull_ttl` (24 h) is still fresh | Run `rails ai:skills:clear_cache` or set `git_pull_ttl: 0` temporarily |
 | `git checkout <ref>` failed | Invalid ref or detached HEAD issue | Verify the `ref` value matches a branch, tag, or SHA in the remote repo |
+| `Lockfile mismatch for pack '…'` | Resolved pack commit differs from `directory.lock` | Run `rails ai:registry:lockfile` to update the lockfile after reviewing the pack changes |
 | Git operation hangs / server request times out | Slow or unreachable remote | Reduce `git_timeout` to fail faster; check network connectivity to the remote |
 | Warning: "Pack '…' depends on '…' which is not in the active pack set" | A loaded pack has an unsatisfied `depends_on` entry | Add the missing pack name to `always_loaded` or `skill_packs` in your manifest |
 
@@ -358,4 +394,5 @@ initializer changes take effect immediately.
 - **Timeout protection**: all git operations are bounded by `git_timeout` (default 30 s) so a slow remote cannot block the calling thread indefinitely.
 - **Cache key sanitization**: local cache directory names are derived from a sanitized source string plus a SHA256 hash suffix to prevent filesystem collisions.
 - **Stable local pack names**: local registry pack names use a SHA256 digest of the directory path, so reordering `local_registry_paths` cannot silently shift pack identities.
+- **Lockfile verification**: a `directory.lock` records the expected commit SHA for each remote pack. The resolver fails closed when the cloned commit does not match, preventing a compromised or unexpectedly modified pack from injecting instructions.
 - **Local path trust**: local paths are used directly without git operations. The path traversal guard in the Resolver still applies to file reads within a local pack.

--- a/lib/rails_ai_bridge/config/registry.rb
+++ b/lib/rails_ai_bridge/config/registry.rb
@@ -35,6 +35,13 @@ module RailsAiBridge
       #   Prevents a slow or unreachable remote from blocking the calling thread indefinitely.
       attr_reader :git_timeout
 
+      # @return [String, nil] path to the skill pack lockfile. nil disables lockfile verification.
+      attr_accessor :lockfile_path
+
+      # @return [Symbol] how to behave when the lockfile differs from the resolved pack:
+      #   :strict (default) raises, :warn logs but proceeds, :disabled skips verification.
+      attr_accessor :lockfile_verification
+
       # Sets the git pull TTL.
       #
       # Coerces the value to a non-negative integer; raises +ArgumentError+ for
@@ -93,6 +100,8 @@ module RailsAiBridge
         @resolver_ttl = 1800
         @git_pull_ttl = 86_400
         @git_timeout = 30
+        @lockfile_path = 'config/rails_ai_bridge/directory.lock'
+        @lockfile_verification = :strict
       end
     end
   end

--- a/lib/rails_ai_bridge/configuration.rb
+++ b/lib/rails_ai_bridge/configuration.rb
@@ -120,6 +120,11 @@ module RailsAiBridge
                    :rate_limiter, :rate_limiter=,
                    :rate_limiter_key_prefix, :rate_limiter_key_prefix=
 
+    # -- Config::Registry -------------------------------------------------------
+    def_delegators :@registry,
+                   :lockfile_path, :lockfile_path=,
+                   :lockfile_verification, :lockfile_verification=
+
     # -- Config::Rubydex --------------------------------------------------------
     def_delegators :@rubydex,
                    :rubydex_enabled, :rubydex_enabled=,

--- a/lib/rails_ai_bridge/registry.rb
+++ b/lib/rails_ai_bridge/registry.rb
@@ -18,6 +18,7 @@ require_relative 'registry/resolver'
 require_relative 'registry/source_parser'
 require_relative 'registry/skill_source_resolver'
 require_relative 'registry/pack_resolver'
+require_relative 'registry/lockfile'
 require_relative 'registry/resolver_cache'
 require_relative 'registry/rake_presenter'
 
@@ -79,6 +80,23 @@ module RailsAiBridge
     # @return [Resolver, nil] wired resolver, or nil if manifest file is missing
     def self.build_resolver(config = RailsAiBridge.configuration.registry)
       resolver_cache.fetch(config) { build_resolver_uncached(config) }
+    end
+
+    # Writes a lockfile containing the current HEAD commit SHA for every pack in
+    # the registry manifest.
+    #
+    # @param config [RailsAiBridge::Config::Registry] registry configuration
+    # @return [void]
+    # @raise [ArgumentError] when the manifest file does not exist
+    def self.write_lockfile(config = RailsAiBridge.configuration.registry)
+      manifest_path = config.registry_manifest_path
+      raise ArgumentError, "Registry manifest not found at #{manifest_path}" unless File.exist?(manifest_path)
+
+      manifest = RegistryManifest.from_file(manifest_path)
+      git_runner = DefaultGitRunner.new(timeout: config.git_timeout)
+      source_resolver = SkillSourceResolver.new(config.skill_cache_dir, git_runner, pull_ttl: config.git_pull_ttl)
+
+      Lockfile.write(config.lockfile_path, manifest, source_resolver)
     end
 
     # @api private

--- a/lib/rails_ai_bridge/registry/lockfile.rb
+++ b/lib/rails_ai_bridge/registry/lockfile.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'fileutils'
+
+module RailsAiBridge
+  module Registry
+    # Records and verifies expected git commit SHAs for skill packs.
+    #
+    # The lockfile is a JSON document keyed by pack name. Each entry stores the
+    # pack source, ref, and the resolved commit SHA. When verification is enabled,
+    # {PackResolver} compares the locked SHA against the actual HEAD of the cloned
+    # repository and fails closed on mismatch.
+    class Lockfile
+      # Represents one lockfile entry.
+      Entry = Data.define(:pack_name, :source, :ref, :commit_sha)
+
+      class << self
+        # Loads a lockfile from disk.
+        #
+        # @param path [String, nil] path to the lockfile; nil means no lockfile
+        # @return [Lockfile] empty lockfile when path is nil or the file does not exist
+        def load(path)
+          return new({}) if path.nil? || !File.exist?(path)
+
+          raw = File.read(path)
+          data = JSON.parse(raw)
+          entries = data.transform_values do |entry|
+            Entry.new(
+              pack_name: entry['pack_name'],
+              source: entry['source'],
+              ref: entry['ref'],
+              commit_sha: entry['commit_sha']
+            )
+          end
+          new(entries)
+        rescue JSON::ParserError => error
+          raise ArgumentError, "Invalid lockfile JSON at #{path}: #{error.message}"
+        end
+
+        # Generates lockfile entries by resolving every pack in the manifest.
+        #
+        # @param manifest [RegistryManifest]
+        # @param source_resolver [SkillSourceResolver]
+        # @return [Hash{String => Entry}]
+        def generate(manifest, source_resolver)
+          manifest.packs.each_with_object({}) do |(name, pack_def), entries|
+            base_path = source_resolver.resolve(pack_def.source, ref: pack_def.ref)
+            commit_sha = source_resolver.current_commit(base_path)
+            entries[name] = Entry.new(
+              pack_name: name,
+              source: pack_def.source,
+              ref: pack_def.ref,
+              commit_sha: commit_sha
+            )
+          end
+        end
+
+        # Writes a lockfile to disk for the given manifest.
+        #
+        # @param path [String]
+        # @param manifest [RegistryManifest]
+        # @param source_resolver [SkillSourceResolver]
+        # @return [void]
+        def write(path, manifest, source_resolver)
+          entries = generate(manifest, source_resolver)
+          new(entries).write(path)
+        end
+      end
+
+      # @param entries [Hash{String => Entry}] map of pack name to lockfile entry
+      def initialize(entries)
+        @entries = entries.freeze
+      end
+
+      delegate :any?, to: :@entries
+
+      # @param pack_name [String]
+      # @return [Entry, nil]
+      def entry(pack_name)
+        @entries[pack_name]
+      end
+
+      # Serializes the lockfile to JSON.
+      #
+      # @return [String]
+      def to_json(*)
+        data = @entries.transform_values do |entry|
+          {
+            'pack_name' => entry.pack_name,
+            'source' => entry.source,
+            'ref' => entry.ref,
+            'commit_sha' => entry.commit_sha
+          }
+        end
+        JSON.pretty_generate(data)
+      end
+
+      # Writes the lockfile to disk.
+      #
+      # @param path [String]
+      # @return [void]
+      def write(path)
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, "#{to_json}\n")
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/registry/pack_resolver.rb
+++ b/lib/rails_ai_bridge/registry/pack_resolver.rb
@@ -22,15 +22,18 @@ module RailsAiBridge
       #
       # @param source_resolver [SkillSourceResolver] resolver for remote git sources
       # @param pack_detector [Object] optional pack detector for testing (defaults to PackDetector)
-      def initialize(source_resolver, pack_detector = PackDetector)
+      # @param lockfile [Lockfile, nil] optional lockfile for pack verification
+      def initialize(source_resolver, pack_detector = PackDetector, lockfile = nil)
         @source_resolver = source_resolver
         @pack_detector = pack_detector
+        @lockfile = lockfile || default_lockfile
       end
 
       # Resolves active packs from the manifest and custom configuration.
       #
       # This will automatically resolve remote repositories if needed, load the tile
-      # manifest configurations, and merge local directory overrides.
+      # manifest configurations, merge local directory overrides, and verify pack
+      # commit SHAs against the configured lockfile.
       #
       # @param manifest [RegistryManifest] the registry manifest containing pack definitions
       # @param explicit_packs [Array<String>, nil] optional list of pack names to load
@@ -46,6 +49,38 @@ module RailsAiBridge
       end
 
       private
+
+      def default_lockfile
+        Lockfile.load(RailsAiBridge.configuration.registry.lockfile_path)
+      end
+
+      # Verifies the resolved pack commit SHA against the lockfile when one exists.
+      #
+      # Behavior is controlled by +config.registry.lockfile_verification+:
+      #   :strict  — raise on mismatch (default)
+      #   :warn    — log a warning and continue
+      #   :disabled — skip verification entirely
+      #
+      # @param name [String] pack name
+      # @param base_path [String] local path to the resolved pack
+      # @return [void]
+      def verify_pack!(name, base_path)
+        return unless @lockfile&.any?
+
+        mode = RailsAiBridge.configuration.registry.lockfile_verification
+        return if mode == :disabled
+
+        entry = @lockfile.entry(name)
+        return unless entry
+
+        actual = @source_resolver.current_commit(base_path)
+        return if actual == entry.commit_sha
+
+        message = "Lockfile mismatch for pack '#{name}': expected #{entry.commit_sha}, got #{actual}"
+        return warn "[rails-ai-bridge] #{message}" if mode == :warn
+
+        raise SkillSourceResolver::ResolutionError, "#{message}. Run `rails ai:registry:lockfile` to update the lockfile."
+      end
 
       # Gathers the set of pack names that should be loaded.
       #
@@ -105,6 +140,8 @@ module RailsAiBridge
           raise SkillSourceResolver::ResolutionError, "Pack '#{name}' not defined in registry manifest" unless pack_def
 
           base_path = @source_resolver.resolve(pack_def.source, ref: pack_def.ref)
+          verify_pack!(name, base_path)
+
           tile_path = File.join(base_path, pack_def.tile)
 
           unless File.exist?(tile_path)

--- a/lib/rails_ai_bridge/registry/skill_source_resolver.rb
+++ b/lib/rails_ai_bridge/registry/skill_source_resolver.rb
@@ -39,6 +39,15 @@ module RailsAiBridge
       def checkout_ref(_path, _ref)
         raise NotImplementedError
       end
+
+      # Returns the current HEAD commit SHA for the repository at +_path+.
+      #
+      # @param _path [String] path to the local repository
+      # @raise [StandardError] if the commit cannot be determined
+      # @return [String] 40-character hex commit SHA
+      def current_commit(_path)
+        raise NotImplementedError
+      end
     end
 
     # Default implementation of {GitRunner} using Open3 to spawn git subprocesses.
@@ -82,6 +91,20 @@ module RailsAiBridge
           # Command is fully static; only the chdir option is a validated directory path.
           _stdout, stderr, status = Open3.capture3('git', 'pull', chdir: path) # nosemgrep: ruby.lang.security.dangerous-exec.dangerous-exec
           fail_with_sanitized_error!('git pull', stderr) unless status.success?
+        end
+      end
+
+      # Returns the current HEAD commit SHA for the repository at +path+.
+      #
+      # @param path [String] path to the local repository
+      # @raise [RuntimeError] if the git command fails or returns non-zero
+      # @return [String] 40-character hex commit SHA
+      def current_commit(path)
+        with_timeout('git rev-parse') do
+          stdout, stderr, status = Open3.capture3('git', 'rev-parse', 'HEAD', chdir: path) # nosemgrep: ruby.lang.security.dangerous-exec.dangerous-exec
+          fail_with_sanitized_error!('git rev-parse', stderr) unless status.success?
+
+          stdout.strip
         end
       end
 
@@ -230,6 +253,17 @@ module RailsAiBridge
 
         perform_checkout_ref(source, cache_path, ref) if ref
         cache_path
+      end
+
+      # Returns the current HEAD commit SHA for the repository at +path+.
+      #
+      # @param path [String] path to the local repository
+      # @return [String] 40-character hex commit SHA
+      # @raise [ResolutionError] if the commit cannot be read
+      def current_commit(path)
+        @git_runner.current_commit(path)
+      rescue StandardError => error
+        raise ResolutionError, "failed to read current commit for pack at #{path}: #{error.message}"
       end
 
       private

--- a/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
+++ b/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
@@ -280,6 +280,19 @@ namespace :ai do
 end
 
 namespace :ai do
+  namespace :registry do
+    desc 'Generate or update the skill pack lockfile (config/rails_ai_bridge/directory.lock)'
+    task lockfile: :environment do
+      require 'rails_ai_bridge'
+
+      config = RailsAiBridge.configuration.registry
+      RailsAiBridge::Registry.write_lockfile(config)
+      puts "📝 Wrote skill pack lockfile to #{config.lockfile_path}"
+    end
+  end
+end
+
+namespace :ai do
   namespace :skills do
     desc 'List all available skills from configured skill packs'
     task list: :environment do

--- a/spec/lib/rails_ai_bridge/registry/lockfile_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/lockfile_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_ai_bridge/registry/lockfile'
+
+RSpec.describe RailsAiBridge::Registry::Lockfile do
+  let(:entry) do
+    described_class::Entry.new(
+      pack_name: 'core',
+      source: 'igmarin/ruby-core-skills',
+      ref: 'v1.0.0',
+      commit_sha: 'abc123'
+    )
+  end
+
+  describe '.load' do
+    it 'returns an empty lockfile when path is nil' do
+      lockfile = described_class.load(nil)
+      expect(lockfile).not_to be_any
+    end
+
+    it 'returns an empty lockfile when the file does not exist' do
+      lockfile = described_class.load('/nonexistent/directory.lock')
+      expect(lockfile).not_to be_any
+    end
+
+    it 'parses a valid lockfile' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'directory.lock')
+        File.write(
+          path,
+          JSON.generate(
+            'core' => {
+              'pack_name' => 'core',
+              'source' => 'igmarin/ruby-core-skills',
+              'ref' => 'v1.0.0',
+              'commit_sha' => 'abc123'
+            }
+          )
+        )
+
+        lockfile = described_class.load(path)
+        expect(lockfile).to be_any
+        expect(lockfile.entry('core').commit_sha).to eq('abc123')
+      end
+    end
+
+    it 'raises on invalid JSON' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'directory.lock')
+        File.write(path, 'not json')
+
+        expect { described_class.load(path) }.to raise_error(ArgumentError, /Invalid lockfile JSON/)
+      end
+    end
+  end
+
+  describe '#write' do
+    it 'writes the lockfile as JSON' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'directory.lock')
+        lockfile = described_class.new('core' => entry)
+
+        lockfile.write(path)
+
+        parsed = JSON.parse(File.read(path))
+        expect(parsed['core']['commit_sha']).to eq('abc123')
+        expect(parsed['core']['source']).to eq('igmarin/ruby-core-skills')
+      end
+    end
+  end
+
+  describe '.generate' do
+    it 'resolves every pack and records its commit SHA' do
+      source_resolver = double('source_resolver')
+      pack_def = double('pack_def', source: 'igmarin/ruby-core-skills', ref: 'v1.0.0')
+      manifest = double('manifest', packs: { 'core' => pack_def })
+
+      allow(source_resolver).to receive(:resolve).with('igmarin/ruby-core-skills', ref: 'v1.0.0').and_return('/tmp/core')
+      allow(source_resolver).to receive(:current_commit).with('/tmp/core').and_return('def456')
+
+      entries = described_class.generate(manifest, source_resolver)
+
+      expect(entries['core'].commit_sha).to eq('def456')
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/registry/pack_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/pack_resolver_spec.rb
@@ -321,6 +321,133 @@ RSpec.describe RailsAiBridge::Registry::PackResolver do
       end
     end
 
+    context 'lockfile verification' do
+      around do |example|
+        saved_mode = RailsAiBridge.configuration.registry.lockfile_verification
+        example.run
+      ensure
+        RailsAiBridge.configuration.registry.lockfile_verification = saved_mode
+      end
+
+      it 'raises when the resolved commit does not match the lockfile in strict mode' do
+        packs = {
+          'core' => RailsAiBridge::Registry::PackDefinition.new(
+            source: 'dummy/core',
+            tile: 'directory.json',
+            always_loaded: false,
+            depends_on: [],
+            ref: nil
+          )
+        }
+
+        manifest = RailsAiBridge::Registry::RegistryManifest.new(
+          version: '1.0.0',
+          packs: packs,
+          default_stack: []
+        )
+
+        allow(mock_git_runner).to receive(:clone_repo) do |_url, dest|
+          FileUtils.mkdir_p(dest)
+          create_mock_tile(dest, name: 'core')
+        end
+        allow(mock_git_runner).to receive(:pull_repo)
+        allow(source_resolver).to receive(:current_commit).and_return('mismatch-sha')
+
+        lockfile = RailsAiBridge::Registry::Lockfile.new(
+          'core' => RailsAiBridge::Registry::Lockfile::Entry.new(
+            pack_name: 'core',
+            source: 'dummy/core',
+            ref: nil,
+            commit_sha: 'expected-sha'
+          )
+        )
+
+        RailsAiBridge.configuration.registry.lockfile_verification = :strict
+        service = described_class.new(source_resolver, RailsAiBridge::Registry::PackDetector, lockfile)
+
+        expect { service.resolve(manifest, ['core'], nil) }
+          .to raise_error(/Lockfile mismatch for pack 'core'/)
+      end
+
+      it 'warns and continues in warn mode' do
+        packs = {
+          'core' => RailsAiBridge::Registry::PackDefinition.new(
+            source: 'dummy/core',
+            tile: 'directory.json',
+            always_loaded: false,
+            depends_on: [],
+            ref: nil
+          )
+        }
+
+        manifest = RailsAiBridge::Registry::RegistryManifest.new(
+          version: '1.0.0',
+          packs: packs,
+          default_stack: []
+        )
+
+        allow(mock_git_runner).to receive(:clone_repo) do |_url, dest|
+          FileUtils.mkdir_p(dest)
+          create_mock_tile(dest, name: 'core')
+        end
+        allow(mock_git_runner).to receive(:pull_repo)
+        allow(source_resolver).to receive(:current_commit).and_return('mismatch-sha')
+
+        lockfile = RailsAiBridge::Registry::Lockfile.new(
+          'core' => RailsAiBridge::Registry::Lockfile::Entry.new(
+            pack_name: 'core',
+            source: 'dummy/core',
+            ref: nil,
+            commit_sha: 'expected-sha'
+          )
+        )
+
+        RailsAiBridge.configuration.registry.lockfile_verification = :warn
+        service = described_class.new(source_resolver, RailsAiBridge::Registry::PackDetector, lockfile)
+
+        expect { service.resolve(manifest, ['core'], nil) }.to output(/Lockfile mismatch for pack 'core'/).to_stderr
+      end
+
+      it 'skips verification when disabled' do
+        packs = {
+          'core' => RailsAiBridge::Registry::PackDefinition.new(
+            source: 'dummy/core',
+            tile: 'directory.json',
+            always_loaded: false,
+            depends_on: [],
+            ref: nil
+          )
+        }
+
+        manifest = RailsAiBridge::Registry::RegistryManifest.new(
+          version: '1.0.0',
+          packs: packs,
+          default_stack: []
+        )
+
+        allow(mock_git_runner).to receive(:clone_repo) do |_url, dest|
+          FileUtils.mkdir_p(dest)
+          create_mock_tile(dest, name: 'core')
+        end
+        allow(mock_git_runner).to receive(:pull_repo)
+        allow(source_resolver).to receive(:current_commit).and_return('mismatch-sha')
+
+        lockfile = RailsAiBridge::Registry::Lockfile.new(
+          'core' => RailsAiBridge::Registry::Lockfile::Entry.new(
+            pack_name: 'core',
+            source: 'dummy/core',
+            ref: nil,
+            commit_sha: 'expected-sha'
+          )
+        )
+
+        RailsAiBridge.configuration.registry.lockfile_verification = :disabled
+        service = described_class.new(source_resolver, RailsAiBridge::Registry::PackDetector, lockfile)
+
+        expect { service.resolve(manifest, ['core'], nil) }.not_to output.to_stderr
+      end
+    end
+
     context 'error handling' do
       it 'handles tile file read errors' do
         packs = {


### PR DESCRIPTION
Implements #65.

Adds a directory.lock that records the expected git commit SHA for each remote skill pack. The resolver compares the cloned HEAD against the lockfile and fails closed on mismatch.

Changes:
- RailsAiBridge::Registry::Lockfile with read/write/generate helpers
- config.registry.lockfile_path and config.registry.lockfile_verification (:strict, :warn, :disabled)
- DefaultGitRunner#current_commit via git rev-parse HEAD
- PackResolver verifies pack commits against the lockfile
- New rake task: rails ai:registry:lockfile
- Docs updated in docs/skill-registry-guide.md

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lockfile support for skill packs, including a command to generate or update it.
  * Introduced configurable verification modes to check resolved packs against the lockfile.

* **Bug Fixes**
  * Pack loading now fails closed when a pack’s resolved revision doesn’t match the lockfile, helping prevent unexpected content from being loaded.
  * Added warning and disabled modes for teams that want softer handling of mismatches.

* **Documentation**
  * Updated the guide with setup, configuration, troubleshooting, and security details for lockfile verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->