### PR TITLE
[#104] deps: experiment mcp 1.x (suite green, no app code changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
-- **`mcp` gem raised to 1.x** (#104/#118) — gemspec now requires `mcp >= 1.0, < 2.0` (was `>= 0.25, < 1.0`). Full suite green on **mcp 1.1.0** with no production code changes. Hosts must run `bundle update mcp` after upgrading. See [UPGRADING.md](UPGRADING.md) for details.
+- **`mcp` gem raised to 1.x** (#104/#118) — gemspec now requires `mcp >= 1.0, < 2.0` (was `>= 0.25, < 1.0`). Full suite green on **mcp 1.1.0** with no production code changes; characterization specs in `spec/lib/rails_ai_bridge/mcp/sdk_compatibility_spec.rb`. Hosts must run `bundle update mcp` after upgrading. See [UPGRADING.md](UPGRADING.md) for details.
 
 ### Fixed
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'benchmark', '~> 0.4' # Ruby 4.0+ default gem extraction
   gem 'bundler-audit', '~> 0.9'
   gem 'combustion', '~> 1.3'
   gem 'rails', '~> 8.1'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'benchmark', '~> 0.4' # Ruby 4.0+ default gem extraction
   gem 'bundler-audit', '~> 0.9'
   gem 'combustion', '~> 1.3'
   gem 'rails', '~> 8.1'

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,21 @@
 # Upgrading rails-ai-bridge
 
+## Upgrading to a release with `mcp` 1.x (#104)
+
+**Action required after this lands on main:**
+
+```bash
+bundle update mcp rails-ai-bridge
+```
+
+The official MCP Ruby SDK major version is **1.x** (gemspec `>= 1.0, < 2.0`).
+Hosts previously resolving `mcp` 0.25.x should pick up 1.1+ via Bundler.
+No configuration changes are required if you only use rails-ai-bridge's tools/HTTP
+stdio surfaces as documented; run your app's MCP smoke checks after upgrade.
+
+---
+
+
 ## Upgrading from 3.6.1 to 3.6.2
 
 **No configuration changes required.**

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,17 +1,20 @@
 # Upgrading rails-ai-bridge
 
-## Upgrading to a release with `mcp` 1.x (#104)
+## Upgrading from 3.7.x to 4.0.0 (`mcp` 1.x) (#104/#118)
 
-**Action required after this lands on main:**
+**Action required:**
 
 ```bash
 bundle update mcp rails-ai-bridge
 ```
 
-The official MCP Ruby SDK major version is **1.x** (gemspec `>= 1.0, < 2.0`).
-Hosts previously resolving `mcp` 0.25.x should pick up 1.1+ via Bundler.
-No configuration changes are required if you only use rails-ai-bridge's tools/HTTP
-stdio surfaces as documented; run your app's MCP smoke checks after upgrade.
+The official MCP Ruby SDK major is **1.x** (gemspec `mcp >= 1.0, < 2.0`; was
+`>= 0.25, < 1.0`). Hosts previously resolving `mcp` 0.25.x must pick up **1.1+**
+via Bundler. Rails-ai-bridge production code did not need API adapters for
+1.1.0, but you should smoke-test MCP stdio/HTTP after upgrading.
+
+Optional: characterization coverage lives in
+`spec/lib/rails_ai_bridge/mcp/sdk_compatibility_spec.rb` (for contributors).
 
 ---
 

--- a/rails-ai-bridge.gemspec
+++ b/rails-ai-bridge.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Core dependencies
-  spec.add_dependency 'mcp', '>= 0.25', '< 1.0' # Official MCP Ruby SDK
+  spec.add_dependency 'mcp', '>= 1.0', '< 2.0' # Official MCP Ruby SDK (1.x stable)
   spec.add_dependency 'railties', '>= 7.1', '< 10.0'
   spec.add_dependency 'thor', '>= 1.0', '< 3.0'
   spec.add_dependency 'zeitwerk', '~> 2.6' # Autoloading

--- a/spec/lib/rails_ai_bridge/context_quality_matrix_spec.rb
+++ b/spec/lib/rails_ai_bridge/context_quality_matrix_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'benchmark'
 require_relative '../../support/real_fixture_app_context'
 
 RSpec.describe 'rails-ai-bridge context quality matrix' do
@@ -140,10 +139,11 @@ RSpec.describe 'rails-ai-bridge context quality matrix' do
     RailsAiBridge.configuration.context_mode = previous_mode
   end
 
-  it 'serializes large fixture output within a small benchmark budget', :perf do
-    elapsed = Benchmark.realtime do
-      10.times { RailsAiBridge::Serializers::Providers::CodexSerializer.new(fixtures.fetch(:large_schema)).call }
-    end
+  it 'serializes large fixture output within a small wall-clock budget', :perf do
+    # Process.clock_gettime avoids the +benchmark+ gem (not a default gem on Ruby 4.0+).
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    10.times { RailsAiBridge::Serializers::Providers::CodexSerializer.new(fixtures.fetch(:large_schema)).call }
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
 
     expect(elapsed).to be < 0.5
   end

--- a/spec/lib/rails_ai_bridge/mcp/sdk_compatibility_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/sdk_compatibility_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mcp'
+
+RSpec.describe 'MCP Ruby SDK compatibility (1.x)' do
+  describe 'SDK version' do
+    it 'loads mcp 1.x' do
+      version = Gem.loaded_specs['mcp']&.version || Gem::Version.new(MCP::VERSION)
+      expect(version).to be >= Gem::Version.new('1.0.0')
+      expect(version).to be < Gem::Version.new('2.0.0')
+    end
+  end
+
+  describe 'tool surface used by rails-ai-bridge' do
+    it 'exposes MCP::Tool with tool_name / input_schema / annotations' do
+      expect(MCP::Tool).to respond_to(:tool_name)
+      expect(MCP::Tool).to respond_to(:input_schema)
+      expect(MCP::Tool).to respond_to(:annotations)
+    end
+
+    it 'builds MCP::Tool::Response text payloads' do
+      response = MCP::Tool::Response.new([{ type: 'text', text: 'ok' }])
+      expect(response).to respond_to(:to_h)
+      hash = response.to_h
+      expect(hash).to be_a(Hash)
+    end
+  end
+
+  describe 'server and transport surface' do
+    it 'constructs MCP::Server with tools' do
+      server = MCP::Server.new(
+        name: 'rails-ai-bridge-compat',
+        version: '0.0.0',
+        tools: []
+      )
+      expect(server).to be_a(MCP::Server)
+    end
+
+    it 'exposes StreamableHTTPTransport and StdioTransport' do
+      expect(defined?(MCP::Server::Transports::StreamableHTTPTransport)).to eq('constant')
+      expect(defined?(MCP::Server::Transports::StdioTransport)).to eq('constant')
+    end
+  end
+
+  describe 'built-in tool inheritance' do
+    it 'registers BaseTool as an MCP::Tool subclass' do
+      expect(RailsAiBridge::Tools::BaseTool.ancestors).to include(MCP::Tool)
+    end
+
+    it 'invokes a built-in tool and returns an MCP::Tool::Response' do
+      response = RailsAiBridge::Tools::GetTestInfo.call
+      expect(response).to be_a(MCP::Tool::Response)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/tools/ruby_search_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/ruby_search_spec.rb
@@ -51,12 +51,13 @@ RSpec.describe RailsAiBridge::Tools::SearchCode::RubySearch do
 
     it 'prevents ReDoS with a timeout' do
       write_file('app/models/user.rb', "#{'a' * 50_000}b")
-      # A regex that exhibits catastrophic backtracking on non-matches
-      require 'benchmark'
-      elapsed = Benchmark.realtime do
-        results = make_searcher(pattern: '^(a+)+$').call
-        expect(results).to be_empty
-      end
+      # A regex that exhibits catastrophic backtracking on non-matches.
+      # Use Process.clock_gettime (not Benchmark) for Ruby 4.0+ where
+      # +benchmark+ is no longer a default gem.
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      results = make_searcher(pattern: '^(a+)+$').call
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+      expect(results).to be_empty
       expect(elapsed).to be < 2.5
     end
 


### PR DESCRIPTION
## Summary

Experimental branch for **#104** — migrate official `mcp` SDK from 0.25 to **1.x**.

### Findings (TDD)
1. **Baseline** on main / mcp 0.25: server/tools/middleware specs green.
2. **Bump** gemspec → `mcp >= 1.0, < 2.0`; resolved **1.1.0**.
3. **RED** was only Ruby 4.0 `benchmark` default-gem removal (unrelated to MCP).
4. **GREEN**: full suite **2214 examples, 0 failures** with **zero production code changes**.

### Changes
| File | Why |
|------|-----|
| `rails-ai-bridge.gemspec` | `mcp >= 1.0, < 2.0` |
| `Gemfile` | `benchmark` for Ruby 4.0 test files |
| `spec/.../mcp/sdk_compatibility_spec.rb` | Characterization: version, Tool/Response, Server, transports, GetTestInfo |
| CHANGELOG / UPGRADING | Unreleased notes |

### Risk / version
- Host-facing API of rails-ai-bridge appears **unchanged**.
- Recommend shipping as **3.7.0** (dep major for consumers of the gemspec constraint) when this is ready to leave draft.
- Do **not** treat as 4.0 unless we find host-visible breakage in CI matrix on GitHub.

## Test plan
- [x] Local full suite green on mcp 1.1.0
- [x] Compatibility specs green
- [ ] CI matrix on this PR
- [ ] Manual smoke: `rails ai:serve` / HTTP MCP optional

Closes nothing until out of draft. Tracks #104.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Updated support for the MCP Ruby SDK 1.x series.
  * Verified compatibility with MCP tools, responses, servers, transports, and invocation behavior.

* **Documentation**
  * Added upgrade guidance for moving to `rails-ai-bridge` 4.0.0, including dependency updates and recommended MCP smoke tests.
  * Updated the unreleased changelog with SDK compatibility coverage.

* **Tests**
  * Improved performance and security test timing without changing validation thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->