### PR TITLE
ci: add Rails 8.1 to release workflow matrix (#164)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.2", "3.3", "3.4"]
-        rails: ["7.1", "7.2", "8.0"]
+        rails: ["7.1", "7.2", "8.0", "8.1"]
         exclude:
           - ruby: "3.2"
             rails: "8.0"
+          - ruby: "3.2"
+            rails: "8.1"
 
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
 


### PR DESCRIPTION
## Summary
- Add Rails 8.1 to the release workflow test matrix, matching the CI matrix
- Add the same Ruby 3.2 × Rails 8.1 exclusion that CI uses

The CI matrix tests Ruby 3.2–3.4 × Rails 7.1–8.1, but the release workflow only tested Rails 7.1, 7.2, and 8.0. Rails 8.1 was missing from the release gate.

Closes #164.

#### Test plan
- [x] `bundle exec rspec` passes
- [x] `bundle exec rubocop` clean
- [x] Release workflow matrix now matches CI matrix

Generated with [Devin](https://devin.ai)