### PR TITLE
feat(observability): ActiveSupport::Notifications hooks

### DIFF
--- a/lib/rails_ai_bridge/http_transport_app.rb
+++ b/lib/rails_ai_bridge/http_transport_app.rb
@@ -53,6 +53,7 @@ module RailsAiBridge
           end
 
           if limiter && !rate_limiter_allow?(limiter, request)
+            Instrumentation.instrument('rate_limit.hit', ip: request.ip, path: request.path)
             Mcp::HttpStructuredLog.emit(request: request, event: :rate_limited, http_status: 429)
             return [429, { 'Content-Type' => 'application/json', 'Retry-After' => window_sec.to_s },
                     ['{"error":"Too many requests"}']]

--- a/lib/rails_ai_bridge/instrumentation.rb
+++ b/lib/rails_ai_bridge/instrumentation.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'delegate'
+
+module RailsAiBridge
+  # Thin wrapper around ActiveSupport::Notifications for rails-ai-bridge events.
+  #
+  # Events are namespaced under +rails_ai_bridge+. If ActiveSupport::Notifications
+  # is not available, the helper yields without instrumentation so the code can be
+  # used outside of Rails without a hard dependency.
+  module Instrumentation
+    NAMESPACE = 'rails_ai_bridge'
+
+    # Emits an instrumentation event.
+    #
+    # @param event [String] event name suffix (e.g. +tool.call+)
+    # @param payload [Hash] extra payload attached to the event
+    # @yield optional block to wrap; the block result is returned
+    # @return [Object] the block result, or nil when no block is given
+    def self.instrument(event, payload = {})
+      return yield unless defined?(ActiveSupport::Notifications) && ActiveSupport::Notifications
+
+      ActiveSupport::Notifications.instrument("#{NAMESPACE}.#{event}", payload) do
+        yield if block_given?
+      end
+    end
+
+    # Wraps an MCP tool class so every call emits a +rails_ai_bridge.tool.call+
+    # event. Caching, when enabled, is handled by the inner wrapper so cache
+    # hit/miss events stay separate from the invocation event.
+    class InstrumentedTool < SimpleDelegator
+      def initialize(tool_class)
+        super
+        @tool_class = tool_class
+      end
+
+      # @param server_context [Object, nil]
+      # @param arguments [Hash]
+      # @return [MCP::Tool::Response]
+      def call(server_context: nil, **arguments)
+        Instrumentation.instrument('tool.call', tool_name: @tool_class.tool_name, arguments: arguments) do
+          @tool_class.call(server_context: server_context, **arguments)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/mcp/authenticator.rb
+++ b/lib/rails_ai_bridge/mcp/authenticator.rb
@@ -51,7 +51,13 @@ module RailsAiBridge
           strategy = resolve_strategy
           return AuthResult.ok(nil) if strategy.nil?
 
-          strategy.authenticate(request)
+          strategy.authenticate(request).tap do |result|
+            if result.success?
+              Instrumentation.instrument('auth.success', strategy: strategy_name(strategy), ip: request.ip)
+            else
+              Instrumentation.instrument('auth.failure', strategy: strategy_name(strategy), ip: request.ip, error: result.error)
+            end
+          end
         end
 
         # Returns +true+ when any auth mechanism is configured — static token,
@@ -78,6 +84,14 @@ module RailsAiBridge
             },
             ['{"error":"Unauthorized"}']
           ]
+        end
+
+        # Human-readable strategy name for observability payloads.
+        #
+        # @param strategy [Auth::BaseStrategy]
+        # @return [String]
+        def strategy_name(strategy)
+          strategy.class.name&.split('::')&.last || 'unknown'
         end
 
         private

--- a/lib/rails_ai_bridge/server.rb
+++ b/lib/rails_ai_bridge/server.rb
@@ -61,7 +61,7 @@ module RailsAiBridge
     # @return [Array<Class, ToolResultCache::CachedTool>] list of tool classes
     def tool_classes
       (TOOLS + RailsAiBridge.configuration.additional_tools).map do |tool_class|
-        ToolResultCache.maybe_wrap(tool_class)
+        Instrumentation::InstrumentedTool.new(ToolResultCache.maybe_wrap(tool_class))
       end
     end
 

--- a/lib/rails_ai_bridge/tool_result_cache.rb
+++ b/lib/rails_ai_bridge/tool_result_cache.rb
@@ -84,15 +84,21 @@ module RailsAiBridge
         return yield unless enabled?
 
         key = cache_key(tool_name, arguments)
+        fingerprint = key.split(':', 2).last
 
         mutex.synchronize do
           entry = cache[key]
-          return entry[:response] if entry && ttl_valid?(entry)
+          if entry && ttl_valid?(entry)
+            Instrumentation.instrument('tool.result_cache_hit', tool_name: tool_name, fingerprint: fingerprint)
+            return entry[:response]
+          end
         end
 
-        response = yield
-        mutex.synchronize { cache[key] = { response: response, fetched_at: monotonic_now } }
-        response
+        Instrumentation.instrument('tool.result_cache_miss', tool_name: tool_name, fingerprint: fingerprint) do
+          response = yield
+          mutex.synchronize { cache[key] = { response: response, fetched_at: monotonic_now } }
+          response
+        end
       end
 
       # Clears all cached tool results.

--- a/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
+++ b/spec/lib/rails_ai_bridge/http_transport_app_spec.rb
@@ -177,6 +177,31 @@ RSpec.describe RailsAiBridge::HttpTransportApp do
       expect(app.call(env).first).to eq(429)
     end
 
+    it 'emits a rate_limit.hit event when a request is throttled' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.rate_limiter = ->(_ip) { false }
+      RailsAiBridge.configuration.mcp.rate_limit_max_requests = 0
+      app = described_class.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for(
+        '/mcp',
+        method: 'POST',
+        'HTTP_AUTHORIZATION' => 'Bearer secret',
+        'REMOTE_ADDR' => '1.2.3.4'
+      )
+
+      events = []
+      callback = ->(name, _started, _finished, _unique_id, payload) { events << [name, payload] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'rails_ai_bridge.rate_limit.hit') do
+        app.call(env)
+      end
+
+      expect(events.size).to eq(1)
+      expect(events.first.first).to eq('rails_ai_bridge.rate_limit.hit')
+      expect(events.first.last[:ip]).to eq('1.2.3.4')
+    end
+
     it 'returns 403 when authorize lambda returns falsey' do
       RailsAiBridge.configuration.http_mcp_token = 'secret'
       RailsAiBridge.configuration.mcp.authorize = ->(_ctx, _req) { false }

--- a/spec/lib/rails_ai_bridge/instrumentation_spec.rb
+++ b/spec/lib/rails_ai_bridge/instrumentation_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::Instrumentation do
+  describe '.instrument' do
+    it 'yields when ActiveSupport::Notifications is unavailable' do
+      stub_const('ActiveSupport::Notifications', nil)
+
+      result = described_class.instrument('tool.call', tool_name: 'test') { 42 }
+      expect(result).to eq(42)
+    end
+
+    it 'instruments through ActiveSupport::Notifications when available' do
+      events = []
+      callback = ->(name, _started, _finished, _unique_id, payload) { events << [name, payload] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'rails_ai_bridge.tool.call') do
+        described_class.instrument('tool.call', tool_name: 'test') { 'done' }
+      end
+
+      expect(events.size).to eq(1)
+      expect(events.first.first).to eq('rails_ai_bridge.tool.call')
+      expect(events.first.last[:tool_name]).to eq('test')
+    end
+  end
+
+  describe 'InstrumentedTool' do
+    let(:tool_class) do
+      Class.new(RailsAiBridge::Tools::BaseTool) do
+        tool_name 'rails_test_tool'
+        description 'Test'
+        input_schema(properties: {})
+
+        def self.call(**)
+          MCP::Tool::Response.new([{ type: 'text', text: 'ok' }])
+        end
+      end
+    end
+
+    it 'emits rails_ai_bridge.tool.call on invocation' do
+      events = []
+      callback = ->(name, _started, _finished, _unique_id, payload) { events << [name, payload] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'rails_ai_bridge.tool.call') do
+        described_class::InstrumentedTool.new(tool_class).call(value: 1)
+      end
+
+      expect(events.size).to eq(1)
+      expect(events.first.first).to eq('rails_ai_bridge.tool.call')
+      expect(events.first.last[:tool_name]).to eq('rails_test_tool')
+      expect(events.first.last[:arguments]).to eq({ value: 1 })
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/authenticator_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/authenticator_spec.rb
@@ -87,6 +87,54 @@ RSpec.describe RailsAiBridge::Mcp::Authenticator do
         expect(described_class.call(build_request(token: 'bad'))).to be_failure
       end
     end
+
+    context 'instrumentation' do
+      before do
+        RailsAiBridge.configuration.http_mcp_token     = nil
+        RailsAiBridge.configuration.mcp_token_resolver = nil
+        RailsAiBridge.configuration.mcp_jwt_decoder    = nil
+      end
+
+      it 'emits auth.success for a valid static token' do
+        RailsAiBridge.configuration.http_mcp_token = 's3cr3t'
+        events = []
+        callback = ->(name, _started, _finished, _unique_id, payload) { events << [name, payload] }
+
+        ActiveSupport::Notifications.subscribed(callback, 'rails_ai_bridge.auth.success') do
+          described_class.call(build_request(token: 's3cr3t'))
+        end
+
+        expect(events.size).to eq(1)
+        expect(events.first.first).to eq('rails_ai_bridge.auth.success')
+        expect(events.first.last[:strategy]).to eq('BearerToken')
+      end
+
+      it 'emits auth.failure for an invalid token' do
+        RailsAiBridge.configuration.http_mcp_token = 's3cr3t'
+        events = []
+        callback = ->(name, _started, _finished, _unique_id, payload) { events << [name, payload] }
+
+        ActiveSupport::Notifications.subscribed(callback, 'rails_ai_bridge.auth.failure') do
+          described_class.call(build_request(token: 'wrong'))
+        end
+
+        expect(events.size).to eq(1)
+        expect(events.first.first).to eq('rails_ai_bridge.auth.failure')
+        expect(events.first.last[:strategy]).to eq('BearerToken')
+        expect(events.first.last[:error]).to eq(:wrong_token)
+      end
+
+      it 'does not emit auth events when no strategy is configured' do
+        events = []
+        callback = ->(name, _started, _finished, _unique_id, _payload) { events << name }
+
+        ActiveSupport::Notifications.subscribed(callback, /rails_ai_bridge\.auth/) do
+          described_class.call(build_request)
+        end
+
+        expect(events).to be_empty
+      end
+    end
   end
 
   describe 'strategy priority' do

--- a/spec/lib/rails_ai_bridge/server_spec.rb
+++ b/spec/lib/rails_ai_bridge/server_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe RailsAiBridge::Server do
 
       server.build
 
-      expect(MCP::Server).to have_received(:new).with(
-        name: 'Test Server',
-        version: '1.0.0',
-        tools: server.tool_classes,
-        resources: [],
-        resource_templates: []
-      )
+      expect(MCP::Server).to have_received(:new) do |**kwargs|
+        expect(kwargs[:name]).to eq('Test Server')
+        expect(kwargs[:version]).to eq('1.0.0')
+        expect(kwargs[:tools].map(&:tool_name)).to eq(server.tool_classes.map(&:tool_name))
+        expect(kwargs[:resources]).to eq([])
+        expect(kwargs[:resource_templates]).to eq([])
+      end
     end
 
     it 'registers resources with the server' do

--- a/spec/lib/rails_ai_bridge/tool_result_cache_spec.rb
+++ b/spec/lib/rails_ai_bridge/tool_result_cache_spec.rb
@@ -109,6 +109,36 @@ RSpec.describe RailsAiBridge::ToolResultCache do
 
       expect(calls).to eq(2)
     end
+
+    it 'emits a cache hit event for cached responses' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      events = []
+      callback = ->(name, _started, _finished, _unique_id, payload) { events << [name, payload] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'rails_ai_bridge.tool.result_cache_hit') do
+        described_class.fetch_response('rails_test', { key: 'value' }) { response }
+        described_class.fetch_response('rails_test', { key: 'value' }) { response }
+      end
+
+      expect(events.size).to eq(1)
+      expect(events.first.first).to eq('rails_ai_bridge.tool.result_cache_hit')
+      expect(events.first.last[:tool_name]).to eq('rails_test')
+      expect(events.first.last[:fingerprint]).to be_a(String)
+    end
+
+    it 'emits a cache miss event for fresh responses' do
+      RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+      events = []
+      callback = ->(name, _started, _finished, _unique_id, payload) { events << [name, payload] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'rails_ai_bridge.tool.result_cache_miss') do
+        described_class.fetch_response('rails_test', { key: 'value' }) { response }
+      end
+
+      expect(events.size).to eq(1)
+      expect(events.first.first).to eq('rails_ai_bridge.tool.result_cache_miss')
+      expect(events.first.last[:tool_name]).to eq('rails_test')
+    end
   end
 
   describe '.maybe_wrap' do


### PR DESCRIPTION
Implements #72.

Adds ActiveSupport::Notifications instrumentation for rails-ai-bridge internals:

- `rails_ai_bridge.tool.call` — every MCP tool invocation
- `rails_ai_bridge.tool.result_cache_hit` / `result_cache_miss` — tool result cache behavior
- `rails_ai_bridge.auth.success` / `auth.failure` — HTTP MCP auth outcomes
- `rails_ai_bridge.rate_limit.hit` — throttled HTTP MCP requests

The helper no-ops when ActiveSupport::Notifications is unavailable, and the existing `HttpStructuredLog` path is unchanged.

Closes #72