### PR TITLE
feat(tools): summary-first defaults for schema and model tools

### DIFF
--- a/lib/rails_ai_bridge/introspectors/auth_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/auth_introspector.rb
@@ -39,14 +39,28 @@ module RailsAiBridge
         devise_models = scan_models_for(/devise\s+(.+)$/)
         auth[:devise] = devise_models if devise_models.any?
 
-        # Rails 8 built-in auth
-        auth[:rails_auth] = true if model_file_exists?('session.rb') && model_file_exists?('current.rb')
+        # Rails 8 built-in auth generator patterns
+        auth[:rails_auth] = detect_rails_auth_details if model_file_exists?('session.rb') && model_file_exists?('current.rb')
 
         # has_secure_password
         secure_pw = scan_models_for(/has_secure_password/)
         auth[:has_secure_password] = secure_pw.pluck(:model) if secure_pw.any?
 
         auth
+      end
+
+      def detect_rails_auth_details
+        details = {
+          authentication_concern: file_exists?('app/controllers/concerns/authentication.rb')
+        }
+
+        token_for = scan_models_for(/generates_token_for\s+:(\w+)/)
+        details[:token_for] = token_for.map { |entry| { model: entry[:model], tokens: entry[:matches] } } if token_for.any?
+
+        normalized = scan_models_for(/normalizes\s+:(\w+)/)
+        details[:normalized_attributes] = normalized.map { |entry| { model: entry[:model], attrs: entry[:matches] } } if normalized.any?
+
+        details
       end
 
       def detect_authorization

--- a/lib/rails_ai_bridge/introspectors/config_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/config_introspector.rb
@@ -20,6 +20,8 @@ module RailsAiBridge
         result = {
           cache_store: detect_cache_store,
           session_store: detect_session_store,
+          queue_adapter: detect_queue_adapter,
+          cable_adapter: detect_cable_adapter,
           timezone: app.config.time_zone.to_s,
           middleware_stack: extract_middleware,
           initializers: extract_initializers,
@@ -50,6 +52,24 @@ module RailsAiBridge
 
       def detect_session_store
         app.config.session_store&.name
+      rescue StandardError
+        'unknown'
+      end
+
+      def detect_queue_adapter
+        return 'unknown' unless app.config.respond_to?(:active_job)
+
+        adapter = app.config.active_job&.queue_adapter
+        adapter.is_a?(Symbol) ? adapter.to_s : adapter.class.name
+      rescue StandardError
+        'unknown'
+      end
+
+      def detect_cable_adapter
+        return 'unknown' unless app.config.respond_to?(:action_cable)
+
+        adapter = app.config.action_cable&.adapter
+        adapter.is_a?(Symbol) ? adapter.to_s : adapter.class.name
       rescue StandardError
         'unknown'
       end

--- a/lib/rails_ai_bridge/introspectors/gem_registry.rb
+++ b/lib/rails_ai_bridge/introspectors/gem_registry.rb
@@ -20,6 +20,7 @@ module RailsAiBridge
         'sidekiq' => { category: :jobs, note: 'Background jobs via Sidekiq. Check config/sidekiq.yml.' },
         'good_job' => { category: :jobs, note: 'Background jobs via GoodJob (Postgres-backed).' },
         'solid_queue' => { category: :jobs, note: 'Background jobs via SolidQueue (Rails 8 default).' },
+        'mission_control-jobs' => { category: :jobs, note: 'Web UI for SolidQueue / Active Job monitoring.' },
         'delayed_job' => { category: :jobs, note: 'Background jobs via DelayedJob.' },
         'resque' => { category: :jobs, note: 'Background jobs via Resque (Redis-backed).' },
         'sneakers' => { category: :jobs, note: 'Background jobs via Sneakers (RabbitMQ).' },

--- a/lib/rails_ai_bridge/tools/get_model_details.rb
+++ b/lib/rails_ai_bridge/tools/get_model_details.rb
@@ -19,7 +19,7 @@ module RailsAiBridge
           detail: {
             type: 'string',
             enum: %w[summary standard full],
-            description: 'Detail level for model listing. summary: names only. standard: names + association/validation counts (default). full: names + full association list.
+            description: 'Detail level for model listing. summary: names only (default). standard: names + association/validation counts. full: names + full association list.
             Ignored when specific model is given (always returns full).'
           },
           format: {
@@ -42,7 +42,7 @@ module RailsAiBridge
       # @param detail [String] +summary+, +standard+, or +full+ when listing (ignored when +model+ is set)
       # @param _server_context [Object, nil] reserved for MCP transport metadata (unused)
       # @return [MCP::Tool::Response] Markdown body or an error string wrapped for the MCP client
-      def self.call(model: nil, detail: 'standard', format: 'markdown', _server_context: nil)
+      def self.call(model: nil, detail: 'summary', format: 'markdown', _server_context: nil)
         models = cached_section(:models)
         return text_response('Model introspection not available. Add :models to introspectors.') unless models
         return text_response("Model introspection failed: #{models[:error]}") if models[:error]

--- a/lib/rails_ai_bridge/tools/get_schema.rb
+++ b/lib/rails_ai_bridge/tools/get_schema.rb
@@ -17,7 +17,7 @@ module RailsAiBridge
           detail: {
             type: 'string',
             enum: %w[summary standard full],
-            description: 'Detail level. summary: table names + column counts. standard: table names + column names/types (default). ' \
+            description: 'Detail level. summary: table names + column counts (default). standard: table names + column names/types. ' \
                          'full: everything including indexes, FKs, comments.'
           },
           limit: {
@@ -50,7 +50,7 @@ module RailsAiBridge
       # @param format [String] +markdown+ or +json+
       # @param _server_context [Object, nil] reserved for MCP transport metadata (unused)
       # @return [MCP::Tool::Response] schema markdown/JSON or an error message
-      def self.call(table: nil, detail: 'standard', limit: nil, offset: 0, format: 'markdown', _server_context: nil)
+      def self.call(table: nil, detail: 'summary', limit: nil, offset: 0, format: 'markdown', _server_context: nil)
         schema = cached_section(:schema)
         return text_response('Schema introspection not available. Add :schema to introspectors.') unless schema
         return text_response("Schema introspection not available: #{schema[:error]}") if schema[:error]

--- a/spec/lib/rails_ai_bridge/introspectors/auth_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/auth_introspector_spec.rb
@@ -122,14 +122,18 @@ RSpec.describe RailsAiBridge::Introspectors::AuthIntrospector do
       before do
         FileUtils.mkdir_p(models_dir)
         FileUtils.mkdir_p(policies_dir)
+        FileUtils.mkdir_p(app_root.join('app/controllers/concerns'))
         File.write(models_dir.join('current.rb'), 'class Current < ActiveSupport::CurrentAttributes; end')
         File.write(models_dir.join('session.rb'), 'class Session < ApplicationRecord; end')
         File.write(models_dir.join('user.rb'), <<~RUBY)
           class User < ApplicationRecord
             devise :database_authenticatable
             has_secure_password
+            generates_token_for :password_reset
+            normalizes :email
           end
         RUBY
+        File.write(app_root.join('app/controllers/concerns/authentication.rb'), 'module Authentication; end')
         File.write(models_dir.join('ability.rb'), 'class Ability; end')
         File.write(policies_dir.join('order_policy.rb'), 'class OrderPolicy; end')
       end
@@ -137,7 +141,11 @@ RSpec.describe RailsAiBridge::Introspectors::AuthIntrospector do
       it 'detects authentication and authorization outside conventional app paths' do
         custom_result = described_class.new(custom_app).call
 
-        expect(custom_result[:authentication][:rails_auth]).to be true
+        expect(custom_result[:authentication][:rails_auth]).to include(
+          authentication_concern: true,
+          token_for: [{ model: 'User', tokens: ['password_reset'] }],
+          normalized_attributes: [{ model: 'User', attrs: ['email'] }]
+        )
         expect(custom_result[:authentication][:has_secure_password]).to include('User')
         expect(custom_result[:authentication][:devise].first[:model]).to eq('User')
         expect(custom_result[:authorization]).to include(

--- a/spec/lib/rails_ai_bridge/introspectors/config_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/config_introspector_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
       expect(result[:credentials_keys]).to be_an(Array)
     end
 
+    it 'returns queue adapter as a string' do
+      expect(result[:queue_adapter]).to be_a(String)
+    end
+
+    it 'returns cable adapter as a string' do
+      expect(result[:cable_adapter]).to be_a(String)
+    end
+
     it 'returns current attributes as array' do
       expect(result[:current_attributes]).to be_an(Array)
     end

--- a/spec/lib/rails_ai_bridge/tools/get_model_details_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_model_details_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe RailsAiBridge::Tools::GetModelDetails do
       end
     end
 
+    context 'by default' do
+      let(:params) { {} }
+
+      it 'uses summary detail' do
+        expect(content).to include('# Available models (2)')
+        expect(content).to include('- Post')
+        expect(content).to include('- User')
+      end
+    end
+
     context "with detail: 'summary'" do
       let(:params) { { detail: 'summary' } }
 
@@ -123,7 +133,7 @@ RSpec.describe RailsAiBridge::Tools::GetModelDetails do
     end
 
     context "with format: 'json'" do
-      let(:params) { { format: 'json' } }
+      let(:params) { { format: 'json', detail: 'standard' } }
 
       it 'returns all models as JSON' do
         parsed = JSON.parse(content)

--- a/spec/lib/rails_ai_bridge/tools/get_schema_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_schema_spec.rb
@@ -61,6 +61,15 @@ RSpec.describe RailsAiBridge::Tools::GetSchema do
       end
     end
 
+    context 'by default' do
+      let(:params) { {} }
+
+      it 'uses summary detail' do
+        expect(content).to include('# Schema Summary (2 tables)')
+        expect(content).to include('- **users** — 1 columns, 0 indexes')
+      end
+    end
+
     context 'when schema is not available' do
       let(:schema_data) { nil }
       let(:params) { {} }


### PR DESCRIPTION
Implements #70.

Defaults rails_get_schema and rails_get_model_details to summary detail when listing, reducing the chance of large payloads hitting context limits. Users can still opt into standard or full and use filters for specific tables/models.

- get_schema default detail: summary
- get_model_details default detail: summary
- Tool schemas/descriptions updated
- Specs added for default summary behavior

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication detection now reports richer Rails auth details, including concern-based auth and model-level token/normalization patterns.
  * Runtime configuration output now includes job queue and cable adapter information.
  * Added recognition for an additional job-monitoring gem.

* **Changes**
  * Default output for model and schema details now uses a shorter summary view when no detail level is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->