### PR TITLE
docs(path-resolver): document intentional shared-utility role + edge-case tests

### DIFF
--- a/lib/rails_ai_bridge/path_resolver.rb
+++ b/lib/rails_ai_bridge/path_resolver.rb
@@ -3,6 +3,27 @@
 module RailsAiBridge
   # Resolves configured Rails logical paths to filesystem paths without leaking
   # machine-specific absolute paths into generated assistant context.
+  #
+  # == Architectural role: intentional shared utility
+  #
+  # PathResolver is deliberately used by every introspector that needs to
+  # locate files on disk (controller, model, view, stimulus, turbo, auth,
+  # api, config, action_text, activeStorage, nonArModels — 11 callers as of
+  # v3.5.2). It is NOT a god class despite high betweenness centrality in
+  # graph analyses: a foundational path-resolution utility is expected to
+  # sit at the centre of the introspector graph. Splitting it would spread
+  # path-safety logic (traversal guards, safe joins) across multiple files
+  # and weaken the single responsibility it currently holds.
+  #
+  # The three private helper classes — SafeRelativePath, SafeJoin, and
+  # ConfiguredPathsError — are kept nested and private_constant so they
+  # cannot leak into the public API or be referenced by callers. This
+  # keeps the safety surface area small and auditable in one file.
+  #
+  # If a future graph analysis flags this class again, check the
+  # betweenness centrality against the caller count before proposing a
+  # split: a utility with many callers and a single responsibility is
+  # healthy, not smelly.
   class PathResolver
     # Validates user-provided relative paths before filesystem operations.
     class SafeRelativePath

--- a/lib/rails_ai_bridge/serializers/context_summary.rb
+++ b/lib/rails_ai_bridge/serializers/context_summary.rb
@@ -459,7 +459,7 @@ module RailsAiBridge
       private_class_method :sensitive_config_basename?
 
       def sensitive_config_path_segment?(path)
-        path.split('/').any? { |segment| SENSITIVE_CONFIG_SEGMENTS.include?(segment) }
+        path.split('/').intersect?(SENSITIVE_CONFIG_SEGMENTS)
       end
       module_function :sensitive_config_path_segment?
       private_class_method :sensitive_config_path_segment?

--- a/spec/lib/rails_ai_bridge/path_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/path_resolver_spec.rb
@@ -90,4 +90,46 @@ RSpec.describe RailsAiBridge::PathResolver do
       expect(Rails.logger).to have_received(:error).with(%r{failed to read path "app/models"})
     end
   end
+
+  # Edge-case tests for the private helper classes. These are accessed via
+  # Ruby's constant lookup since they are private_constant — the specs document
+  # their behavior and guard against regressions in the path-safety surface.
+  describe 'SafeRelativePath (private helper)' do
+    let(:safe_relative_path) { described_class.const_get(:SafeRelativePath) }
+
+    it 'normalizes backslashes to forward slashes' do
+      expect(safe_relative_path.new('sub\\dir\\file.rb', argument_name: 'x').to_s).to eq('sub/dir/file.rb')
+    end
+
+    it 'rejects Windows-style absolute paths' do
+      expect { safe_relative_path.new('C:/secrets.yml', argument_name: 'x').to_s }.to raise_error(ArgumentError)
+    end
+
+    it 'rejects empty paths' do
+      expect { safe_relative_path.new('', argument_name: 'x').to_s }.to raise_error(ArgumentError)
+    end
+
+    it 'accepts a plain relative path' do
+      expect(safe_relative_path.new('billing/account.rb', argument_name: 'x').to_s).to eq('billing/account.rb')
+    end
+  end
+
+  describe 'SafeJoin (private helper)' do
+    let(:safe_join) { described_class.const_get(:SafeJoin) }
+    let(:base) { Dir.mktmpdir('safe-join') }
+
+    after { FileUtils.rm_rf(base) }
+
+    it 'joins a base directory and a relative file into an absolute path' do
+      joined = safe_join.new(base, 'nested/file.rb').to_s
+      expect(joined).to eq(File.expand_path(File.join(base, 'nested/file.rb')))
+    end
+
+    it 'raises when the joined path escapes the base directory via traversal' do
+      expect { safe_join.new(base, '../../etc/passwd').to_s }.to raise_error(
+        ArgumentError,
+        /relative_file must stay within the resolved directory/
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **Investigation**: A graphify knowledge graph analysis flagged `PathResolver` as a potential god class (29 edges, betweenness centrality 0.127, 11 introspector callers). After tracing the code, it is **NOT a god class** — it is a well-factored shared utility with a single clear responsibility (resolve Rails logical paths → filesystem paths safely). High betweenness is expected and healthy for a foundational utility.
- **Documentation**: Added a class-level docblock explaining the intentional shared-utility role and why splitting would be over-engineering. This prevents future false positives from graph analyses.
- **Tests**: Added 6 edge-case tests for the private helper classes (`SafeRelativePath`, `SafeJoin`) covering backslash normalization, Windows path rejection, empty path rejection, valid joins, and traversal escape prevention.

Closes #90

## Test plan

- [x] `bundle exec rspec spec/lib/rails_ai_bridge/path_resolver_spec.rb` — 14 examples, 0 failures (8 original + 6 new)
- [x] `bundle exec rubocop lib/rails_ai_bridge/path_resolver.rb spec/lib/rails_ai_bridge/path_resolver_spec.rb` — no offenses
- [ ] Full suite: `bundle exec rspec` (CI will verify)

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation clarifying path resolution behavior and safety boundaries.

* **Bug Fixes**
  * Improved validation of relative paths, including Windows-style absolute paths and empty inputs.
  * Prevented path traversal when joining files with a base directory.

* **Tests**
  * Added coverage for path normalization, valid relative paths, absolute path rejection, and directory escape prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->