### PR TITLE
test: registry server specs and integration tests

### DIFF
--- a/spec/lib/rails_ai_bridge/mcp/registry_integration_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/registry_integration_spec.rb
@@ -1,0 +1,329 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_ai_bridge/registry/tile_manifest'
+
+RSpec.describe 'Registry tools integration in MCP server' do
+  let(:app) { Rails.application }
+  let(:server) { RailsAiBridge::Server.new(app).build }
+
+  let(:registry_tool_names) do
+    %w[rails_list_registry rails_resolve_skill rails_use_skill rails_use_agent]
+  end
+
+  around do |example|
+    original_ttl = RailsAiBridge.configuration.mcp.tool_result_cache_ttl
+    RailsAiBridge::ToolResultCache.reset!
+    # Caching is enabled so the full wrapper chain
+    # (InstrumentedTool -> CachedTool -> raw tool) is exercised and the
+    # CachedTool translates server_context to _server_context.
+    RailsAiBridge.configuration.mcp.tool_result_cache_ttl = 30
+    example.run
+  ensure
+    RailsAiBridge.configuration.mcp.tool_result_cache_ttl = original_ttl
+    RailsAiBridge::ToolResultCache.reset!
+  end
+
+  def build_tile(name:, version:, summary:)
+    RailsAiBridge::Registry::TileManifest.new(
+      name: name,
+      version: version,
+      summary: summary,
+      depends_on: [],
+      skills: {},
+      agents: {},
+      deprecated_skills: {}
+    )
+  end
+
+  def build_resolved(name:, pack:, path:, content:)
+    RailsAiBridge::Registry::ResolvedSkill.new(name: name, pack: pack, path: path, content: content)
+  end
+
+  def build_resolver(**stubs)
+    defaults = { resolve_skill: nil, resolve_agent: nil, check_deprecated: nil,
+                 list_skills: [], list_agents: [], active_packs: [] }
+    instance_double(RailsAiBridge::Registry::Resolver, **defaults, **stubs)
+  end
+
+  def tool_response(tool_name, **arguments)
+    server.tools[tool_name].call(**arguments)
+  end
+
+  def response_text(tool_name, **arguments)
+    tool_response(tool_name, **arguments).content.first[:text]
+  end
+
+  describe 'tool registration' do
+    it 'registers all four registry tools in the MCP server' do
+      registry_tool_names.each do |name|
+        expect(server.tools).to have_key(name)
+      end
+    end
+
+    it 'wraps registry tools with Instrumentation::InstrumentedTool' do
+      registry_tool_names.each do |name|
+        expect(server.tools[name]).to be_a(RailsAiBridge::Instrumentation::InstrumentedTool)
+      end
+    end
+  end
+
+  describe 'rails_list_registry' do
+    context 'when no registry manifest is configured' do
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(nil) }
+
+      it 'returns a setup message mentioning the registry manifest' do
+        text = response_text('rails_list_registry', type: 'skills')
+
+        expect(text).to include('registry manifest')
+        expect(text).to include('config/rails_ai_bridge_registry.json')
+      end
+    end
+
+    context 'when skills are available' do
+      let(:skills) do
+        [
+          RailsAiBridge::Registry::SkillSummary.new(name: 'code-review', pack: 'rails', description: 'Review Rails code.'),
+          RailsAiBridge::Registry::SkillSummary.new(name: 'write-tests', pack: 'core', description: 'Write RSpec tests.')
+        ]
+      end
+      let(:resolver) { build_resolver(list_skills: skills) }
+
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver) }
+
+      it 'lists all skills with name, pack, and description' do
+        text = response_text('rails_list_registry', type: 'skills')
+
+        expect(text).to include('# Available Skills')
+        expect(text).to include('code-review')
+        expect(text).to include('rails')
+        expect(text).to include('write-tests')
+        expect(text).to include('core')
+      end
+
+      it 'filters skills by pack' do
+        text = response_text('rails_list_registry', type: 'skills', pack: 'rails')
+
+        expect(text).to include('code-review')
+        expect(text).not_to include('write-tests')
+      end
+    end
+
+    context 'when agents are available' do
+      let(:agents) do
+        [
+          RailsAiBridge::Registry::SkillSummary.new(name: 'tdd-workflow', pack: 'rails', description: 'Full TDD cycle.')
+        ]
+      end
+      let(:resolver) { build_resolver(list_agents: agents) }
+
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver) }
+
+      it 'lists all agents' do
+        text = response_text('rails_list_registry', type: 'agents')
+
+        expect(text).to include('# Available Agents')
+        expect(text).to include('tdd-workflow')
+      end
+    end
+
+    context 'when packs are loaded' do
+      let(:active_packs) do
+        [
+          RailsAiBridge::Registry::LoadedPack.new(
+            name: 'rails',
+            tile: build_tile(name: 'rails', version: '1.2.0', summary: 'Rails-specific skills.'),
+            base_path: '/tmp/rails',
+            priority: 10
+          )
+        ]
+      end
+      let(:resolver) { build_resolver(active_packs: active_packs) }
+
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver) }
+
+      it 'lists active packs with version and priority' do
+        text = response_text('rails_list_registry', type: 'packs')
+
+        expect(text).to include('# Active Skill Packs')
+        expect(text).to include('rails')
+        expect(text).to include('1.2.0')
+        expect(text).to include('10')
+      end
+    end
+  end
+
+  describe 'rails_resolve_skill' do
+    context 'when no registry manifest is configured' do
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(nil) }
+
+      it 'returns a setup message mentioning the registry manifest' do
+        text = response_text('rails_resolve_skill', name: 'code-review')
+
+        expect(text).to include('registry manifest')
+      end
+    end
+
+    context 'when the skill is found' do
+      let(:skill) do
+        build_resolved(name: 'code-review', pack: 'rails',
+                       path: '/cache/rails/code-review/SKILL.md',
+                       content: "# Code Review\n\nReview Rails PRs.")
+      end
+      let(:resolver) { build_resolver(resolve_skill: skill) }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(resolver).to receive(:resolve_skill).with('code-review').and_return(skill)
+      end
+
+      it 'returns the full skill content with name and pack' do
+        text = response_text('rails_resolve_skill', name: 'code-review')
+
+        expect(text).to include('# code-review')
+        expect(text).to include('rails')
+        expect(text).to include(skill.content)
+      end
+    end
+
+    context 'when the skill is not found' do
+      let(:resolver) { build_resolver(resolve_skill: nil) }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(resolver).to receive(:resolve_skill).with('nonexistent-skill').and_return(nil)
+      end
+
+      it 'mentions the skill name and suggests rails_list_registry' do
+        text = response_text('rails_resolve_skill', name: 'nonexistent-skill')
+
+        expect(text).to include('nonexistent-skill')
+        expect(text).to include('rails_list_registry')
+      end
+    end
+
+    context 'when resolving an agent' do
+      let(:agent) do
+        build_resolved(name: 'tdd-workflow', pack: 'rails',
+                       path: '/cache/rails/tdd-workflow/AGENT.md',
+                       content: "# TDD Workflow\n\nFull TDD cycle.")
+      end
+      let(:resolver) { build_resolver(resolve_agent: agent) }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(resolver).to receive(:resolve_agent).with('tdd-workflow').and_return(agent)
+      end
+
+      it 'returns the full agent content' do
+        text = response_text('rails_resolve_skill', name: 'tdd-workflow', type: 'agent')
+
+        expect(text).to include('# tdd-workflow')
+        expect(text).to include(agent.content)
+      end
+    end
+  end
+
+  describe 'rails_use_skill' do
+    context 'when no registry manifest is configured' do
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(nil) }
+
+      it 'returns a setup message mentioning the registry manifest' do
+        text = response_text('rails_use_skill', name: 'code-review')
+
+        expect(text).to include('registry manifest')
+      end
+    end
+
+    context 'when the skill is found' do
+      let(:skill) do
+        build_resolved(name: 'code-review', pack: 'rails',
+                       path: '/cache/rails/code-review/SKILL.md',
+                       content: "# Code Review\n\nReview Rails PRs.")
+      end
+      let(:resolver) { build_resolver(resolve_skill: skill, check_deprecated: nil) }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(resolver).to receive(:resolve_skill).with('code-review').and_return(skill)
+        allow(resolver).to receive(:check_deprecated).with('code-review').and_return(nil)
+      end
+
+      it 'frames the output as an application directive with skill content' do
+        text = response_text('rails_use_skill', name: 'code-review')
+
+        expect(text).to include('Applying skill: code-review')
+        expect(text).to include('rails')
+        expect(text).to include(skill.content)
+        expect(text).to include('Work through every step')
+      end
+    end
+
+    context 'when the skill is not found' do
+      let(:resolver) { build_resolver(resolve_skill: nil) }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(resolver).to receive(:resolve_skill).with('nonexistent-skill').and_return(nil)
+      end
+
+      it 'mentions the skill name and suggests rails_list_registry' do
+        text = response_text('rails_use_skill', name: 'nonexistent-skill')
+
+        expect(text).to include('nonexistent-skill')
+        expect(text).to include('rails_list_registry')
+      end
+    end
+  end
+
+  describe 'rails_use_agent' do
+    context 'when no registry manifest is configured' do
+      before { allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(nil) }
+
+      it 'returns a setup message mentioning the registry manifest' do
+        text = response_text('rails_use_agent', name: 'tdd-workflow')
+
+        expect(text).to include('registry manifest')
+      end
+    end
+
+    context 'when the agent is found' do
+      let(:agent) do
+        build_resolved(name: 'tdd-workflow', pack: 'core',
+                       path: '/cache/core/agents/tdd-workflow.md',
+                       content: "# TDD Workflow\n\nRed, green, refactor.")
+      end
+      let(:resolver) { build_resolver(resolve_agent: agent) }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(resolver).to receive(:resolve_agent).with('tdd-workflow').and_return(agent)
+      end
+
+      it 'frames the output as an activation directive with agent content' do
+        text = response_text('rails_use_agent', name: 'tdd-workflow')
+
+        expect(text).to include('Activating agent: tdd-workflow')
+        expect(text).to include('core')
+        expect(text).to include(agent.content)
+        expect(text).to include('end to end')
+      end
+    end
+
+    context 'when the agent is not found' do
+      let(:resolver) { build_resolver(resolve_agent: nil) }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(resolver).to receive(:resolve_agent).with('nonexistent-agent').and_return(nil)
+      end
+
+      it 'mentions the agent name and suggests rails_list_registry with agents type' do
+        text = response_text('rails_use_agent', name: 'nonexistent-agent')
+
+        expect(text).to include('nonexistent-agent')
+        expect(text).to include('rails_list_registry type=agents')
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/server_spec.rb
+++ b/spec/lib/rails_ai_bridge/server_spec.rb
@@ -36,6 +36,19 @@ RSpec.describe RailsAiBridge::Server do
     end
   end
 
+  describe 'TOOLS constant' do
+    it 'includes all 16 built-in tools' do
+      expect(RailsAiBridge::Server::TOOLS.length).to eq(16)
+    end
+
+    it 'includes the registry tool classes' do
+      expect(RailsAiBridge::Server::TOOLS).to include(RailsAiBridge::Tools::ListRegistry)
+      expect(RailsAiBridge::Server::TOOLS).to include(RailsAiBridge::Tools::ResolveSkill)
+      expect(RailsAiBridge::Server::TOOLS).to include(RailsAiBridge::Tools::UseSkill)
+      expect(RailsAiBridge::Server::TOOLS).to include(RailsAiBridge::Tools::UseAgent)
+    end
+  end
+
   describe '#tool_classes' do
     it 'returns built-in tools plus additional tools' do
       additional_tools = [double(tool_name: 'custom_tool')]
@@ -53,6 +66,77 @@ RSpec.describe RailsAiBridge::Server do
       tool_classes = server.tool_classes
 
       expect(tool_classes).to eq(RailsAiBridge::Server::TOOLS)
+    end
+
+    it 'returns a wrapper for every built-in tool' do
+      allow(RailsAiBridge.configuration).to receive(:additional_tools).and_return([])
+
+      tool_classes = server.tool_classes
+
+      expect(tool_classes.length).to eq(RailsAiBridge::Server::TOOLS.length)
+      expect(tool_classes.map(&:tool_name)).to eq(RailsAiBridge::Server::TOOLS.map(&:tool_name))
+    end
+
+    it 'wraps every tool with Instrumentation::InstrumentedTool' do
+      allow(RailsAiBridge.configuration).to receive(:additional_tools).and_return([])
+
+      tool_classes = server.tool_classes
+
+      expect(tool_classes).to all(be_a(RailsAiBridge::Instrumentation::InstrumentedTool))
+    end
+
+    it 'includes wrappers for the registry tools' do
+      allow(RailsAiBridge.configuration).to receive(:additional_tools).and_return([])
+
+      tool_names = server.tool_classes.map(&:tool_name)
+
+      expect(tool_names).to include('rails_list_registry')
+      expect(tool_names).to include('rails_resolve_skill')
+      expect(tool_names).to include('rails_use_skill')
+      expect(tool_names).to include('rails_use_agent')
+    end
+
+    context 'when caching is enabled' do
+      before do
+        allow(RailsAiBridge.configuration.mcp).to receive(:tool_result_cache_ttl).and_return(30)
+      end
+
+      it 'wraps every tool with Instrumentation::InstrumentedTool' do
+        allow(RailsAiBridge.configuration).to receive(:additional_tools).and_return([])
+
+        tool_classes = server.tool_classes
+
+        expect(tool_classes).to all(be_a(RailsAiBridge::Instrumentation::InstrumentedTool))
+      end
+
+      it 'wraps the registry tools with ToolResultCache::CachedTool' do
+        allow(RailsAiBridge.configuration).to receive(:additional_tools).and_return([])
+
+        registry_names = %w[rails_list_registry rails_resolve_skill rails_use_skill rails_use_agent]
+        registry_wrappers = server.tool_classes.select { |t| registry_names.include?(t.tool_name) }
+
+        expect(registry_wrappers.length).to eq(4)
+        expect(registry_wrappers.map(&:__getobj__)).to all(be_a(RailsAiBridge::ToolResultCache::CachedTool))
+      end
+
+      it 'wraps all built-in tools with ToolResultCache::CachedTool' do
+        allow(RailsAiBridge.configuration).to receive(:additional_tools).and_return([])
+
+        inner = server.tool_classes.map(&:__getobj__)
+
+        expect(inner).to all(be_a(RailsAiBridge::ToolResultCache::CachedTool))
+      end
+    end
+
+    context 'when caching is disabled' do
+      it 'does not wrap tools with ToolResultCache::CachedTool' do
+        allow(RailsAiBridge.configuration).to receive(:additional_tools).and_return([])
+
+        inner = server.tool_classes.map(&:__getobj__)
+
+        expect(inner).to all(be_a(Class))
+        expect(inner).to all(be < RailsAiBridge::Tools::BaseTool)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Group C of the 4.2.0 release plan: extends server specs for the registry tools and adds an integration spec covering the registry tools working within the MCP server context.

## Changes

### Task 1 — Extend `server_spec.rb` for registry tools (#149)

- Assert `Server::TOOLS` includes all 4 registry tool classes (`ListRegistry`, `ResolveSkill`, `UseSkill`, `UseAgent`) and totals 16 built-in tools.
- Assert `Server#tool_classes` returns a wrapper for every built-in tool (count + tool names).
- Assert every tool is wrapped with `Instrumentation::InstrumentedTool`.
- Assert the registry tool names (`rails_list_registry`, `rails_resolve_skill`, `rails_use_skill`, `rails_use_agent`) are present.
- When caching is enabled (`tool_result_cache_ttl > 0`), assert registry tools (and all built-in tools) are wrapped with `ToolResultCache::CachedTool` while still being wrapped by `InstrumentedTool`.
- When caching is disabled, assert tools are not wrapped with `CachedTool`.

### Task 2 — Integration spec for registry tools in MCP server (#150)

New `spec/lib/rails_ai_bridge/mcp/registry_integration_spec.rb`:

- Boots a real `RailsAiBridge::Server` via `.build` and verifies all 4 registry tools are registered in `server.tools` and wrapped with `Instrumentation::InstrumentedTool`.
- Invokes `rails_list_registry` (skills, agents, packs) and verifies response shape and content.
- Covers the "no registry configured" error path for every registry tool.
- Covers `rails_resolve_skill` with a valid skill, a missing skill, and agent resolution.
- Covers `rails_use_skill` and `rails_use_agent` basic invocation (found / not found / no manifest).
- Exercises the full wrapper chain (InstrumentedTool → CachedTool → raw tool) by enabling caching.

## Verification

- `bundle exec rspec` — 2372 examples, 0 failures
- `bundle exec rubocop` — 435 files inspected, no offenses