### PR TITLE
chore(release): bump version to 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.1] - 2026-08-07
+
 ### Security
 
 - **Skill-pack git URL scheme allowlist** (#105/#110) — `DefaultGitRunner#clone_repo` accepts only `https://`, SCP-style `git@host:path`, and `ssh://`. Rejects `file://`, plain `http://`, and empty URLs. Validation `ArgumentError`s do not interpolate the raw URL, so credentials in userinfo cannot leak via exception messages.

--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ Bug reports and pull requests: [github.com/igmarin/rails-ai-bridge/issues](https
 
 ## Acknowledgments & Origins
 
-This gem ships as **rails-ai-bridge** (Ruby **`RailsAiBridge`**, version **3.6.0**). Earlier iterations of the same codebase were distributed as `rails-ai-context`.
+This gem ships as **rails-ai-bridge** (Ruby **`RailsAiBridge`**, version **3.6.1**). Earlier iterations of the same codebase were distributed as `rails-ai-context`.
 
 RailsMCP evolved from 
 [crisnahine/rails-ai-context](https://github.com/crisnahine/rails-ai-context),

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,23 @@
 # Upgrading rails-ai-bridge
 
+## Upgrading from 3.6.0 to 3.6.1
+
+**One action required if you are pinned to `rubydex` 0.2.x:**
+
+The `rubydex` gem constraint moved from `~> 0.2.9` to `~> 0.3.0`. After upgrading
+rails-ai-bridge:
+
+```bash
+bundle update rubydex
+```
+
+No configuration or application code changes are required for the security and
+documentation updates in 3.6.1. Skill-pack git sources must use `https://`,
+SCP-style `git@host:path`, or `ssh://` (plain `http://` and `file://` are rejected).
+
+---
+
+
 ## Upgrading from 3.5.x to 3.6.0
 
 **One action required if you are pinned to an older `rubydex`:**

--- a/lib/rails_ai_bridge/path_resolver.rb
+++ b/lib/rails_ai_bridge/path_resolver.rb
@@ -9,7 +9,7 @@ module RailsAiBridge
   # PathResolver is deliberately used by every introspector that needs to
   # locate files on disk (controller, model, view, stimulus, turbo, auth,
   # api, config, action_text, activeStorage, nonArModels — 11 callers as of
-  # v3.6.0). It is NOT a god class despite high betweenness centrality in
+  # v3.6.1). It is NOT a god class despite high betweenness centrality in
   # graph analyses: a foundational path-resolution utility is expected to
   # sit at the centre of the introspector graph. Splitting it would spread
   # path-safety logic (traversal guards, safe joins) across multiple files

--- a/lib/rails_ai_bridge/version.rb
+++ b/lib/rails_ai_bridge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiBridge
-  VERSION = '3.6.0'
+  VERSION = '3.6.1'
 end


### PR DESCRIPTION
## Summary

Release prep for **3.6.1** — security hardening, rubydex 0.3, and operator docs.

### Version bump
- `version.rb`: 3.6.0 → **3.6.1**

### Documentation
- **CHANGELOG.md**: `[3.6.1] - 2026-08-07` (Security + Changed from Unreleased)
- **UPGRADING.md**: 3.6.0 → 3.6.1 (`bundle update rubydex`, skill-pack URL schemes)
- **README.md** / **path_resolver.rb**: version display → 3.6.1

### Included since 3.6.0
- Skill-pack git URL scheme allowlist (#105/#110)
- rubydex `~> 0.3.0` (#103/#111)
- SECURITY.md supported versions (#106/#112)
- Residual MCP HTTP risk checklist (#107/#113)

## Test plan
- [x] `RailsAiBridge::VERSION` → `3.6.1`
- [x] allowlist specs green
- [x] rubocop on touched Ruby files
- [ ] CI green
- [ ] After merge: tag `v3.6.1` to trigger Release workflow (RubyGems + GitHub Release)

## After merge
```bash
git checkout main && git pull
git tag -a v3.6.1 -m "v3.6.1"
git push origin v3.6.1
```