### PR TITLE
fix: address code review findings on managed regions (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,16 @@ Markdown provider files only (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`,
 receives markers. Freshness skipping and `ai:doctor` staleness both read through the region,
 so unchanged runs are still no-ops.
 
+**Caveats:**
+
+- Avoid writing marker-shaped lines (`<!-- BEGIN rails-ai-bridge: … -->` or
+  `<!-- END rails-ai-bridge -->`) in your own prose — the first BEGIN and the first
+  following END delimit the managed region, so a stray marker in hand-authored content
+  would truncate or misidentify the block.
+- If you delete both markers from a file, the old generated content is treated as your
+  own prose on the next run and a new block is appended. Re-add markers around the
+  generated part before your next run, or delete it manually.
+
 ### Extending the built-ins
 
 If you need host-app or companion-gem extensions, register them explicitly in the initializer:

--- a/lib/rails_ai_bridge/freshness_header.rb
+++ b/lib/rails_ai_bridge/freshness_header.rb
@@ -84,6 +84,17 @@ module RailsAiBridge
         match ? match[3] : nil
       end
 
+      # Returns +true+ when +content+ starts with the gem's freshness header,
+      # indicating it is prior whole-file output from this gem (not hand-authored).
+      #
+      # @param content [String, nil]
+      # @return [Boolean]
+      def gem_generated?(content)
+        return false unless content
+
+        HEADER_PATTERN.match?(content)
+      end
+
       private
 
       # Embeds freshness metadata into JSON content via a +_meta+ key.

--- a/lib/rails_ai_bridge/serializers/context_file_serializer.rb
+++ b/lib/rails_ai_bridge/serializers/context_file_serializer.rb
@@ -153,12 +153,16 @@ module RailsAiBridge
         # from appending a second copy of the context below the stale one — a duplicate
         # that would then never refresh, because it now reads as user content.
         #
+        # Memoized per instance so the header check runs once per write cycle, not twice
+        # (previous_payload + compose both call it).
+        #
         # @param existing [String, nil] current file content
         # @return [String, nil] +existing+ when it is unmarked gem output
         def whole_file_output(existing)
-          return nil unless existing && !ManagedRegion.markers?(existing)
+          return @cached_result if @cached_for == existing
 
-          existing if FreshnessHeader::HEADER_PATTERN.match?(existing)
+          @cached_for = existing
+          @cached_result = existing if existing && !ManagedRegion.markers?(existing) && FreshnessHeader.gem_generated?(existing)
         end
       end
       private_constant :WholeFileLayout, :ManagedRegionLayout

--- a/lib/rails_ai_bridge/serializers/managed_region.rb
+++ b/lib/rails_ai_bridge/serializers/managed_region.rb
@@ -80,7 +80,7 @@ module RailsAiBridge
           # Block form: a String replacement would interpret backslash escapes in the payload.
           return existing.sub(REGION_PATTERN) { block } if markers?(existing)
 
-          "#{existing.chomp}\n\n#{block}"
+          "#{existing.rstrip}\n\n#{block}"
         end
       end
     end

--- a/spec/lib/rails_ai_bridge/freshness_header_spec.rb
+++ b/spec/lib/rails_ai_bridge/freshness_header_spec.rb
@@ -59,6 +59,25 @@ RSpec.describe RailsAiBridge::FreshnessHeader do
         expect(described_class.extract_version(old_header)).to be_nil
       end
     end
+
+    describe '.gem_generated?' do
+      it 'returns true when content starts with the freshness header' do
+        expect(described_class.gem_generated?(embedded_content)).to be true
+      end
+
+      it 'returns true for older headers without gem version' do
+        old_header = "<!-- Generated at: 2026-04-03T14:22:00Z | Source fingerprint: a1b2c3d4e5f6 -->\n# Title"
+        expect(described_class.gem_generated?(old_header)).to be true
+      end
+
+      it 'returns false for hand-authored content' do
+        expect(described_class.gem_generated?("# House rules\n\nSome prose.\n")).to be false
+      end
+
+      it 'returns false for nil' do
+        expect(described_class.gem_generated?(nil)).to be false
+      end
+    end
   end
 
   describe 'format-dispatching methods' do

--- a/spec/lib/rails_ai_bridge/serializers/managed_region_spec.rb
+++ b/spec/lib/rails_ai_bridge/serializers/managed_region_spec.rb
@@ -124,5 +124,12 @@ RSpec.describe RailsAiBridge::Serializers::ManagedRegion do
       expect(merged.scan(described_class::BEGIN_MARKER).size).to eq(1)
       expect(described_class.extract(merged)).to eq(payload.chomp)
     end
+
+    it 'collapses trailing blank lines when appending to an existing file' do
+      merged = described_class.merge("# House rules\n\n\n\n", payload)
+
+      expect(merged).to start_with("# House rules\n\n#{described_class::BEGIN_MARKER}")
+      expect(merged).not_to start_with("# House rules\n\n\n\n")
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/tasks/rails_ai_bridge_rake_spec.rb
+++ b/spec/lib/rails_ai_bridge/tasks/rails_ai_bridge_rake_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe 'rails_ai_bridge rake tasks' do
       rake['ai:bridge:claude'].invoke
       expect(RailsAiBridge.configuration.managed_region).to be true
     end
+
+    it 'stays off when MERGE=0 and config is already false' do
+      ENV['MERGE'] = '0'
+      expect { rake['ai:bridge'].invoke }.to output(/Managed region: off/).to_stdout
+      expect(RailsAiBridge.configuration.managed_region).to be false
+    end
   end
 
   describe 'ai:bridge' do


### PR DESCRIPTION
## Summary

Addresses the Suggestion and Nice-to-have findings from the code review of PR #119 (managed regions).

### Suggestions fixed
- **Decouple `ManagedRegionLayout` from `FreshnessHeader::HEADER_PATTERN`** — extracted a public `FreshnessHeader.gem_generated?` predicate so the layout doesn't reach into a private constant. If the header pattern changes, the predicate is the single update point.
- **Memoize `whole_file_output`** — the method was called 2–3× per write cycle with the same content. Now cached per instance (one `ManagedRegionLayout` is created per format per run).
- **Document marker-collision caveat** — added README note that marker-shaped lines in hand-authored prose would misidentify the managed region.
- **Document deleted-markers caveat** — added README note that deleting both markers causes the old generated content to be treated as user prose, with a new block appended on the next run.

### Nice-to-haves fixed
- **Collapse trailing blank lines on append** — `ManagedRegion.merge` now uses `rstrip` instead of `chomp`, so `"prose\n\n\n"` + block doesn't produce 4+ blank lines.
- **Add `MERGE=0` when already `false` test** — locks in the behavior that explicitly disabling when already off stays off and prints the status line.
- **ast-grep false positive** — the "hardcoded RSA passphrase" warning on the backslash test string is a false positive (tests regexp back-reference handling, not a credential). No code change needed.

### Changes
| File | Change |
|------|--------|
| `lib/rails_ai_bridge/freshness_header.rb` | Add `gem_generated?` predicate |
| `lib/rails_ai_bridge/serializers/context_file_serializer.rb` | Use `gem_generated?` + memoize `whole_file_output` |
| `lib/rails_ai_bridge/serializers/managed_region.rb` | `rstrip` instead of `chomp` on append |
| `README.md` | Marker-collision and deleted-markers caveats |
| `spec/lib/rails_ai_bridge/freshness_header_spec.rb` | Specs for `gem_generated?` |
| `spec/lib/rails_ai_bridge/serializers/managed_region_spec.rb` | Spec for trailing-newline collapse |
| `spec/lib/rails_ai_bridge/tasks/rails_ai_bridge_rake_spec.rb` | Spec for `MERGE=0` when already false |

#### Test plan
- [x] `bundle exec rspec` — 106 examples, 0 failures (affected spec files)
- [x] `bundle exec rubocop --parallel` — clean

Generated with [Devin](https://devin.ai)