### PR TITLE
deps: bump mcp, rubydex, simplecov + fix simplecov 1.0 filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development, :test do
   gem 'rubocop-rails', '~> 2.35'
   gem 'rubocop-rails-omakase', '~> 1.0'
   gem 'rubocop-rspec', '~> 3.10'
-  gem 'simplecov', '~> 0.22'
+  gem 'simplecov', '~> 1.0.0'
   gem 'skunk', '~> 0.5'
   gem 'sqlite3', '~> 2.9'
 end

--- a/lib/rails_ai_bridge/serializers/context_summary.rb
+++ b/lib/rails_ai_bridge/serializers/context_summary.rb
@@ -459,7 +459,7 @@ module RailsAiBridge
       private_class_method :sensitive_config_basename?
 
       def sensitive_config_path_segment?(path)
-        path.split('/').any? { |segment| SENSITIVE_CONFIG_SEGMENTS.include?(segment) }
+        path.split('/').intersect?(SENSITIVE_CONFIG_SEGMENTS)
       end
       module_function :sensitive_config_path_segment?
       private_class_method :sensitive_config_path_segment?

--- a/rails-ai-bridge.gemspec
+++ b/rails-ai-bridge.gemspec
@@ -50,11 +50,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Core dependencies
-  spec.add_dependency 'mcp', '>= 0.10', '< 1.0' # Official MCP Ruby SDK
+  spec.add_dependency 'mcp', '>= 0.25', '< 1.0' # Official MCP Ruby SDK
   spec.add_dependency 'railties', '>= 7.1', '< 10.0'
   spec.add_dependency 'thor', '>= 1.0', '< 3.0'
   spec.add_dependency 'zeitwerk', '~> 2.6' # Autoloading
 
   # Semantic code analysis via Shopify's rubydex
-  spec.add_dependency 'rubydex', '~> 0.2.4'
+  spec.add_dependency 'rubydex', '~> 0.2.9'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'simplecov'
 SimpleCov.start do
-  add_filter '/spec/'
+  skip 'spec'
 end
 
 require_relative 'reek_helper'


### PR DESCRIPTION
## Summary

- **mcp** `>= 0.10` → `>= 0.25` — lock file already at 0.25.0; lower bound now matches the actual minimum the code requires
- **rubydex** `~> 0.2.4` → `~> 0.2.9` — lock file already at 0.2.9; tighten to reflect the actual minimum
- **simplecov** `~> 0.22` → `~> 1.0.0` — major version bump with a breaking change fix

### simplecov 1.0 breaking change fix

simplecov 1.0 changed `SourceFile#project_filename` to return a truly relative path with no leading separator (e.g. `spec/foo.rb` instead of `/spec/foo.rb`). The old `add_filter '/spec/'` string filter would no longer match because path-segment matching requires no leading slash. Migrated to the new `skip` API per the [simplecov 1.0 migration guide](https://github.com/simplecov-ruby/simplecov):

```ruby
# Before (simplecov 0.22)
SimpleCov.start do
  add_filter '/spec/'
end

# After (simplecov 1.0)
SimpleCov.start do
  skip 'spec'
end
```

## Dependency review

| Gem | Constraint | Locked | Latest | Status |
|-----|-----------|--------|--------|--------|
| mcp | `>= 0.25, < 1.0` | 0.25.0 | 0.25.0 | Bumped (was `>= 0.10`) |
| rubydex | `~> 0.2.9` | 0.2.9 | 0.2.9 | Bumped (was `~> 0.2.4`) |
| simplecov | `~> 1.0.0` | 1.0.2 | 1.0.2 | Bumped (was `~> 0.22`) + filter fix |
| railties | `>= 7.1, < 10.0` | 8.1.3 | 8.1.3 | Current, no action |
| thor | `>= 1.0, < 3.0` | 1.5.0 | 1.5.0 | Current, no action |
| zeitwerk | `~> 2.6` | 2.8.2 | 2.8.2 | Current, no action |
| bundler-audit | `~> 0.9` | 0.9.3 | 0.9.3 | Current, no action |
| combustion | `~> 1.3` | 1.5.0 | 1.5.0 | Current, no action |
| reek | `~> 6.1` | 6.5.0 | 6.5.0 | Current, no action |
| rspec | `~> 3.13` | 3.13.2 | 3.13.2 | Current, no action |
| rubocop | `~> 1.65` | 1.88.2 | 1.88.2 | Current, no action |
| skunk | `~> 0.5` | 0.5.4 | 0.5.4 | Current, no action |
| sqlite3 | `~> 2.9` | 2.9.5 | 2.9.5 | Current, no action |

**Security:** `bundle-audit` reports no vulnerabilities.

## Test plan

- [x] `bundle exec rspec` — 2157 examples, 0 failures
- [x] Coverage: 94.27% (filter works correctly with new `skip` API)
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec bundle-audit` — no vulnerabilities
- [ ] CI verification

Generated with [Devin](https://devin.ai)