### PR TITLE
chore(release): bump version to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0]
+
+### Changed
+
+- **`mcp` minimum version raised to 0.25** (#92) — the gemspec lower bound is now `>= 0.25` (was `>= 0.10`), matching the minimum version the codebase actually requires. The upper bound remains `< 1.0`.
+- **`rubydex` constraint tightened to `~> 0.2.9`** (#92) — was `~> 0.2.4`. This is a **minor breaking change** for users pinned to rubydex 0.2.4–0.2.8; update your lockfile with `bundle update rubydex`.
+- **`simplecov` bumped to 1.0** (#92) — development dependency only; does not affect gem consumers. The test suite filter was migrated from `add_filter '/spec/'` to `skip 'spec'` per the simplecov 1.0 migration guide (`SourceFile#project_filename` no longer includes a leading separator).
+
+### Fixed
+
+- **`Style/ArrayIntersect` lint offense** (#91/#92) — pre-existing rubocop offense in `context_summary.rb` autocorrected to use `Array#intersect?`. No behavior change.
+
+### Added
+
+- **PathResolver architectural documentation** (#90/#91) — class-level docblock documents PathResolver's intentional role as a shared utility (11 introspector callers, high betweenness centrality). Prevents false "god class" flags from future graph analyses.
+- **PathResolver edge-case tests** (#90/#91) — 6 new specs covering the private `SafeRelativePath` (backslash normalization, Windows path rejection, empty path rejection) and `SafeJoin` (valid joins, traversal escape prevention) helper classes.
+
 ## [3.5.2]
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ Bug reports and pull requests: [github.com/igmarin/rails-ai-bridge/issues](https
 
 ## Acknowledgments & Origins
 
-This gem ships as **rails-ai-bridge** (Ruby **`RailsAiBridge`**, version **3.1.0**). Earlier iterations of the same codebase were distributed as `rails-ai-context`.
+This gem ships as **rails-ai-bridge** (Ruby **`RailsAiBridge`**, version **3.6.0**). Earlier iterations of the same codebase were distributed as `rails-ai-context`.
 
 RailsMCP evolved from 
 [crisnahine/rails-ai-context](https://github.com/crisnahine/rails-ai-context),

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,22 @@
 # Upgrading rails-ai-bridge
 
+## Upgrading from 3.5.x to 3.6.0
+
+**One action required if you are pinned to an older `rubydex`:**
+
+The `rubydex` gem constraint was tightened from `~> 0.2.4` to `~> 0.2.9`. If your
+lockfile resolves to rubydex 0.2.4–0.2.8, update it after upgrading:
+
+```bash
+bundle update rubydex
+```
+
+No other configuration or code changes are required. The `mcp` lower bound also
+moved from `>= 0.10` to `>= 0.25`, but if you were already on a recent version
+(no earlier than 0.25) this is a no-op.
+
+---
+
 ## Upgrading from 1.x to 2.x
 
 **No configuration changes required.** Every `config.*` attribute from 1.x is still available — `Configuration` now delegates to focused sub-objects but exposes the same flat DSL. See `CHANGELOG.md` for the full list of internal changes.

--- a/lib/rails_ai_bridge/path_resolver.rb
+++ b/lib/rails_ai_bridge/path_resolver.rb
@@ -9,7 +9,7 @@ module RailsAiBridge
   # PathResolver is deliberately used by every introspector that needs to
   # locate files on disk (controller, model, view, stimulus, turbo, auth,
   # api, config, action_text, activeStorage, nonArModels — 11 callers as of
-  # v3.5.2). It is NOT a god class despite high betweenness centrality in
+  # v3.6.0). It is NOT a god class despite high betweenness centrality in
   # graph analyses: a foundational path-resolution utility is expected to
   # sit at the centre of the introspector graph. Splitting it would spread
   # path-safety logic (traversal guards, safe joins) across multiple files

--- a/lib/rails_ai_bridge/version.rb
+++ b/lib/rails_ai_bridge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiBridge
-  VERSION = '3.5.2'
+  VERSION = '3.6.0'
 end


### PR DESCRIPTION
## Summary

Release prep for **3.6.0** — dependency constraint tightening + documentation.

### Version bump
- `version.rb`: 3.5.2 → 3.6.0

### Documentation updates
- **CHANGELOG.md**: added `[3.6.0]` section with Changed/Fixed/Added entries covering the `mcp`, `rubydex`, and `simplecov` dependency changes, the lint fix, and the PathResolver documentation + tests
- **UPGRADING.md**: added "Upgrading from 3.5.x to 3.6.0" section documenting the one user-facing action (`bundle update rubydex` for users pinned to 0.2.4–0.2.8)
- **README.md**: fixed stale "version 3.1.0" reference in Acknowledgments section → 3.6.0
- **path_resolver.rb**: updated docblock caller-count reference from v3.5.2 → v3.6.0

### Why 3.6.0 (minor) not 3.5.3 (patch)
The `rubydex` constraint tightening (`~> 0.2.4` → `~> 0.2.9`) is a breaking change for users pinned to rubydex 0.2.4–0.2.8. Per semver, this warrants a minor bump.

## Test plan

- [x] `bundle exec rspec` — 2163 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [x] Version loads correctly: `RailsAiBridge::VERSION` → `3.6.0`
- [ ] CI verification

Generated with [Devin](https://devin.ai)