### PR TITLE
chore(release): bump version to 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.2] - 2026-08-07
+
 ### Added
 
-- **`structure.sql` support in offline/static schema introspection** (#96/#97) — apps using `config.active_record.schema_format = :sql` (no `db/schema.rb`) now get table, column, index, and foreign-key context offline via `Introspectors::Schema::StaticStructureSqlParser`. The live-connection path was already format-agnostic. Output shape matches the live introspector so formatters work unchanged. Partition-child tables (`CREATE TABLE … PARTITION OF …`) are not expanded (follow-up).
+- **`structure.sql` support in offline/static schema introspection** (#96/#97/#116) — apps using `config.active_record.schema_format = :sql` (no `db/schema.rb`) now get table, column, index, and foreign-key context offline via `Introspectors::Schema::StaticStructureSqlParser`. The live-connection path was already format-agnostic. Output shape matches the live introspector so formatters work unchanged. Partition-child tables (`CREATE TABLE … PARTITION OF …`) are not expanded (follow-up).
 
 ### Fixed
 
-- **`ai:doctor` schema check for `schema_format = :sql`** (#96/#97) — Schema check passes when `db/structure.sql` is present; fix hint points at `rails db:migrate` (or `rails db:schema:dump`).
+- **`ai:doctor` schema check for `schema_format = :sql`** (#96/#97/#116) — Schema check passes when `db/structure.sql` is present; fix hint points at `rails db:migrate` (or `rails db:schema:dump`).
 
 ## [3.6.1] - 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ Bug reports and pull requests: [github.com/igmarin/rails-ai-bridge/issues](https
 
 ## Acknowledgments & Origins
 
-This gem ships as **rails-ai-bridge** (Ruby **`RailsAiBridge`**, version **3.6.1**). Earlier iterations of the same codebase were distributed as `rails-ai-context`.
+This gem ships as **rails-ai-bridge** (Ruby **`RailsAiBridge`**, version **3.6.2**). Earlier iterations of the same codebase were distributed as `rails-ai-context`.
 
 RailsMCP evolved from 
 [crisnahine/rails-ai-context](https://github.com/crisnahine/rails-ai-context),

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,16 @@
 # Upgrading rails-ai-bridge
 
+## Upgrading from 3.6.1 to 3.6.2
+
+**No configuration changes required.**
+
+If your app uses `config.active_record.schema_format = :sql`, offline schema
+introspection and `rails ai:doctor` now use `db/structure.sql` automatically
+(no need for `db/schema.rb`). Live DB introspection was already format-agnostic.
+
+---
+
+
 ## Upgrading from 3.6.0 to 3.6.1
 
 **One action required if you are pinned to `rubydex` 0.2.x:**

--- a/lib/rails_ai_bridge/path_resolver.rb
+++ b/lib/rails_ai_bridge/path_resolver.rb
@@ -9,7 +9,7 @@ module RailsAiBridge
   # PathResolver is deliberately used by every introspector that needs to
   # locate files on disk (controller, model, view, stimulus, turbo, auth,
   # api, config, action_text, activeStorage, nonArModels — 11 callers as of
-  # v3.6.1). It is NOT a god class despite high betweenness centrality in
+  # v3.6.2). It is NOT a god class despite high betweenness centrality in
   # graph analyses: a foundational path-resolution utility is expected to
   # sit at the centre of the introspector graph. Splitting it would spread
   # path-safety logic (traversal guards, safe joins) across multiple files

--- a/lib/rails_ai_bridge/version.rb
+++ b/lib/rails_ai_bridge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsAiBridge
-  VERSION = '3.6.1'
+  VERSION = '3.6.2'
 end


### PR DESCRIPTION
## Summary

Release prep for **3.6.2** — `structure.sql` offline schema support (already on main via #116).

### Version
- `3.6.1` → **3.6.2**

### Docs
- CHANGELOG `[3.6.2]` from Unreleased (#96/#97/#116)
- UPGRADING 3.6.1 → 3.6.2
- README / path_resolver version refs

### Included
- Static `structure.sql` parser (tables, columns, indexes, FKs)
- Doctor schema check accepts `db/structure.sql`

## Test plan
- [x] `RailsAiBridge::VERSION` → `3.6.2`
- [ ] CI green
- [ ] Tag `v3.6.2` after merge → Release workflow

**Note:** Feature PR #116 already merged; Dependabot #94 (mcp 2.x) is **not** part of this release.