### PR TITLE
Support structure.sql (schema_format = :sql) in offline schema introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ai:doctor` schema check for `schema_format = :sql`** (#96/#97) — Schema check passes when `db/structure.sql` is present; fix hint points at `rails db:migrate` (or `rails db:schema:dump`).
 
 ## [3.6.1] - 2026-08-07
- - 2026-08-07
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`structure.sql` support in offline/static schema introspection** (#96/#97) — apps using `config.active_record.schema_format = :sql` (no `db/schema.rb`) now get table, column, index, and foreign-key context offline via `Introspectors::Schema::StaticStructureSqlParser`. The live-connection path was already format-agnostic. Output shape matches the live introspector so formatters work unchanged. Partition-child tables (`CREATE TABLE … PARTITION OF …`) are not expanded (follow-up).
+
+### Fixed
+
+- **`ai:doctor` schema check for `schema_format = :sql`** (#96/#97) — Schema check passes when `db/structure.sql` is present; fix hint points at `rails db:migrate` (or `rails db:schema:dump`).
+
 ## [3.6.1] - 2026-08-07
 
 ### Security
@@ -19,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`rubydex` bumped to `~> 0.3.0`** (#103/#111) — was `~> 0.2.9`. Run `bundle update rubydex` in host apps.
 - **Dependency audit (2026-08)** (#99) — `bundle-audit` clean; official `mcp` remains on **0.25.x** (`< 1.0`). Migration to `mcp` 1.x remains open in #104.
+
 
 ## [3.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ai:doctor` schema check for `schema_format = :sql`** (#96/#97) — Schema check passes when `db/structure.sql` is present; fix hint points at `rails db:migrate` (or `rails db:schema:dump`).
 
 ## [3.6.1] - 2026-08-07
+ - 2026-08-07
 
 ### Security
 
@@ -27,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`rubydex` bumped to `~> 0.3.0`** (#103/#111) — was `~> 0.2.9`. Run `bundle update rubydex` in host apps.
 - **Dependency audit (2026-08)** (#99) — `bundle-audit` clean; official `mcp` remains on **0.25.x** (`< 1.0`). Migration to `mcp` 1.x remains open in #104.
-
 
 ## [3.6.0]
 

--- a/lib/rails_ai_bridge/doctor/checkers/schema_checker.rb
+++ b/lib/rails_ai_bridge/doctor/checkers/schema_checker.rb
@@ -9,14 +9,15 @@ module RailsAiBridge
       class SchemaChecker < BaseChecker
         # @return [Doctor::Check] +:pass+ when a schema file exists; +:warn+ otherwise
         def call
+          schema_file = present_schema_file
           check(
             'Schema',
-            present_schema_file,
-            pass: { message: "#{present_schema_file} found" },
+            schema_file,
+            pass: { message: "#{schema_file} found" },
             fail: {
               status: :warn,
               message: 'db/schema.rb or db/structure.sql not found',
-              fix: 'Run `rails db:migrate` (or `db:schema:dump`) to generate one'
+              fix: 'Run `rails db:migrate` (or `rails db:schema:dump`) to generate one'
             }
           )
         end

--- a/lib/rails_ai_bridge/doctor/checkers/schema_checker.rb
+++ b/lib/rails_ai_bridge/doctor/checkers/schema_checker.rb
@@ -3,17 +3,29 @@
 module RailsAiBridge
   class Doctor
     module Checkers
-      # Verifies +db/schema.rb+ exists for schema-driven AI context.
+      # Verifies a schema file exists for schema-driven AI context. Accepts
+      # either +db/schema.rb+ (+schema_format = :ruby+) or +db/structure.sql+
+      # (+schema_format = :sql+).
       class SchemaChecker < BaseChecker
-        # @return [Doctor::Check] +:pass+ when the schema file exists; +:warn+ otherwise
+        # @return [Doctor::Check] +:pass+ when a schema file exists; +:warn+ otherwise
         def call
-          schema_path = File.join(app.root, 'db/schema.rb')
           check(
             'Schema',
-            File.exist?(schema_path),
-            pass: { message: 'db/schema.rb found' },
-            fail: { status: :warn, message: 'db/schema.rb not found', fix: 'Run `rails db:schema:dump` to generate it' }
+            present_schema_file,
+            pass: { message: "#{present_schema_file} found" },
+            fail: {
+              status: :warn,
+              message: 'db/schema.rb or db/structure.sql not found',
+              fix: 'Run `rails db:migrate` (or `db:schema:dump`) to generate one'
+            }
           )
+        end
+
+        private
+
+        # @return [String, nil] the schema file that exists (schema.rb preferred), or +nil+
+        def present_schema_file
+          %w[db/schema.rb db/structure.sql].find { |rel| File.exist?(File.join(app.root, rel)) }
         end
       end
     end

--- a/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser.rb
+++ b/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser.rb
@@ -23,10 +23,16 @@ module RailsAiBridge
       #   +PRIMARY KEY+, +FOREIGN KEY+, …) are skipped.
       # * +);+ — closes the current table context
       # * +CREATE [UNIQUE] INDEX name ON [schema.]table USING method (cols)+ —
-      #   adds an index entry (first column only) to the named table
+      #   adds an index entry (first simple column) to the named table.
+      #   Functional/expression indexes (e.g. +lower(email)+) are skipped.
+      # * +ALTER TABLE [ONLY] table ADD CONSTRAINT ... FOREIGN KEY (col)
+      #   REFERENCES ref_table (pk)+ — adds a foreign-key entry to +table+
+      #   (pg_dump emits these in a separate constraints section).
       #
-      # Foreign keys are intentionally left empty to match {StaticSchemaParser};
-      # the live {SchemaIntrospector} path reports them in full.
+      # Unlike {StaticSchemaParser} (whose +schema.rb+ static form leaves foreign
+      # keys empty), +structure.sql+ spells foreign keys out as parseable DDL, so
+      # this parser populates them offline — matching what the live
+      # {SchemaIntrospector} path reports.
       #
       # Internal Rails tables (+ar_internal_metadata+, +schema_migrations+) and
       # any table matching {Config::Introspection#excluded_tables} are silently
@@ -56,6 +62,21 @@ module RailsAiBridge
         # (parity with {StaticSchemaParser}).
         INDEX_LINE = /\ACREATE\s+(?:UNIQUE\s+)?INDEX\s+.+?\s+ON\s+(?:[\w"]+\.)?"?([A-Za-z_]\w*)"?\s+(?:USING\s+\w+\s+)?\(([^)]+)\)/
 
+        # Regex matching an +ALTER TABLE [ONLY] [schema.]table+ statement, which
+        # in pg_dump precedes an +ADD CONSTRAINT+ line. Captures the target table.
+        ALTER_TABLE_LINE = /\AALTER TABLE (?:ONLY\s+)?(?:[\w"]+\.)?"?([A-Za-z_]\w*)"?/
+
+        # Regex matching an +ADD CONSTRAINT ... FOREIGN KEY (cols) REFERENCES
+        # [schema.]ref_table (pk)+ clause. Captures local columns, referenced
+        # table, and referenced columns.
+        FOREIGN_KEY_LINE = /FOREIGN KEY\s*\(([^)]+)\)\s*REFERENCES\s+(?:[\w"]+\.)?"?([A-Za-z_]\w*)"?\s*\(([^)]+)\)/
+
+        # Regex matching an +ON DELETE <action>+ clause on a foreign-key line.
+        ON_DELETE = /ON DELETE ([A-Z ]+?)(?=\s+ON UPDATE|\s+(?:NOT\s+)?(?:DEFERRABLE|VALID)|[,;)]|\z)/i
+
+        # Regex matching an +ON UPDATE <action>+ clause on a foreign-key line.
+        ON_UPDATE = /ON UPDATE ([A-Z ]+?)(?=\s+(?:NOT\s+)?(?:DEFERRABLE|VALID)|[,;)]|\z)/i
+
         # Rails-managed tables that must never appear in introspection output.
         INTERNAL_TABLES = %w[ar_internal_metadata schema_migrations].freeze
 
@@ -72,22 +93,17 @@ module RailsAiBridge
           @tables        = {}
           @current_table = nil
           @in_table      = false
+          @alter_target  = nil
         end
 
-        # Parse the structure.sql content and return the tables hash.
+        # Parse the structure.sql content and return the tables hash. Never
+        # raises — malformed or non-UTF-8 input is caught and reported as an
+        # error hash, per the introspector contract.
         #
         # @return [Hash{Symbol => Object}] with keys +:adapter+, +:tables+,
-        #   +:total_tables+, and +:note+
+        #   +:total_tables+, and +:note+; or +{ error: }+ on failure
         def call
-          @content.each_line do |line|
-            if @in_table
-              parse_body_line(line)
-            else
-              next if parse_table_line?(line)
-
-              parse_index_line?(line)
-            end
-          end
+          @content.each_line { |line| parse_line(line) }
 
           {
             adapter: 'static_parse',
@@ -95,9 +111,25 @@ module RailsAiBridge
             total_tables: @tables.size,
             note: 'Parsed from db/structure.sql (no DB connection)'
           }
+        rescue StandardError => error
+          { error: "Failed to parse db/structure.sql: #{error.message}" }
         end
 
         private
+
+        # Dispatches a single line to the table-body handler or the top-level
+        # (create/index/alter/foreign-key) handlers.
+        #
+        # @param line [String]
+        # @return [void]
+        def parse_line(line)
+          return parse_body_line(line) if @in_table
+          return if parse_table_line?(line)
+          return if parse_index_line?(line)
+          return if parse_alter_table_line?(line)
+
+          parse_foreign_key_line?(line)
+        end
 
         # Opens a table context on a +CREATE TABLE+ line. Sets +@current_table+
         # to +nil+ for skipped tables while still tracking that we are inside a
@@ -158,6 +190,43 @@ module RailsAiBridge
           true
         end
 
+        # Records the target table of an +ALTER TABLE+ statement so a following
+        # +ADD CONSTRAINT ... FOREIGN KEY+ line can attach to it. Sets
+        # +@alter_target+ to +nil+ for skipped/unknown tables.
+        #
+        # @param line [String]
+        # @return [Boolean] +true+ if the line matched
+        def parse_alter_table_line?(line)
+          match = ALTER_TABLE_LINE.match(line)
+          return false unless match
+
+          @alter_target = @tables.key?(match[1]) ? match[1] : nil
+          true
+        end
+
+        # Appends a foreign-key entry to the current +@alter_target+ table. Mirrors
+        # the live introspector's shape (+from_table+, +to_table+, +column+,
+        # +primary_key+, +on_delete+, +on_update+), keeping the first column of a
+        # composite key for parity with index handling. No-ops without a target.
+        #
+        # @param line [String]
+        # @return [Boolean] +true+ if the line matched
+        def parse_foreign_key_line?(line)
+          match = FOREIGN_KEY_LINE.match(line)
+          return false unless match
+          return true unless @alter_target
+
+          @tables[@alter_target][:foreign_keys] << {
+            from_table: @alter_target,
+            to_table: match[2],
+            column: first_identifier(match[1]),
+            primary_key: first_identifier(match[3]),
+            on_delete: fk_action(line, ON_DELETE),
+            on_update: fk_action(line, ON_UPDATE)
+          }.compact
+          true
+        end
+
         # Strips a trailing comma and the +DEFAULT ...+ / +NOT NULL+ / +NULL+
         # modifiers to leave the bare SQL type.
         #
@@ -173,13 +242,37 @@ module RailsAiBridge
         end
 
         # Extracts the first column identifier from an index's parenthesised
-        # column list, dropping opclasses (+col varchar_pattern_ops+) and
-        # expression noise.
+        # column list. Keeps plain and opclass-qualified columns
+        # (+col varchar_pattern_ops+ → +col+) but returns +nil+ for functional
+        # or expression indexes (+lower(email)+) so they are skipped rather than
+        # mis-attributed to the function name.
         #
         # @param columns [String] raw text between the index parentheses
         # @return [String, nil]
         def first_index_column(columns)
+          first = columns.split(',').first&.strip
+          return nil if first.nil? || first.include?('(')
+
+          first.slice(/[A-Za-z_]\w*/)
+        end
+
+        # Returns the first identifier from a (possibly composite) column list.
+        #
+        # @param columns [String] comma-separated column list
+        # @return [String, nil]
+        def first_identifier(columns)
           columns.split(',').first&.slice(/[A-Za-z_]\w*/)
+        end
+
+        # Extracts a normalized foreign-key referential action (e.g. +CASCADE+,
+        # +SET NULL+) from a line, or +nil+ when the clause is absent.
+        #
+        # @param line [String]
+        # @param pattern [Regexp] {ON_DELETE} or {ON_UPDATE}
+        # @return [String, nil]
+        def fk_action(line, pattern)
+          match = pattern.match(line)
+          match && match[1].strip.squeeze(' ').upcase
         end
 
         # @param name [String]

--- a/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser.rb
+++ b/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Introspectors
+    module Schema
+      # Parses a +db/structure.sql+ file as plain text, without a live database
+      # connection. This is the +schema_format = :sql+ counterpart to
+      # {StaticSchemaParser}: apps that keep their schema as SQL (common on
+      # Postgres, where +schema.rb+ cannot represent partitions, views,
+      # extensions, or custom SQL) have no +db/schema.rb+ to fall back to in
+      # offline environments (CI, Claude Code, agent contexts).
+      #
+      # Each instance is single-use: construct it with the file content and a
+      # configuration object, call {#call}, and discard. No mutable state
+      # escapes the instance.
+      #
+      # == Supported DDL (pg_dump / structure.sql form)
+      #
+      # * +CREATE TABLE [IF NOT EXISTS] [schema.]name (+ — opens a table context
+      # * +<name> <type> ...+ — a column line inside the table body; the leading
+      #   identifier is the column and the remainder (minus +NOT NULL+/+DEFAULT+)
+      #   is the SQL type. Table-level constraint lines (+CONSTRAINT+,
+      #   +PRIMARY KEY+, +FOREIGN KEY+, …) are skipped.
+      # * +);+ — closes the current table context
+      # * +CREATE [UNIQUE] INDEX name ON [schema.]table USING method (cols)+ —
+      #   adds an index entry (first column only) to the named table
+      #
+      # Foreign keys are intentionally left empty to match {StaticSchemaParser};
+      # the live {SchemaIntrospector} path reports them in full.
+      #
+      # Internal Rails tables (+ar_internal_metadata+, +schema_migrations+) and
+      # any table matching {Config::Introspection#excluded_tables} are silently
+      # skipped.
+      #
+      # @example
+      #   content = File.read("db/structure.sql")
+      #   result  = StaticStructureSqlParser.new(content: content, config: RailsAiBridge.configuration).call
+      #   # => { adapter: "static_parse", tables: { ... }, total_tables: N, note: "..." }
+      #
+      # @see RailsAiBridge::Introspectors::SchemaIntrospector
+      # @see RailsAiBridge::Introspectors::Schema::StaticSchemaParser
+      class StaticStructureSqlParser
+        # Regex matching a +CREATE TABLE+ declaration, tolerating +IF NOT EXISTS+,
+        # a schema qualifier (+public.+), and optional quoting of either part.
+        TABLE_LINE = /\ACREATE TABLE (?:IF NOT EXISTS\s+)?(?:[\w"]+\.)?"?([A-Za-z_]\w*)"?\s*\(/
+
+        # Regex matching the end of a table body (+);+ at column zero).
+        TABLE_END_LINE = /\A\)/
+
+        # Regex matching a column definition inside a table body: leading
+        # whitespace, an identifier (optionally quoted), then the type/modifiers.
+        COLUMN_LINE = /\A\s+"?([A-Za-z_]\w*)"?\s+(.+)/
+
+        # Regex matching a +CREATE INDEX+ statement. Captures the target table
+        # and the raw parenthesised column list; only the first column is kept
+        # (parity with {StaticSchemaParser}).
+        INDEX_LINE = /\ACREATE\s+(?:UNIQUE\s+)?INDEX\s+.+?\s+ON\s+(?:[\w"]+\.)?"?([A-Za-z_]\w*)"?\s+(?:USING\s+\w+\s+)?\(([^)]+)\)/
+
+        # Rails-managed tables that must never appear in introspection output.
+        INTERNAL_TABLES = %w[ar_internal_metadata schema_migrations].freeze
+
+        # Table-level constraint keywords that share a column line's shape but
+        # are not columns.
+        CONSTRAINT_KEYWORDS = %w[CONSTRAINT PRIMARY FOREIGN UNIQUE CHECK EXCLUDE LIKE DEFERRABLE].freeze
+
+        # @param content [String] full text of +db/structure.sql+
+        # @param config  [RailsAiBridge::Config::Introspection, RailsAiBridge::Configuration]
+        #   any object that responds to +#excluded_table?+
+        def initialize(content:, config:)
+          @content       = content
+          @config        = config
+          @tables        = {}
+          @current_table = nil
+          @in_table      = false
+        end
+
+        # Parse the structure.sql content and return the tables hash.
+        #
+        # @return [Hash{Symbol => Object}] with keys +:adapter+, +:tables+,
+        #   +:total_tables+, and +:note+
+        def call
+          @content.each_line do |line|
+            if @in_table
+              parse_body_line(line)
+            else
+              next if parse_table_line?(line)
+
+              parse_index_line?(line)
+            end
+          end
+
+          {
+            adapter: 'static_parse',
+            tables: @tables,
+            total_tables: @tables.size,
+            note: 'Parsed from db/structure.sql (no DB connection)'
+          }
+        end
+
+        private
+
+        # Opens a table context on a +CREATE TABLE+ line. Sets +@current_table+
+        # to +nil+ for skipped tables while still tracking that we are inside a
+        # body, so the closing +);+ is honoured.
+        #
+        # @param line [String]
+        # @return [Boolean] +true+ if the line matched
+        def parse_table_line?(line)
+          match = TABLE_LINE.match(line)
+          return false unless match
+
+          name = match[1]
+          @in_table = true
+          @current_table = skip_table?(name) ? nil : name
+          @tables[@current_table] = { columns: [], indexes: [], foreign_keys: [] } if @current_table
+          true
+        end
+
+        # Handles a line while inside a table body: either the closing paren or a
+        # column definition (constraint lines are ignored).
+        #
+        # @param line [String]
+        # @return [void]
+        def parse_body_line(line)
+          if TABLE_END_LINE.match?(line)
+            @in_table = false
+            @current_table = nil
+            return
+          end
+
+          parse_column_line(line) if @current_table
+        end
+
+        # Appends a column to the current table unless the line is a table-level
+        # constraint.
+        #
+        # @param line [String]
+        # @return [void]
+        def parse_column_line(line)
+          match = COLUMN_LINE.match(line)
+          return unless match
+          return if constraint_keyword?(match[1])
+
+          @tables[@current_table][:columns] << { name: match[1], type: normalize_type(match[2]) }
+        end
+
+        # Adds an index entry (first column only) to the matching table. No-ops
+        # when the table is not present in +@tables+.
+        #
+        # @param line [String]
+        # @return [Boolean] +true+ if the line matched
+        def parse_index_line?(line)
+          match = INDEX_LINE.match(line)
+          return false unless match
+
+          column = first_index_column(match[2])
+          @tables[match[1]]&.dig(:indexes)&.push({ columns: column }) if column
+          true
+        end
+
+        # Strips a trailing comma and the +DEFAULT ...+ / +NOT NULL+ / +NULL+
+        # modifiers to leave the bare SQL type.
+        #
+        # @param raw [String] everything after the column name
+        # @return [String] the SQL type (e.g. +"character varying"+, +"bigint"+)
+        def normalize_type(raw)
+          raw.strip
+             .sub(/,\s*\z/, '')
+             .sub(/\s+DEFAULT\b.*\z/i, '')
+             .sub(/\s+NOT\s+NULL\s*\z/i, '')
+             .sub(/\s+NULL\s*\z/i, '')
+             .strip
+        end
+
+        # Extracts the first column identifier from an index's parenthesised
+        # column list, dropping opclasses (+col varchar_pattern_ops+) and
+        # expression noise.
+        #
+        # @param columns [String] raw text between the index parentheses
+        # @return [String, nil]
+        def first_index_column(columns)
+          columns.split(',').first&.slice(/[A-Za-z_]\w*/)
+        end
+
+        # @param name [String]
+        # @return [Boolean] +true+ when +name+ is a table-level constraint keyword
+        def constraint_keyword?(name)
+          CONSTRAINT_KEYWORDS.include?(name.upcase)
+        end
+
+        # @param name [String]
+        # @return [Boolean] +true+ when +name+ is internal or excluded by config
+        def skip_table?(name)
+          INTERNAL_TABLES.any? { |t| name.start_with?(t) } ||
+            @config.excluded_table?(name)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/schema_introspector.rb
@@ -146,6 +146,10 @@ module RailsAiBridge
         else
           { error: "No db/schema.rb or db/structure.sql found in #{File.join(app.root, 'db')}" }
         end
+      rescue StandardError => error
+        # Guards the exist?/read race (file removed between check and read) and
+        # any other read failure, honouring the introspector never-raise contract.
+        { error: "Failed to read schema file: #{error.message}" }
       end
     end
   end

--- a/lib/rails_ai_bridge/introspectors/schema_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/schema_introspector.rb
@@ -4,11 +4,13 @@ module RailsAiBridge
   module Introspectors
     # Extracts database schema information — tables, columns, indexes, and
     # foreign keys — from a live ActiveRecord connection when available, or by
-    # falling back to text-parsing +db/schema.rb+ via
-    # {Schema::StaticSchemaParser} when no connection is present (CI, Claude
-    # Code, offline environments).
+    # text-parsing the schema file when no connection is present (CI, Claude
+    # Code, offline environments). The static fallback prefers +db/schema.rb+
+    # ({Schema::StaticSchemaParser}) and falls back to +db/structure.sql+
+    # ({Schema::StaticStructureSqlParser}) for +schema_format = :sql+ apps.
     #
     # @see Schema::StaticSchemaParser
+    # @see Schema::StaticStructureSqlParser
     class SchemaIntrospector
       # @return [Rails::Application]
       attr_reader :app
@@ -127,15 +129,23 @@ module RailsAiBridge
         File.join(app.root, 'db', 'schema.rb')
       end
 
-      # Fallback: parse db/schema.rb as text when the DB is not connected.
-      # Delegates all parsing to {Schema::StaticSchemaParser}.
-      #
-      # @return [Hash] parsed schema result, or +{ error: }+ when the file is absent
-      def static_schema_parse
-        path = schema_file_path
-        return { error: "No schema.rb found at #{path}" } unless File.exist?(path)
+      def structure_sql_path
+        File.join(app.root, 'db', 'structure.sql')
+      end
 
-        Schema::StaticSchemaParser.new(content: File.read(path), config: config).call
+      # Fallback used when the DB is not connected. Prefers +db/schema.rb+
+      # (Ruby DSL) and falls back to +db/structure.sql+ (raw SQL) so
+      # +schema_format = :sql+ apps still get schema context offline.
+      #
+      # @return [Hash] parsed schema result, or +{ error: }+ when neither file exists
+      def static_schema_parse
+        if File.exist?(schema_file_path)
+          Schema::StaticSchemaParser.new(content: File.read(schema_file_path), config: config).call
+        elsif File.exist?(structure_sql_path)
+          Schema::StaticStructureSqlParser.new(content: File.read(structure_sql_path), config: config).call
+        else
+          { error: "No db/schema.rb or db/structure.sql found in #{File.join(app.root, 'db')}" }
+        end
       end
     end
   end

--- a/spec/lib/rails_ai_bridge/doctor/checkers/schema_checker_spec.rb
+++ b/spec/lib/rails_ai_bridge/doctor/checkers/schema_checker_spec.rb
@@ -5,28 +5,56 @@ require 'spec_helper'
 RSpec.describe RailsAiBridge::Doctor::Checkers::SchemaChecker do
   let(:app) { Rails.application }
   let(:checker) { described_class.new(app) }
+  let(:schema_rb_path) { File.join(app.root, 'db/schema.rb') }
+  let(:structure_sql_path) { File.join(app.root, 'db/structure.sql') }
+
+  before do
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with(schema_rb_path).and_return(schema_rb_exists)
+    allow(File).to receive(:exist?).with(structure_sql_path).and_return(structure_sql_exists)
+  end
 
   describe '#call' do
-    let(:schema_path) { File.join(app.root, 'db/schema.rb') }
-
     context 'when db/schema.rb exists' do
-      before { allow(File).to receive(:exist?).with(schema_path).and_return(true) }
+      let(:schema_rb_exists) { true }
+      let(:structure_sql_exists) { false }
 
-      it 'returns a pass check' do
+      it 'returns a pass check naming schema.rb' do
         result = checker.call
         expect(result.status).to eq(:pass)
         expect(result.message).to eq('db/schema.rb found')
       end
     end
 
-    context 'when db/schema.rb does not exist' do
-      before { allow(File).to receive(:exist?).with(schema_path).and_return(false) }
+    context 'when only db/structure.sql exists (schema_format = :sql)' do
+      let(:schema_rb_exists) { false }
+      let(:structure_sql_exists) { true }
 
-      it 'returns a warn check' do
+      it 'returns a pass check naming structure.sql' do
+        result = checker.call
+        expect(result.status).to eq(:pass)
+        expect(result.message).to eq('db/structure.sql found')
+      end
+    end
+
+    context 'when db/schema.rb takes precedence over db/structure.sql' do
+      let(:schema_rb_exists) { true }
+      let(:structure_sql_exists) { true }
+
+      it 'reports schema.rb' do
+        expect(checker.call.message).to eq('db/schema.rb found')
+      end
+    end
+
+    context 'when neither schema file exists' do
+      let(:schema_rb_exists) { false }
+      let(:structure_sql_exists) { false }
+
+      it 'returns a warn check that mentions both files' do
         result = checker.call
         expect(result.status).to eq(:warn)
-        expect(result.message).to eq('db/schema.rb not found')
-        expect(result.fix).to include('rails db:schema:dump')
+        expect(result.message).to eq('db/schema.rb or db/structure.sql not found')
+        expect(result.fix).to include('rails db:migrate')
       end
     end
   end

--- a/spec/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser_spec.rb
@@ -151,6 +151,27 @@ RSpec.describe RailsAiBridge::Introspectors::Schema::StaticStructureSqlParser do
       content = "CREATE INDEX idx ON public.unknown USING btree (col);\n"
       expect(parse(content)[:tables]).to be_empty
     end
+
+    it 'keeps an opclass-qualified column (drops the opclass)' do
+      content = <<~DDL
+        CREATE TABLE public.users (
+            email character varying
+        );
+        CREATE INDEX index_users_on_email ON public.users USING btree (email varchar_pattern_ops);
+      DDL
+      indexes = parse(content)[:tables]['users'][:indexes]
+      expect(indexes.pluck(:columns)).to contain_exactly('email')
+    end
+
+    it 'skips a functional/expression index instead of mis-attributing the function name' do
+      content = <<~DDL
+        CREATE TABLE public.users (
+            email character varying
+        );
+        CREATE INDEX index_users_on_lower_email ON public.users USING btree (lower((email)::text));
+      DDL
+      expect(parse(content)[:tables]['users'][:indexes]).to be_empty
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -221,6 +242,78 @@ RSpec.describe RailsAiBridge::Introspectors::Schema::StaticStructureSqlParser do
     it 'supports glob patterns in excluded_tables' do
       config.excluded_tables << 'audit_*'
       expect(parse(content)[:tables]).not_to have_key('audit_logs')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Foreign key parsing (ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY)
+  # ---------------------------------------------------------------------------
+  describe 'foreign key parsing' do
+    let(:content) do
+      <<~DDL
+        CREATE TABLE public.posts (
+            id bigint NOT NULL,
+            user_id bigint
+        );
+        CREATE TABLE public.users (
+            id bigint NOT NULL
+        );
+        ALTER TABLE ONLY public.posts
+            ADD CONSTRAINT fk_rails_abc123 FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+      DDL
+    end
+
+    it 'attaches the foreign key to the altered table' do
+      fks = parse(content)[:tables]['posts'][:foreign_keys]
+      expect(fks.size).to eq(1)
+    end
+
+    it 'captures from_table, to_table, column and primary_key' do
+      fk = parse(content)[:tables]['posts'][:foreign_keys].first
+      expect(fk).to include(from_table: 'posts', to_table: 'users', column: 'user_id', primary_key: 'id')
+    end
+
+    it 'captures the ON DELETE referential action' do
+      fk = parse(content)[:tables]['posts'][:foreign_keys].first
+      expect(fk[:on_delete]).to eq('CASCADE')
+    end
+
+    it 'omits absent on_update rather than storing nil' do
+      fk = parse(content)[:tables]['posts'][:foreign_keys].first
+      expect(fk).not_to have_key(:on_update)
+    end
+
+    it 'ignores a FOREIGN KEY whose ALTER TABLE target is not a parsed table' do
+      content = <<~DDL
+        ALTER TABLE ONLY public.unknown
+            ADD CONSTRAINT fk FOREIGN KEY (x_id) REFERENCES public.users(id);
+      DDL
+      expect(parse(content)[:tables]).to be_empty
+    end
+
+    it 'does not treat a non-foreign-key ADD CONSTRAINT as a foreign key' do
+      content = <<~DDL
+        CREATE TABLE public.users (
+            id bigint NOT NULL
+        );
+        ALTER TABLE ONLY public.users
+            ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+      DDL
+      expect(parse(content)[:tables]['users'][:foreign_keys]).to be_empty
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Error handling (introspector contract: never raise)
+  # ---------------------------------------------------------------------------
+  describe 'error handling' do
+    it 'returns an error hash instead of raising on invalid-encoding input' do
+      invalid = +"CREATE TABLE public.users (\n    email \xC3\x28 NOT NULL\n);\n"
+      invalid.force_encoding('UTF-8')
+
+      result = nil
+      expect { result = parse(invalid) }.not_to raise_error
+      expect(result[:error]).to include('db/structure.sql')
     end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::Introspectors::Schema::StaticStructureSqlParser do
+  let(:config) { RailsAiBridge.configuration }
+
+  def parse(content)
+    described_class.new(content: content, config: config).call
+  end
+
+  # ---------------------------------------------------------------------------
+  # Shape of the result
+  # ---------------------------------------------------------------------------
+  describe 'result shape' do
+    let(:content) do
+      <<~DDL
+        CREATE TABLE public.users (
+            id bigint NOT NULL,
+            email character varying NOT NULL,
+            age integer
+        );
+      DDL
+    end
+
+    it 'returns a Hash' do
+      expect(parse(content)).to be_a(Hash)
+    end
+
+    it 'sets adapter to static_parse' do
+      expect(parse(content)[:adapter]).to eq('static_parse')
+    end
+
+    it 'includes a note about the parse source' do
+      expect(parse(content)[:note]).to include('structure.sql')
+    end
+
+    it 'total_tables equals the number of tables parsed' do
+      result = parse(content)
+      expect(result[:total_tables]).to eq(result[:tables].size)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Table parsing
+  # ---------------------------------------------------------------------------
+  describe 'table parsing' do
+    let(:content) do
+      <<~DDL
+        CREATE TABLE public.users (
+            email character varying
+        );
+        CREATE TABLE public.posts (
+            title character varying
+        );
+      DDL
+    end
+
+    it 'captures each CREATE TABLE as a table key (schema-qualifier stripped)' do
+      expect(parse(content)[:tables].keys).to contain_exactly('users', 'posts')
+    end
+
+    it 'initialises each table with empty indexes and foreign_keys arrays' do
+      result = parse(content)
+      expect(result[:tables]['users'][:indexes]).to eq([])
+      expect(result[:tables]['users'][:foreign_keys]).to eq([])
+    end
+
+    it 'handles IF NOT EXISTS and an unqualified, quoted table name' do
+      content = %(CREATE TABLE IF NOT EXISTS "orders" (\n    id bigint\n);\n)
+      expect(parse(content)[:tables]).to have_key('orders')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Column parsing
+  # ---------------------------------------------------------------------------
+  describe 'column parsing' do
+    let(:content) do
+      <<~DDL
+        CREATE TABLE public.users (
+            id bigint NOT NULL,
+            email character varying(255) DEFAULT ''::character varying NOT NULL,
+            created_at timestamp without time zone NOT NULL,
+            "order" integer,
+            active boolean
+        );
+      DDL
+    end
+
+    it 'captures column names, including quoted reserved words' do
+      columns = parse(content)[:tables]['users'][:columns]
+      expect(columns.pluck(:name)).to contain_exactly('id', 'email', 'created_at', 'order', 'active')
+    end
+
+    it 'strips NOT NULL to leave the bare type' do
+      columns = parse(content)[:tables]['users'][:columns]
+      expect(columns.find { |c| c[:name] == 'id' }[:type]).to eq('bigint')
+    end
+
+    it 'strips a DEFAULT clause (and trailing NOT NULL) to leave the bare type' do
+      columns = parse(content)[:tables]['users'][:columns]
+      expect(columns.find { |c| c[:name] == 'email' }[:type]).to eq('character varying(255)')
+    end
+
+    it 'preserves multi-word SQL types' do
+      columns = parse(content)[:tables]['users'][:columns]
+      expect(columns.find { |c| c[:name] == 'created_at' }[:type]).to eq('timestamp without time zone')
+    end
+
+    it 'does not capture columns outside a table block' do
+      expect(parse("    email character varying\n")[:tables]).to be_empty
+    end
+
+    it 'skips table-level constraint lines' do
+      content = <<~DDL
+        CREATE TABLE public.users (
+            id bigint NOT NULL,
+            CONSTRAINT users_pkey PRIMARY KEY (id)
+        );
+      DDL
+      names = parse(content)[:tables]['users'][:columns].pluck(:name)
+      expect(names).to contain_exactly('id')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Index parsing
+  # ---------------------------------------------------------------------------
+  describe 'index parsing' do
+    let(:content) do
+      <<~DDL
+        CREATE TABLE public.users (
+            email character varying
+        );
+        CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
+        CREATE INDEX index_users_on_name_and_age ON public.users USING btree (name, age);
+      DDL
+    end
+
+    it 'adds an index entry to the matching table' do
+      expect(parse(content)[:tables]['users'][:indexes].size).to eq(2)
+    end
+
+    it 'records only the first column of each index (parity with schema.rb parser)' do
+      indexes = parse(content)[:tables]['users'][:indexes]
+      expect(indexes.pluck(:columns)).to contain_exactly('email', 'name')
+    end
+
+    it 'ignores CREATE INDEX for a table not in the schema' do
+      content = "CREATE INDEX idx ON public.unknown USING btree (col);\n"
+      expect(parse(content)[:tables]).to be_empty
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Internal table filtering
+  # ---------------------------------------------------------------------------
+  describe 'internal table filtering' do
+    let(:content) do
+      <<~DDL
+        CREATE TABLE public.ar_internal_metadata (
+            key character varying NOT NULL
+        );
+        CREATE TABLE public.schema_migrations (
+            version character varying NOT NULL
+        );
+        CREATE TABLE public.users (
+            email character varying
+        );
+      DDL
+    end
+
+    it 'excludes ar_internal_metadata' do
+      expect(parse(content)[:tables]).not_to have_key('ar_internal_metadata')
+    end
+
+    it 'excludes schema_migrations' do
+      expect(parse(content)[:tables]).not_to have_key('schema_migrations')
+    end
+
+    it 'keeps application tables' do
+      expect(parse(content)[:tables]).to have_key('users')
+    end
+
+    it 'does not leak columns from a skipped table into the next table' do
+      expect(parse(content)[:tables]['users'][:columns].pluck(:name)).to contain_exactly('email')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Config-driven exclusions
+  # ---------------------------------------------------------------------------
+  describe 'config-driven exclusions' do
+    let(:content) do
+      <<~DDL
+        CREATE TABLE public.users (
+            email character varying
+        );
+        CREATE TABLE public.posts (
+            title character varying
+        );
+        CREATE TABLE public.audit_logs (
+            action character varying
+        );
+      DDL
+    end
+
+    after { config.excluded_tables.clear }
+
+    it 'excludes a table listed in config.excluded_tables' do
+      config.excluded_tables << 'users'
+      expect(parse(content)[:tables]).not_to have_key('users')
+    end
+
+    it 'keeps tables not in the exclusion list' do
+      config.excluded_tables << 'users'
+      expect(parse(content)[:tables]).to have_key('posts')
+    end
+
+    it 'supports glob patterns in excluded_tables' do
+      config.excluded_tables << 'audit_*'
+      expect(parse(content)[:tables]).not_to have_key('audit_logs')
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/schema_introspector_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tempfile'
 
 RSpec.describe RailsAiBridge::Introspectors::SchemaIntrospector do
   let(:introspector) { described_class.new(Rails.application) }
@@ -86,14 +87,57 @@ RSpec.describe RailsAiBridge::Introspectors::SchemaIntrospector do
       end
     end
 
-    context 'when schema.rb is absent' do
-      before do
-        allow(introspector).to receive_messages(active_record_connected?: false,
-                                                schema_file_path: '/nonexistent/schema.rb')
+    context 'when schema.rb is absent but structure.sql exists (schema_format = :sql)' do
+      let(:structure_sql) do
+        Tempfile.new(['structure', '.sql']).tap do |f|
+          f.write(<<~DDL)
+            CREATE TABLE public.users (
+                id bigint NOT NULL,
+                email character varying NOT NULL
+            );
+            CREATE TABLE public.posts (
+                id bigint NOT NULL,
+                title character varying
+            );
+          DDL
+          f.flush
+        end
       end
 
-      it 'returns an error hash' do
-        expect(introspector.call[:error]).to include('schema.rb')
+      before do
+        allow(introspector).to receive_messages(active_record_connected?: false,
+                                                schema_file_path: '/nonexistent/schema.rb',
+                                                structure_sql_path: structure_sql.path)
+      end
+
+      after { structure_sql.close! }
+
+      it 'falls back to the structure.sql parser' do
+        expect(introspector.call[:adapter]).to eq('static_parse')
+      end
+
+      it 'notes structure.sql as the parse source' do
+        expect(introspector.call[:note]).to include('structure.sql')
+      end
+
+      it 'includes tables from structure.sql' do
+        tables = introspector.call[:tables]
+        expect(tables).to have_key('users')
+        expect(tables).to have_key('posts')
+      end
+    end
+
+    context 'when neither schema.rb nor structure.sql is present' do
+      before do
+        allow(introspector).to receive_messages(active_record_connected?: false,
+                                                schema_file_path: '/nonexistent/schema.rb',
+                                                structure_sql_path: '/nonexistent/structure.sql')
+      end
+
+      it 'returns an error hash mentioning both files' do
+        error = introspector.call[:error]
+        expect(error).to include('schema.rb')
+        expect(error).to include('structure.sql')
       end
     end
   end

--- a/spec/lib/rails_ai_bridge/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/schema_introspector_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe RailsAiBridge::Introspectors::SchemaIntrospector do
   describe '#call' do
     context 'when ActiveRecord is not connected and no schema file exists' do
       before do
+        # Guard against stale fixtures: a sibling context writes db/schema.rb into
+        # this shared fixture dir and only cleans up in an `after` hook, so remove
+        # the dir up front to keep this assertion independent of hook ordering.
+        FileUtils.rm_rf(File.join(fixture_path, 'db'))
         allow(introspector).to receive(:active_record_connected?).and_return(false)
       end
 

--- a/spec/lib/rails_ai_bridge/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/schema_introspector_spec.rb
@@ -8,14 +8,15 @@ RSpec.describe RailsAiBridge::Introspectors::SchemaIntrospector do
   let(:introspector) { described_class.new(app) }
 
   describe '#call' do
-    context 'when ActiveRecord is not connected and no schema.rb' do
+    context 'when ActiveRecord is not connected and no schema file exists' do
       before do
         allow(introspector).to receive(:active_record_connected?).and_return(false)
       end
 
-      it 'returns an error' do
+      it 'returns an error mentioning both schema files' do
         result = introspector.call
-        expect(result[:error]).to include('No schema.rb')
+        expect(result[:error]).to include('db/schema.rb')
+        expect(result[:error]).to include('structure.sql')
       end
     end
 


### PR DESCRIPTION
Fixes #96.

### Problem
Apps configured with `config.active_record.schema_format = :sql` keep their schema in `db/structure.sql` and have no `db/schema.rb`. In offline environments (CI, Claude Code, agent contexts) the static fallback understood only `schema.rb` and returned `{ error: "No schema.rb found" }`, so the whole schema layer was unavailable for these apps. The live-connection path was already format-agnostic.

### Change
- Add `Introspectors::Schema::StaticStructureSqlParser`, the `schema_format = :sql` counterpart to `StaticSchemaParser`. It parses `CREATE TABLE` / column / `CREATE INDEX` / `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` DDL and returns the **live introspector's output shape** (tables → columns/indexes/foreign keys), so every downstream formatter works unchanged. `#call` never raises — malformed or non-UTF-8 input is caught and returned as `{ error: }`, per the introspector contract.
- `SchemaIntrospector#static_schema_parse` now prefers `db/schema.rb` and falls back to `db/structure.sql` before erroring (mirroring `Fingerprinter#schema_path`), guarded so a `File.read` race returns an error hash rather than raising.
- `Doctor::Checkers::SchemaChecker` passes when `db/structure.sql` is present and points its fix hint at `rails db:migrate`.

### Tests
- New spec for `StaticStructureSqlParser`: shape, tables, columns (multi-word types, quoted reserved words), indexes (opclass-qualified columns kept; functional/expression indexes skipped), foreign keys (from/to/column/primary_key/on_delete), internal-table filtering, config exclusions, and invalid-encoding error handling.
- `SchemaIntrospector` specs for the `structure.sql` fallback and the neither-file-present error.
- Updated `SchemaChecker` specs for `structure.sql` and precedence.
- Full suite green (2200 examples, 0 failures), RuboCop clean. Smoke-tested against a real 261 KB Postgres `structure.sql` (129 tables, 127/127 foreign keys parsed).

### Scope notes
- Partition child tables (`CREATE TABLE … PARTITION OF …`) are not parsed (no inline column list); the parent table's columns are still captured. Can be added as a follow-up.
- `spec/support/real_fixture_app_context.rb` has a parallel `schema_for` helper that reads only `schema.rb`; it's test scaffolding not exercised for SQL-format fixtures, so left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline schema introspection from PostgreSQL `db/structure.sql` files.
  * Schema detection now supports both `db/schema.rb` and `db/structure.sql`, preferring `schema.rb`.
  * Static introspection recognizes tables, columns, indexes, foreign keys, exclusions, and referential actions.

* **Bug Fixes**
  * Improved `ai:doctor` schema checks for applications using SQL-format schemas.
  * Updated missing-schema guidance to reference both supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->