### PR TITLE
[#106] docs: align SECURITY.md supported versions with 3.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,12 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 3.0.x   | :white_check_mark: |
-| 2.x     | :white_check_mark: |
-| 1.x     | :white_check_mark: |
-| < 1.0   | :x:                |
+| 3.6.x   | :white_check_mark: |
+| 3.5.x   | :white_check_mark: |
+| 3.0.x–3.4.x | :white_check_mark: (security fixes best-effort) |
+| 2.x     | :x: (end of life — upgrade to 3.x) |
+| 1.x     | :x: |
+| < 1.0   | :x: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Closes #106

## Summary
Update supported-versions table for the 3.6/3.5 line; mark 1.x/2.x EOL.

Parent epic: #100