### PR TITLE
fix: replace object_id with stable cache key for fork safety (#162)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
+    labels:
+      - "deps"
+      - "improvement"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        update-types:
+          - "patch"
+          - "minor"
+    labels:
+      - "deps"
+      - "improvement"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.2", "3.3", "3.4"]
-        rails: ["7.1", "7.2", "8.0"]
+        rails: ["7.1", "7.2", "8.0", "8.1"]
         exclude:
           - ruby: "3.2"
             rails: "8.0"
+          - ruby: "3.2"
+            rails: "8.1"
 
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
 

--- a/lib/rails_ai_bridge/context_provider.rb
+++ b/lib/rails_ai_bridge/context_provider.rb
@@ -108,7 +108,7 @@ module RailsAiBridge
       end
 
       def cache_key(app)
-        app.object_id
+        "#{app.class.name}:#{defined?(Rails) && Rails.respond_to?(:env) ? Rails.env : 'development'}"
       end
 
       def metadata_key?(section_name)

--- a/lib/rails_ai_bridge/engine.rb
+++ b/lib/rails_ai_bridge/engine.rb
@@ -39,6 +39,7 @@ module RailsAiBridge
     # preventing stale config after an initializer change.
     config.to_prepare do
       RailsAiBridge::Registry.invalidate_resolver_cache!
+      RailsAiBridge::ContextProvider.reset!
     end
 
     # Auto-mount MCP HTTP middleware when configured

--- a/spec/lib/rails_ai_bridge/context_provider_spec.rb
+++ b/spec/lib/rails_ai_bridge/context_provider_spec.rb
@@ -93,4 +93,32 @@ RSpec.describe RailsAiBridge::ContextProvider do
       expect(second).to eq(schema_context[:schema])
     end
   end
+
+  describe 'fork safety' do
+    it 'uses a stable cache key that does not depend on object_id' do
+      app1 = double('App1', class: double(name: 'Rails::Application'))
+      app2 = double('App2', class: double(name: 'Rails::Application'))
+      allow(RailsAiBridge).to receive(:introspect).and_return(context)
+      allow(RailsAiBridge::Fingerprinter).to receive(:snapshot).and_return(fingerprint)
+      allow(RailsAiBridge::Fingerprinter::CachedSnapshot).to receive(:fetch).and_return(fingerprint)
+
+      described_class.fetch(app1)
+
+      # A new app object with the same class name and env should hit the same cache key
+      result = described_class.fetch(app2)
+
+      expect(result).to eq(context)
+      # introspect should only be called once because both apps share the cache key
+      expect(RailsAiBridge).to have_received(:introspect).once
+    end
+
+    it 'cache key includes class name and Rails env' do
+      app_double = double('App', class: double(name: 'MyApp::Application'))
+
+      key = described_class.send(:cache_key, app_double)
+
+      expect(key).to include('MyApp::Application')
+      expect(key).to include(Rails.env.to_s)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Replace `app.object_id` with `"#{app.class.name}:#{Rails.env}"` as the ContextProvider cache key
- Add `ContextProvider.reset!` to the engine's `to_prepare` hook so the cache clears on every Zeitwerk reload

`object_id` is not stable across forks (Puma, Unicorn, Pitchfork) or Rails reloads. After fork, the child process inherits the parent cache but the app object may be re-created, causing cache misses or stale entries.

Closes #162.

#### Test plan
- [x] `bundle exec rspec spec/lib/rails_ai_bridge/context_provider_spec.rb` — 8 examples, 0 failures
- [x] `bundle exec rubocop` clean
- [x] New fork-safety tests verify stable cache key across different app objects with same class name
- [x] New test verifies cache key includes class name and Rails env

Generated with [Devin](https://devin.ai)