### PR TITLE
[#105] security: allowlist skill-pack git URL schemes

### DIFF
--- a/lib/rails_ai_bridge/registry/skill_source_resolver.rb
+++ b/lib/rails_ai_bridge/registry/skill_source_resolver.rb
@@ -71,9 +71,18 @@ module RailsAiBridge
       # @param dest [String] destination directory path
       # @raise [RuntimeError] if git clone command fails, returns non-zero, or times out
       # @return [void]
+      # Allowlisted remote URL forms for skill-pack clones.
+      # +https://+, SCP-style +git@host:path+, and +ssh://+ only.
+      ALLOWED_GIT_URL_PATTERN = %r{\A(?:https://|ssh://|git@[A-Za-z0-9._-]+:)}.freeze
+
       def clone_repo(url, dest)
+        url = url.to_s
         raise ArgumentError, "Invalid git URL #{url.inspect}: URLs must not start with '-'" if url.start_with?('-')
         raise ArgumentError, "Invalid destination #{dest.inspect}: paths must not start with '-'" if dest.to_s.start_with?('-')
+        unless url.match?(ALLOWED_GIT_URL_PATTERN)
+          raise ArgumentError,
+                "Invalid git URL #{url.inspect}: scheme is not allowlisted (use https://, git@host:path, or ssh://)"
+        end
 
         with_timeout('git clone') do
           _stdout, stderr, status = Open3.capture3('git', 'clone', '--', url, dest)

--- a/lib/rails_ai_bridge/registry/skill_source_resolver.rb
+++ b/lib/rails_ai_bridge/registry/skill_source_resolver.rb
@@ -69,19 +69,21 @@ module RailsAiBridge
       #
       # @param url [String] git repository URL
       # @param dest [String] destination directory path
+      # @raise [ArgumentError] if the URL or destination is unsafe or not allowlisted
       # @raise [RuntimeError] if git clone command fails, returns non-zero, or times out
       # @return [void]
-      # Allowlisted remote URL forms for skill-pack clones.
-      # +https://+, SCP-style +git@host:path+, and +ssh://+ only.
-      ALLOWED_GIT_URL_PATTERN = %r{\A(?:https://|ssh://|git@[A-Za-z0-9._-]+:)}.freeze
+      # @note Skill-pack clones accept only +https://+, SCP-style
+      #   +git@host:path+, and +ssh://+ remote URLs.
+      ALLOWED_GIT_URL_PATTERN = %r{\A(?:https://|ssh://|git@[A-Za-z0-9._-]+:)}
 
       def clone_repo(url, dest)
         url = url.to_s
-        raise ArgumentError, "Invalid git URL #{url.inspect}: URLs must not start with '-'" if url.start_with?('-')
-        raise ArgumentError, "Invalid destination #{dest.inspect}: paths must not start with '-'" if dest.to_s.start_with?('-')
+        # Avoid interpolating +url+ into errors: userinfo may contain credentials.
+        raise ArgumentError, "Invalid git URL: URLs must not start with '-'" if url.start_with?('-')
+        raise ArgumentError, "Invalid destination: paths must not start with '-'" if dest.to_s.start_with?('-')
         unless url.match?(ALLOWED_GIT_URL_PATTERN)
           raise ArgumentError,
-                "Invalid git URL #{url.inspect}: scheme is not allowlisted (use https://, git@host:path, or ssh://)"
+                'Invalid git URL: scheme is not allowlisted (use https://, git@host:path, or ssh://)'
         end
 
         with_timeout('git clone') do

--- a/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
@@ -740,6 +740,57 @@ RSpec.describe RailsAiBridge::Registry::DefaultGitRunner do
       expect { runner.clone_repo('https://github.com/org/repo.git', '-evil') }
         .to raise_error(ArgumentError, /Invalid destination/)
     end
+
+    # ── S2: URL scheme allowlist (https / git@ / ssh only) ───────────────────
+
+    context 'when URL scheme is not allowlisted' do
+      it 'rejects file:// URLs before invoking git' do
+        expect(Open3).not_to receive(:capture3)
+
+        expect { runner.clone_repo('file:///etc/passwd', '/tmp/dest') }
+          .to raise_error(ArgumentError, /Invalid git URL|scheme|allowlisted/i)
+      end
+
+      it 'rejects plain http:// URLs' do
+        expect(Open3).not_to receive(:capture3)
+
+        expect { runner.clone_repo('http://github.com/org/repo.git', '/tmp/dest') }
+          .to raise_error(ArgumentError, /Invalid git URL|scheme|allowlisted/i)
+      end
+
+      it 'rejects empty URLs' do
+        expect(Open3).not_to receive(:capture3)
+
+        expect { runner.clone_repo('', '/tmp/dest') }
+          .to raise_error(ArgumentError, /Invalid git URL|scheme|allowlisted/i)
+      end
+    end
+
+    context 'when URL scheme is allowlisted' do
+      it 'accepts https:// URLs' do
+        allow(Open3).to receive(:capture3)
+          .with('git', 'clone', '--', 'https://github.com/org/repo.git', '/tmp/dest')
+          .and_return(['', '', succeeding_status])
+
+        expect { runner.clone_repo('https://github.com/org/repo.git', '/tmp/dest') }.not_to raise_error
+      end
+
+      it 'accepts git@host:path SSH scp-style URLs' do
+        allow(Open3).to receive(:capture3)
+          .with('git', 'clone', '--', 'git@github.com:org/repo.git', '/tmp/dest')
+          .and_return(['', '', succeeding_status])
+
+        expect { runner.clone_repo('git@github.com:org/repo.git', '/tmp/dest') }.not_to raise_error
+      end
+
+      it 'accepts ssh:// URLs' do
+        allow(Open3).to receive(:capture3)
+          .with('git', 'clone', '--', 'ssh://git@github.com/org/repo.git', '/tmp/dest')
+          .and_return(['', '', succeeding_status])
+
+        expect { runner.clone_repo('ssh://git@github.com/org/repo.git', '/tmp/dest') }.not_to raise_error
+      end
+    end
   end
 
   describe '#pull_repo' do

--- a/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb
@@ -764,6 +764,16 @@ RSpec.describe RailsAiBridge::Registry::DefaultGitRunner do
         expect { runner.clone_repo('', '/tmp/dest') }
           .to raise_error(ArgumentError, /Invalid git URL|scheme|allowlisted/i)
       end
+
+      it 'does not embed credentials from a rejected URL in the error message' do
+        expect(Open3).not_to receive(:capture3)
+
+        expect { runner.clone_repo('http://super-secret-token@github.com/org/repo.git', '/tmp/dest') }
+          .to raise_error(ArgumentError) { |e|
+            expect(e.message).not_to include('super-secret-token')
+            expect(e.message).to match(/scheme is not allowlisted/i)
+          }
+      end
     end
 
     context 'when URL scheme is allowlisted' do


### PR DESCRIPTION
Closes #105

## Summary
Reject non-allowlisted git clone URL schemes for skill-pack sources (`file://`, `http://`, empty). Allow `https://`, `git@host:path`, and `ssh://`.

## Test plan
- [x] RED→GREEN TDD on `DefaultGitRunner#clone_repo` scheme examples
- [x] `bundle exec rspec spec/lib/rails_ai_bridge/registry/skill_source_resolver_spec.rb` (81 examples)

## Stack
Independent PR (no Graphite on agent host). Merge order soft: after or parallel with #103.

Parent epic: #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Git repository cloning now accepts only secure HTTPS and SSH-based URL formats.
  * Unsupported, empty, or potentially unsafe URL formats are rejected before any Git operation runs.

* **Tests**
  * Added coverage for accepted HTTPS and SSH URLs and rejected unsupported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->