### PR TITLE
[#103] deps: bump rubydex to ~> 0.3.0

### DIFF
--- a/rails-ai-bridge.gemspec
+++ b/rails-ai-bridge.gemspec
@@ -56,5 +56,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'zeitwerk', '~> 2.6' # Autoloading
 
   # Semantic code analysis via Shopify's rubydex
-  spec.add_dependency 'rubydex', '~> 0.2.9'
+  spec.add_dependency 'rubydex', '~> 0.3.0'
 end


### PR DESCRIPTION
Closes #103

## Summary
Raise gemspec `rubydex` from `~> 0.2.9` to `~> 0.3.0`.

Note: `Gemfile.lock` is gitignored in this gem; consumers pick up 0.3 via gemspec.

## Test plan
- [x] `bundle exec rspec spec/lib/rails_ai_bridge/rubydex_adapter_spec.rb` — 50 examples, 0 failures on rubydex 0.3.0

Parent epic: #99