### PR TITLE
feat: 4.2.0 registry features — context providers, Doctor checker, path standardization, memoization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,8 @@ Layout/LineLength:
   Max: 180
 Metrics/ModuleLength:
   Max: 240
+  Exclude:
+    - "lib/rails_ai_bridge/resources.rb"
 Metrics/MethodLength:
   Max: 70
 RSpec/NestedGroups:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ structure to AI assistants via the Model Context Protocol (MCP).
 - `lib/rails_ai_bridge/configuration.rb` — User-facing config with presets (:standard, :full)
 - `lib/rails_ai_bridge/introspector.rb` — Orchestrates sub-introspectors
 - `lib/rails_ai_bridge/introspectors/` — Built-in introspector classes; `:standard` preset runs **9**, `:full` runs **27** (see `Configuration::PRESETS`). Registry: `Introspector::BUILTIN_INTROSPECTORS` (includes opt-in symbols such as `database_stats`, `non_ar_models` not listed in those presets).
-- `lib/rails_ai_bridge/tools/` — 16 built-in MCP tools using the official mcp SDK (hosts can add more via `additional_tools`)
+- `lib/rails_ai_bridge/tools/` — 17 built-in MCP tools using the official mcp SDK (hosts can add more via `additional_tools`)
 - `lib/rails_ai_bridge/serializers/` — Output formatters (claude, claude_rules, codex, cursor_rules, devin, devin_rules, copilot, copilot_instructions, gemini, rules, markdown, JSON)
 - `lib/rails_ai_bridge/resources.rb` — MCP resources (static data AI clients read directly)
 - `lib/rails_ai_bridge/server.rb` — MCP server configuration (stdio + HTTP transports)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ structure to AI assistants via the Model Context Protocol (MCP).
   runs **9**, `:full` runs **27** (see `Configuration::PRESETS`). Registry:
   `Introspector::BUILTIN_INTROSPECTORS` (includes opt-in symbols such as
   `database_stats`, `non_ar_models` not listed in those presets).
-- `lib/rails_ai_bridge/tools/` — 16 built-in MCP tools using the official mcp SDK
+- `lib/rails_ai_bridge/tools/` — 17 built-in MCP tools using the official mcp SDK
   (hosts can add more via `additional_tools`)
 - `lib/rails_ai_bridge/serializers/` — Output formatters (claude, claude_rules,
   codex, cursor_rules, devin, devin_rules, copilot, copilot_instructions,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ The test suite uses [Combustion](https://github.com/pat/combustion) to boot a mi
 ```
 lib/rails_ai_bridge/
 ├── introspectors/          # Built-in introspectors (schema, models, non_ar_models, routes, …)
-├── tools/                  # 16 built-in MCP tools (detail levels, pagination, extensible)
+├── tools/                  # 17 built-in MCP tools (detail levels, pagination, extensible)
 ├── rubydex_adapter.rb       # Rubydex API wrapper (singleton + query interface + stats)
 ├── rubydex_adapter/         # Extracted collaborators (one concern each)
 │   ├── serializer.rb        # Hash serialization (declaration_to_hash, definition_to_hash, …)

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ This keeps context focused and avoids unnecessary token usage while still allowi
 
 ## MCP Tools
 
-The gem exposes **16 built-in tools** via MCP that AI clients call on-demand (hosts can append more via `config.additional_tools`):
+The gem exposes **17 built-in tools** via MCP that AI clients call on-demand (hosts can append more via `config.additional_tools`):
 
 | Tool | What it returns |
 |------|----------------|
@@ -271,6 +271,7 @@ The gem exposes **16 built-in tools** via MCP that AI clients call on-demand (ho
 | `rails_resolve_skill` | Full content of a named skill or agent from the registry (priority ordering + deprecation redirects); optional `pack=` pin and `type=agent` |
 | `rails_use_skill` | Loads a skill framed as an application directive (apply it step by step to the current task) |
 | `rails_use_agent` | Loads an agent/workflow framed as an activation directive (follow it end to end) |
+| `rails_list_context_providers` | Context providers declared in the registry manifest — external services (e.g. MCP servers) the bridge can query for project context; shows type, endpoint, optional flag, and tool specs |
 
 All tools are **read-only** — they never modify your application or database.
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The gem exposes **17 built-in tools** via MCP that AI clients call on-demand (ho
 | `rails_get_view` | View layouts, templates, partials; optional per-file detail under the configured `app/views` path |
 | `rails_search_semantic` | Semantic code search using rubydex — find declarations by name with types, locations, and relationships |
 | `rails_get_stimulus` | Stimulus controllers: targets, values, actions, outlets (requires `:stimulus` introspector) |
-| `rails_list_registry` | Skill pack catalog — list skills, agents, or active packs; requires `config/rails_ai_bridge_registry.json` |
+| `rails_list_registry` | Skill pack catalog — list skills, agents, or active packs; requires `config/rails_ai_bridge/registry.json` |
 | `rails_resolve_skill` | Full content of a named skill or agent from the registry (priority ordering + deprecation redirects); optional `pack=` pin and `type=agent` |
 | `rails_use_skill` | Loads a skill framed as an application directive (apply it step by step to the current task) |
 | `rails_use_agent` | Loads an agent/workflow framed as an activation directive (follow it end to end) |
@@ -544,7 +544,7 @@ end
 | `parallel_introspection` | `false` | Run introspectors concurrently (requires `concurrent-ruby`, which is already a Rails dependency) |
 | `parallel_pool_size` | `4` | Max threads in the parallel pool; capped at the number of active introspectors so no idle threads are created |
 | `parallel_timeout_seconds` | `10` | Per-introspector future timeout (seconds); timed-out introspectors return `{ error: "timed out after Ns" }` without blocking the others |
-| `registry.registry_manifest_path` | `"config/rails_ai_bridge_registry.json"` | Path to the registry manifest JSON file for skill pack resolution |
+| `registry.registry_manifest_path` | `"config/rails_ai_bridge/registry.json"` | Path to the registry manifest JSON file for skill pack resolution |
 | `registry.skill_cache_dir` | `"~/.rails-ai-bridge/cache"` | Directory for caching git repositories containing skill packs |
 | `registry.skill_packs` | `nil` | Explicit pack names to load, or `nil` for auto-detection based on framework |
 | `registry.local_registry_paths` | `[]` | Local directory paths (must contain `directory.json`) loaded at priority 0 |
@@ -687,10 +687,10 @@ To customize it in your initializer (`config/initializers/rails_ai_bridge.rb`):
 rails-ai-bridge can load **skill packs** — shared collections of agent instructions — from versioned git repositories and surface them through `rails_list_registry` and rake tasks.
 
 ```ruby
-config.registry.registry_manifest_path = "config/rails_ai_bridge_registry.json"
+config.registry.registry_manifest_path = "config/rails_ai_bridge/registry.json"
 ```
 
-Quick example manifest (`config/rails_ai_bridge_registry.json`):
+Quick example manifest (`config/rails_ai_bridge/registry.json`):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Optional: `gem install rails-ai-bridge` installs the gem into your Ruby environm
 | Zero config | Yes — Railtie + install generator | No — per-project `projects.yml` | No |
 | Token optimization | Yes — compact files + `detail:"summary"` workflow | Varies | No |
 | Codex-oriented repo files | Yes — `AGENTS.md`, `.codex/README.md` | No | DIY |
-| Live MCP tools | Yes — 16 read-only `rails_*` tools (extensible) | Yes | No |
+| Live MCP tools | Yes — 17 read-only `rails_*` tools (extensible) | Yes | No |
 | Auto-introspection | Yes — up to **27** domains (`:full`) | No — server points at projects you configure | DIY |
 
 *Comparison reflects typical documented setups; verify against each project before treating any row as absolute.*

--- a/docs/02-port-registry-resolution.md
+++ b/docs/02-port-registry-resolution.md
@@ -96,7 +96,7 @@ end
 ### 3. Configuration
 
 **Add to `lib/rails_ai_bridge/configuration.rb`:**
-- `registry_manifest_path` — Path to registry.json (default: `config/rails_ai_bridge_registry.json`)
+- `registry_manifest_path` — Path to registry.json (default: `config/rails_ai_bridge/registry.json`)
 - `skill_cache_dir` — Path to git cache directory (default: `~/.rails-ai-bridge/cache`)
 - `skill_packs` — Array of explicit pack names to load (optional)
 - `local_registry_paths` — Array of local registry directories (optional)

--- a/docs/devin-setup.md
+++ b/docs/devin-setup.md
@@ -226,7 +226,7 @@ rails-ai-bridge supports a skill registry — a collection of reusable AI skills
 
 The `rails_list_registry` tool returns all available skills. The `rails_resolve_skill` tool retrieves the full content of a named skill so Devin can apply it.
 
-Skills are configured via `config/rails_ai_bridge_registry.json` in your Rails application. A minimal registry file looks like:
+Skills are configured via `config/rails_ai_bridge/registry.json` in your Rails application. A minimal registry file looks like:
 
 ```json
 {
@@ -261,4 +261,4 @@ Devin will call `rails_list_registry`, review the options, and call `rails_resol
 | `.devin/rules/rails-mcp-tools.md` | `rails ai:bridge:devin` | Yes |
 | `AGENTS.md` | `rails ai:bridge:devin` | Yes |
 | `.devin/mcp.json` | Manual | Yes |
-| `config/rails_ai_bridge_registry.json` | Manual | Yes |
+| `config/rails_ai_bridge/registry.json` | Manual | Yes |

--- a/docs/port-registry-resolution.md
+++ b/docs/port-registry-resolution.md
@@ -119,7 +119,7 @@ necessary for the future skill compiler feature.
 
 **Files:**
 - `lib/rails_ai_bridge/config/registry.rb` — `Config::Registry` sub-object
-  - `registry_manifest_path` (default: `config/rails_ai_bridge_registry.json`)
+  - `registry_manifest_path` (default: `config/rails_ai_bridge/registry.json`)
   - `skill_cache_dir` (default: `~/.rails-ai-bridge/cache`)
   - `skill_packs` (default: `nil` — triggers auto-detection)
   - `local_registry_paths` (default: `[]`)

--- a/docs/registry-resolution.md
+++ b/docs/registry-resolution.md
@@ -16,7 +16,7 @@ When a pack is loaded, its skills and agents appear in `rails_list_registry`, an
 
 ## Quick start
 
-**1. Create the registry manifest** at `config/rails_ai_bridge_registry.json`:
+**1. Create the registry manifest** at `config/rails_ai_bridge/registry.json`:
 
 ```json
 {
@@ -39,7 +39,7 @@ When a pack is loaded, its skills and agents appear in `rails_list_registry`, an
 
 ```ruby
 RailsAiBridge.configure do |config|
-  config.registry.registry_manifest_path = "config/rails_ai_bridge_registry.json"
+  config.registry.registry_manifest_path = "config/rails_ai_bridge/registry.json"
 end
 ```
 
@@ -102,7 +102,7 @@ All options live under `config.registry.*`:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `registry_manifest_path` | `"config/rails_ai_bridge_registry.json"` | Path to the registry manifest JSON |
+| `registry_manifest_path` | `"config/rails_ai_bridge/registry.json"` | Path to the registry manifest JSON |
 | `skill_cache_dir` | `~/.rails-ai-bridge/cache` | Directory for caching cloned git repositories |
 | `skill_packs` | `nil` | Explicit list of pack names to load, or `nil` for auto-detection |
 | `local_registry_paths` | `[]` | Local directory paths containing a `directory.json` (loaded at priority 0) |

--- a/docs/skill-registry-guide.md
+++ b/docs/skill-registry-guide.md
@@ -18,7 +18,7 @@ A **skill pack** is a git repository containing:
 - **Markdown files** for each skill (e.g. `skills/code-review.md`)
 - Optional **deprecation redirects** when skills are renamed
 
-The skill registry in your Rails app is a **`config/rails_ai_bridge_registry.json`** manifest that tells rails-ai-bridge which packs to load, where to find them, and how to prioritize them when two packs define a skill with the same name.
+The skill registry in your Rails app is a **`config/rails_ai_bridge/registry.json`** manifest that tells rails-ai-bridge which packs to load, where to find them, and how to prioritize them when two packs define a skill with the same name.
 
 ---
 
@@ -26,7 +26,7 @@ The skill registry in your Rails app is a **`config/rails_ai_bridge_registry.jso
 
 ### Step 1 — Create the registry manifest
 
-Create `config/rails_ai_bridge_registry.json` in your Rails app:
+Create `config/rails_ai_bridge/registry.json` in your Rails app:
 
 ```json
 {
@@ -78,7 +78,7 @@ In `config/initializers/rails_ai_bridge.rb`:
 
 ```ruby
 RailsAiBridge.configure do |config|
-  config.registry.registry_manifest_path = "config/rails_ai_bridge_registry.json"
+  config.registry.registry_manifest_path = "config/rails_ai_bridge/registry.json"
 end
 ```
 
@@ -195,13 +195,13 @@ This protects against:
 rails ai:registry:lockfile
 ```
 
-The file is written to `config/rails_ai_bridge/directory.lock` by default. Commit it alongside your manifest.
+The file is written to `config/rails_ai_bridge/registry.lock` by default. Commit it alongside your manifest.
 
 ### Configuration
 
 ```ruby
 RailsAiBridge.configure do |config|
-  config.registry.lockfile_path = "config/rails_ai_bridge/directory.lock"
+  config.registry.lockfile_path = "config/rails_ai_bridge/registry.lock"
   config.registry.lockfile_verification = :strict  # :strict (default), :warn, or :disabled
 end
 ```
@@ -438,7 +438,7 @@ initializer changes take effect immediately.
 
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
-| `rails ai:skills:list` shows "No registry manifest found" | Manifest file does not exist or path is wrong | Create `config/rails_ai_bridge_registry.json` or check `config.registry.registry_manifest_path` |
+| `rails ai:skills:list` shows "No registry manifest found" | Manifest file does not exist or path is wrong | Create `config/rails_ai_bridge/registry.json` or check `config.registry.registry_manifest_path` |
 | Git clone fails with "not found" | Pack source URL is wrong or repo is private | Check the `source` field; for private repos use a full SSH URL `git@github.com:org/repo.git` |
 | `Invalid source format` error mentioning `http://` | Pack source uses plain HTTP | Change `source` to `https://` or `git@` — plain HTTP is not accepted |
 | Pack loads but shows 0 skills | `directory.json` is missing or has wrong path | Check the root of the cloned pack for `directory.json`; set `tile:` field if the file is elsewhere |
@@ -446,7 +446,7 @@ initializer changes take effect immediately.
 | Stale skills after pack update | Resolver cache is warm or pull TTL has not elapsed | Run `rails ai:skills:clear_cache` to force a re-clone on the next build |
 | Pack is not re-fetched even after `resolver_ttl` expired | Pack was cloned recently — `git_pull_ttl` (24 h) is still fresh | Run `rails ai:skills:clear_cache` or set `git_pull_ttl: 0` temporarily |
 | `git checkout <ref>` failed | Invalid ref or detached HEAD issue | Verify the `ref` value matches a branch, tag, or SHA in the remote repo |
-| `Lockfile mismatch for pack '…'` | Resolved pack commit differs from `directory.lock` | Run `rails ai:registry:lockfile` to update the lockfile after reviewing the pack changes |
+| `Lockfile mismatch for pack '…'` | Resolved pack commit differs from `registry.lock` | Run `rails ai:registry:lockfile` to update the lockfile after reviewing the pack changes |
 | Git operation hangs / server request times out | Slow or unreachable remote | Reduce `git_timeout` to fail faster; check network connectivity to the remote |
 | Warning: "Pack '…' depends on '…' which is not in the active pack set" | A loaded pack has an unsatisfied `depends_on` entry | Add the missing pack name to `always_loaded` or `skill_packs` in your manifest, or enable `config.registry.auto_load_dependencies` |
 | Warning: "Circular dependency detected: …" | Two or more active packs depend on each other | Break the cycle in the manifests; packs still load, but the cycle usually indicates a mistake |
@@ -462,5 +462,5 @@ initializer changes take effect immediately.
 - **Timeout protection**: all git operations are bounded by `git_timeout` (default 30 s) so a slow remote cannot block the calling thread indefinitely.
 - **Cache key sanitization**: local cache directory names are derived from a sanitized source string plus a SHA256 hash suffix to prevent filesystem collisions.
 - **Stable local pack names**: local registry pack names use a SHA256 digest of the directory path, so reordering `local_registry_paths` cannot silently shift pack identities.
-- **Lockfile verification**: a `directory.lock` records the expected commit SHA for each remote pack. The resolver fails closed when the cloned commit does not match, preventing a compromised or unexpectedly modified pack from injecting instructions.
+- **Lockfile verification**: a `registry.lock` records the expected commit SHA for each remote pack. The resolver fails closed when the cloned commit does not match, preventing a compromised or unexpectedly modified pack from injecting instructions.
 - **Local path trust**: local paths are used directly without git operations. The path traversal guard in the Resolver still applies to file reads within a local pack.

--- a/lib/rails_ai_bridge/config/registry.rb
+++ b/lib/rails_ai_bridge/config/registry.rb
@@ -11,8 +11,20 @@ module RailsAiBridge
     # @see RailsAiBridge::Registry::PackResolver
     # @see RailsAiBridge::Registry::Resolver
     class Registry
+      # Default path for the registry manifest (4.2.0+ standard location).
+      DEFAULT_REGISTRY_MANIFEST_PATH = 'config/rails_ai_bridge/registry.json'
+
+      # Legacy manifest path used before 4.2.0; kept for backward-compat fallback.
+      LEGACY_REGISTRY_MANIFEST_PATH = 'config/rails_ai_bridge_registry.json'
+
+      # Default path for the skill pack lockfile (4.2.0+ standard location).
+      DEFAULT_LOCKFILE_PATH = 'config/rails_ai_bridge/registry.lock'
+
+      # Legacy lockfile path used before 4.2.0; kept for backward-compat fallback.
+      LEGACY_LOCKFILE_PATH = 'config/rails_ai_bridge/directory.lock'
+
       # @return [String] path to the registry manifest JSON file
-      attr_accessor :registry_manifest_path
+      attr_writer :registry_manifest_path
 
       # @return [String] directory for caching git repositories
       attr_accessor :skill_cache_dir
@@ -36,7 +48,38 @@ module RailsAiBridge
       attr_reader :git_timeout
 
       # @return [String, nil] path to the skill pack lockfile. nil disables lockfile verification.
-      attr_accessor :lockfile_path
+      attr_writer :lockfile_path
+
+      # Returns the configured registry manifest path, applying a backward-compatibility
+      # fallback when the default path does not exist but the legacy path does.
+      #
+      # @return [String] resolved manifest path
+      def registry_manifest_path
+        return @registry_manifest_path unless @registry_manifest_path == DEFAULT_REGISTRY_MANIFEST_PATH
+
+        File.exist?(DEFAULT_REGISTRY_MANIFEST_PATH) ? DEFAULT_REGISTRY_MANIFEST_PATH : legacy_manifest_path
+      end
+
+      # Returns the configured lockfile path, applying a backward-compatibility
+      # fallback when the default path does not exist but the legacy path does.
+      # Returns +nil+ when lockfile verification is disabled.
+      #
+      # @return [String, nil] resolved lockfile path
+      def lockfile_path
+        return @lockfile_path unless @lockfile_path == DEFAULT_LOCKFILE_PATH
+
+        File.exist?(DEFAULT_LOCKFILE_PATH) ? DEFAULT_LOCKFILE_PATH : legacy_lockfile_path
+      end
+
+      # @api private
+      def legacy_manifest_path
+        File.exist?(LEGACY_REGISTRY_MANIFEST_PATH) ? LEGACY_REGISTRY_MANIFEST_PATH : DEFAULT_REGISTRY_MANIFEST_PATH
+      end
+
+      # @api private
+      def legacy_lockfile_path
+        File.exist?(LEGACY_LOCKFILE_PATH) ? LEGACY_LOCKFILE_PATH : DEFAULT_LOCKFILE_PATH
+      end
 
       # @return [Symbol] how to behave when the lockfile differs from the resolved pack:
       #   :strict (default) raises, :warn logs but proceeds, :disabled skips verification.
@@ -97,14 +140,14 @@ module RailsAiBridge
       end
 
       def initialize
-        @registry_manifest_path = 'config/rails_ai_bridge_registry.json'
+        @registry_manifest_path = DEFAULT_REGISTRY_MANIFEST_PATH
         @skill_cache_dir = File.expand_path('~/.rails-ai-bridge/cache')
         @skill_packs = nil
         @local_registry_paths = []
         @resolver_ttl = 1800
         @git_pull_ttl = 86_400
         @git_timeout = 30
-        @lockfile_path = 'config/rails_ai_bridge/directory.lock'
+        @lockfile_path = DEFAULT_LOCKFILE_PATH
         @lockfile_verification = :strict
         @auto_load_dependencies = false
       end

--- a/lib/rails_ai_bridge/doctor.rb
+++ b/lib/rails_ai_bridge/doctor.rb
@@ -22,7 +22,8 @@ module RailsAiBridge
       check_ripgrep: Checkers::RipgrepChecker,
       check_view_mcp_tool: Checkers::ViewMcpToolChecker,
       check_stimulus_mcp_tool: Checkers::StimulusMcpToolChecker,
-      check_bridge_metadata: Checkers::BridgeMetadataChecker
+      check_bridge_metadata: Checkers::BridgeMetadataChecker,
+      check_registry: Checkers::RegistryChecker
     }.freeze
 
     attr_reader :app

--- a/lib/rails_ai_bridge/doctor/checkers/registry_checker.rb
+++ b/lib/rails_ai_bridge/doctor/checkers/registry_checker.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  class Doctor
+    module Checkers
+      # Verifies the registry manifest is present, valid, and resolvable.
+      #
+      # Checks (in order):
+      # 1. The configured +registry_manifest_path+ exists.
+      # 2. The manifest JSON parses successfully.
+      # 3. +RegistryManifest.validate!+ passes schema validation.
+      # 4. +Registry.build_resolver+ returns a non-nil resolver.
+      # 5. The lockfile exists and matches (when +lockfile_path+ is configured).
+      #
+      # Each failure short-circuits with an actionable fix hint so the user can
+      # resolve the first problem before chasing downstream symptoms.
+      class RegistryChecker < BaseChecker
+        # @return [Doctor::Check] +:pass+, +:warn+, or +:fail+
+        def call
+          return missing_manifest_check unless manifest_path_exists?
+
+          return invalid_json_check unless manifest_parses?
+
+          return validation_failed_check unless manifest_validates?
+
+          resolver = build_resolver
+          return resolver_failed_check(resolver) unless resolver
+
+          return lockfile_check if lockfile_configured? && !lockfile_exists?
+
+          new_check(name: 'Registry', status: :pass, message: 'Registry manifest is valid and resolvable', fix: nil)
+        end
+
+        private
+
+        def registry_config
+          RailsAiBridge.configuration.registry
+        end
+
+        def manifest_path
+          registry_config.registry_manifest_path
+        end
+
+        def manifest_path_exists?
+          File.exist?(manifest_path)
+        end
+
+        def missing_manifest_check
+          new_check(
+            name: 'Registry',
+            status: :warn,
+            message: "Registry manifest not found at `#{manifest_path}`",
+            fix: 'Create a registry manifest file — see docs/skill-registry-guide.md'
+          )
+        end
+
+        def manifest_parses?
+          parsed_manifest
+          true
+        rescue ArgumentError
+          false
+        end
+
+        def invalid_json_check
+          new_check(
+            name: 'Registry',
+            status: :fail,
+            message: "Registry manifest at `#{manifest_path}` contains invalid JSON or could not be read",
+            fix: "Fix the JSON syntax in the manifest file — run `ruby -rjson -e 'JSON.parse(File.read(ARGV[0]))' #{manifest_path}` to see the parse error"
+          )
+        end
+
+        def parsed_manifest
+          @parsed_manifest ||= RailsAiBridge::Registry::RegistryManifest.from_file(manifest_path)
+        end
+
+        def manifest_validates?
+          RailsAiBridge::Registry::RegistryManifest.validate!(raw_manifest_hash)
+          true
+        rescue RailsAiBridge::Registry::RegistryManifest::ValidationError
+          false
+        end
+
+        def raw_manifest_hash
+          JSON.parse(File.read(manifest_path))
+        end
+
+        def validation_failed_check
+          new_check(
+            name: 'Registry',
+            status: :fail,
+            message: "Registry manifest at `#{manifest_path}` failed schema validation",
+            fix: 'Check the manifest structure — see docs/skill-registry-guide.md for the expected schema'
+          )
+        end
+
+        def build_resolver
+          RailsAiBridge::Registry.build_resolver(registry_config)
+        end
+
+        def resolver_failed_check(resolver)
+          new_check(
+            name: 'Registry',
+            status: :warn,
+            message: "Registry manifest parsed but resolver returned nil#{resolver_reason(resolver)}",
+            fix: 'Check that all pack sources are reachable and git is available — see logs for details'
+          )
+        end
+
+        def resolver_reason(resolver)
+          return '' unless resolver.nil?
+
+          ' (manifest missing or pack sources could not be resolved)'
+        end
+
+        def lockfile_configured?
+          registry_config.lockfile_path
+        end
+
+        def lockfile_exists?
+          File.exist?(registry_config.lockfile_path)
+        end
+
+        def lockfile_check
+          new_check(
+            name: 'Registry',
+            status: :warn,
+            message: "Lockfile not found at `#{registry_config.lockfile_path}`",
+            fix: 'Run `rails ai:registry:lock` to generate the lockfile, or set lockfile_path to nil to disable verification'
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/instrumentation.rb
+++ b/lib/rails_ai_bridge/instrumentation.rb
@@ -40,7 +40,9 @@ module RailsAiBridge
       # @return [MCP::Tool::Response]
       def call(server_context: nil, **arguments)
         Instrumentation.instrument('tool.call', tool_name: @tool_class.tool_name, arguments: arguments) do
-          invoke_tool(arguments, server_context)
+          Registry.with_request_resolver do
+            invoke_tool(arguments, server_context)
+          end
         end
       end
 

--- a/lib/rails_ai_bridge/registry.rb
+++ b/lib/rails_ai_bridge/registry.rb
@@ -44,6 +44,11 @@ module RailsAiBridge
   # @see Registry::ResolvedSkill
   # @see Registry::SkillSummary
   module Registry
+    # Thread-local key for the request-scoped resolver.
+    #
+    # @api private
+    REQUEST_RESOLVER_KEY = :rails_ai_bridge_request_resolver
+
     # Module-level resolver cache (one per process, lazy-initialized on first use).
     #
     # @api private
@@ -68,11 +73,38 @@ module RailsAiBridge
       @resolver_cache_mutex.synchronize { @resolver_cache&.invalidate! }
     end
 
+    # Wraps a block in a request scope so that {build_resolver} is called at most
+    # once per request cycle. The first {build_resolver} call within the block
+    # stores the result in a thread-local; subsequent calls return the same
+    # resolver without touching the TTL cache. The thread-local is always cleared
+    # when the block exits, even on error.
+    #
+    # @yield block to execute within the request scope
+    # @return [Object] the block result
+    def self.with_request_resolver
+      previous = Thread.current[REQUEST_RESOLVER_KEY]
+      Thread.current[REQUEST_RESOLVER_KEY] = nil
+      yield
+    ensure
+      Thread.current[REQUEST_RESOLVER_KEY] = previous
+    end
+
+    # Clears the request-scoped resolver for the current thread, if any.
+    #
+    # @return [void]
+    def self.clear_request_resolver!
+      Thread.current[REQUEST_RESOLVER_KEY] = nil
+    end
+
     # Builds (or returns a cached) {Resolver} from the current {Config::Registry}.
     #
     # The first call for a given TTL window loads the manifest from disk, wires the
     # {SkillSourceResolver} and {PackResolver} pipeline, and caches the result.
     # Subsequent calls within the TTL window return the same resolver without I/O.
+    #
+    # When inside a {with_request_resolver} block, the first successful build is
+    # memoized for the remainder of the request so multiple tool calls in the same
+    # request cycle share a single resolver without risking a mid-request rebuild.
     #
     # Returns +nil+ when the registry manifest file does not exist, allowing callers
     # to surface a helpful setup message rather than raising. A nil result is never
@@ -81,8 +113,36 @@ module RailsAiBridge
     # @param config [RailsAiBridge::Config::Registry] registry configuration
     # @return [Resolver, nil] wired resolver, or nil if manifest file is missing
     def self.build_resolver(config = RailsAiBridge.configuration.registry)
-      resolver_cache.fetch(config) { build_resolver_uncached(config) }
+      return request_resolver if request_resolver?
+
+      resolver = resolver_cache.fetch(config) { build_resolver_uncached(config) }
+      store_request_resolver(resolver) if request_active?
+      resolver
     end
+
+    # @api private
+    def self.request_resolver?
+      !Thread.current[REQUEST_RESOLVER_KEY].nil?
+    end
+    private_class_method :request_resolver?
+
+    # @api private
+    def self.request_resolver
+      Thread.current[REQUEST_RESOLVER_KEY]
+    end
+    private_class_method :request_resolver
+
+    # @api private
+    def self.request_active?
+      Thread.current.key?(REQUEST_RESOLVER_KEY)
+    end
+    private_class_method :request_active?
+
+    # @api private
+    def self.store_request_resolver(resolver)
+      Thread.current[REQUEST_RESOLVER_KEY] = resolver if resolver
+    end
+    private_class_method :store_request_resolver
 
     # Writes a lockfile containing the current HEAD commit SHA for every pack in
     # the registry manifest.

--- a/lib/rails_ai_bridge/resources.rb
+++ b/lib/rails_ai_bridge/resources.rb
@@ -16,6 +16,9 @@ module RailsAiBridge
     # URI pattern for matching stimulus controller URIs (rails://stimulus/{name})
     STIMULUS_URI_PATTERN = %r{\Arails://stimulus/(.+)\z}
 
+    # URI pattern for matching context provider URIs (rails://context-providers/{name})
+    CONTEXT_PROVIDER_URI_PATTERN = %r{\Arails://context-providers/(.+)\z}
+
     # Standard MIME type for all JSON resources
     JSON_MIME_TYPE = 'application/json'
 
@@ -125,7 +128,9 @@ module RailsAiBridge
       #
       # @return [Hash{String => Hash}] resource definitions keyed by URI
       def resource_definitions
-        STATIC_RESOURCES.merge(RailsAiBridge.configuration.additional_resources)
+        STATIC_RESOURCES
+          .merge(context_provider_resources)
+          .merge(RailsAiBridge.configuration.additional_resources)
       end
 
       # Builds the list of static +MCP::Resource+ objects for all registered URIs.
@@ -165,6 +170,12 @@ module RailsAiBridge
             uri_template: 'rails://stimulus/{name}',
             name: 'Stimulus Controller Details',
             description: 'Detailed information about a specific Stimulus controller',
+            mime_type: JSON_MIME_TYPE
+          ),
+          MCP::ResourceTemplate.new(
+            uri_template: 'rails://context-providers/{name}',
+            name: 'Context Provider Details',
+            description: 'Detailed information about a specific context provider declared in the registry manifest',
             mime_type: JSON_MIME_TYPE
           )
         ]
@@ -217,17 +228,20 @@ module RailsAiBridge
         definition = resource_definitions[uri]
         return nil unless definition
 
+        return read_context_provider(definition[:context_provider_name]) if definition[:context_provider_name]
+
         fetch_context_section(definition[:key])
       end
 
-      # Resolves templated resource URIs (models, views, stimulus).
+      # Resolves templated resource URIs (models, views, stimulus, context providers).
       # Tries each template pattern in order until one matches.
       # @param uri [String] templated resource URI
       # @return [Hash, nil] resource data or nil if no pattern matches
       def read_templated_resource(uri)
         read_model_resource(uri) ||
           read_view_template_resource(uri) ||
-          read_stimulus_template_resource(uri)
+          read_stimulus_template_resource(uri) ||
+          read_context_provider_resource(uri)
       end
 
       # Resolves model-specific resource URIs.
@@ -265,6 +279,18 @@ module RailsAiBridge
 
         name = CGI.unescape(match[1])
         read_stimulus_resource(name)
+      end
+
+      # Resolves context provider-specific resource URIs.
+      # Extracts provider name from URI and looks it up in the registry manifest.
+      # @param uri [String] context provider resource URI (rails://context-providers/{name})
+      # @return [Hash, nil] provider data or nil if no pattern matches
+      def read_context_provider_resource(uri)
+        match = uri.match(CONTEXT_PROVIDER_URI_PATTERN)
+        return nil unless match
+
+        name = CGI.unescape(match[1])
+        read_context_provider(name)
       end
 
       # Generates bridge metadata including version, configuration, and available resources.
@@ -308,6 +334,64 @@ module RailsAiBridge
         data = fetch_context_section(:stimulus)
         controllers = Array(data[:controllers])
         find_controller_by_name(controllers, name) || { error: STIMULUS_NOT_FOUND_ERROR % name }
+      end
+
+      # Builds dynamic MCP resource definitions for each context provider declared
+      # in the registry manifest. Each provider is exposed as a readable resource
+      # at +rails://context-providers/{name}+.
+      #
+      # @return [Hash{String => Hash}] resource definitions keyed by URI
+      def context_provider_resources
+        manifest = load_registry_manifest
+        return {} unless manifest
+
+        manifest.context_providers.each_with_object({}) do |(name, provider), resources|
+          uri = "rails://context-providers/#{name}"
+          resources[uri] = {
+            name: "Context Provider: #{name}",
+            description: "Context provider '#{name}' (#{provider.type}) declared in the registry manifest",
+            mime_type: JSON_MIME_TYPE,
+            context_provider_name: name
+          }
+        end
+      end
+
+      # Loads the registry manifest from the configured path, returning nil when
+      # no manifest is configured or the file is missing/unreadable.
+      #
+      # @return [Registry::RegistryManifest, nil]
+      def load_registry_manifest
+        path = RailsAiBridge.configuration.registry.registry_manifest_path
+        return nil unless path && File.exist?(path)
+
+        Registry::RegistryManifest.from_file(path)
+      rescue ArgumentError => error
+        Rails.logger&.error { "[rails-ai-bridge] Resource manifest load failed: #{error.message}" }
+        nil
+      end
+
+      # Fetches a single context provider by name from the registry manifest.
+      # @param name [String] provider name to find
+      # @return [Hash, nil] provider data or nil if not found
+      def read_context_provider(name)
+        manifest = load_registry_manifest
+        return nil unless manifest
+
+        provider = manifest.context_providers[name]
+        return nil unless provider
+
+        {
+          name: name,
+          type: provider.type,
+          endpoint: provider.endpoint,
+          optional: provider.optional?,
+          tools: provider.tools.map do |tool|
+            spec = { name: tool.name }
+            spec[:field] = tool.field if tool.mapped?
+            spec[:arguments] = tool.arguments if tool.arguments
+            spec
+          end
+        }
       end
 
       # Safely extracts a value from context with fallback.

--- a/lib/rails_ai_bridge/server.rb
+++ b/lib/rails_ai_bridge/server.rb
@@ -45,7 +45,8 @@ module RailsAiBridge
       Tools::ListRegistry,
       Tools::ResolveSkill,
       Tools::UseSkill,
-      Tools::UseAgent
+      Tools::UseAgent,
+      Tools::ListContextProviders
     ].freeze
 
     # Initialize a new MCP server instance.

--- a/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
+++ b/lib/rails_ai_bridge/tasks/rails_ai_bridge.rake
@@ -299,7 +299,7 @@ end
 
 namespace :ai do
   namespace :registry do
-    desc 'Generate or update the skill pack lockfile (config/rails_ai_bridge/directory.lock)'
+    desc 'Generate or update the skill pack lockfile (config/rails_ai_bridge/registry.lock)'
     task lockfile: :environment do
       require 'rails_ai_bridge'
 

--- a/lib/rails_ai_bridge/tools/list_context_providers.rb
+++ b/lib/rails_ai_bridge/tools/list_context_providers.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  module Tools
+    # MCP tool for listing context providers declared in the registry manifest.
+    #
+    # Context providers are external services (currently MCP servers) that the
+    # bridge can query for project context. This tool reads the
+    # +context_providers+ section of the registry manifest and returns a
+    # formatted list with each provider's type, endpoint, optional flag, and
+    # requested tool specs.
+    #
+    # @example List all context providers
+    #   rails_list_context_providers
+    class ListContextProviders < BaseTool
+      ENDPOINT_MAX_LENGTH = 80
+      SETUP_DOC_PATH = 'docs/skill-registry-guide.md'
+
+      SETUP_MESSAGE = <<~MSG.freeze
+        No registry manifest found at `%<path>s`.
+
+        To use context providers, create a registry manifest file.
+        See `#{SETUP_DOC_PATH}` for a step-by-step guide.
+
+        Quick start — add `config/rails_ai_bridge/registry.json` to your Rails app:
+
+        ```json
+        {
+          "version": "1.0.0",
+          "packs": {},
+          "default_stack": [],
+          "context_providers": {}
+        }
+        ```
+
+        Then configure the registry in `config/initializers/rails_ai_bridge.rb`:
+
+        ```ruby
+        RailsAiBridge.configure do |config|
+          config.registry.registry_manifest_path = "config/rails_ai_bridge/registry.json"
+        end
+        ```
+
+        Once configured, add context providers and run `rails ai:skills:list` to verify.
+      MSG
+
+      tool_name 'rails_list_context_providers'
+      description 'List context providers declared in the registry manifest. ' \
+                  'Each provider is an external service (e.g. an MCP server) the bridge ' \
+                  'can query for project context. Shows type, endpoint, optional flag, ' \
+                  'and requested tool specs. Requires a registry manifest — see docs/skill-registry-guide.md.'
+
+      input_schema(
+        properties: {}
+      )
+
+      annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false)
+
+      # @param _server_context [Object, nil] reserved for MCP transport metadata (unused)
+      # @return [MCP::Tool::Response] formatted provider list or a setup/error message
+      def self.call(_server_context: nil)
+        manifest = load_manifest
+        return text_response(format(SETUP_MESSAGE, path: manifest_path)) unless manifest
+
+        text_response(ContextProviderFormatter.new(manifest).format)
+      end
+
+      # @api private
+      def self.manifest_path
+        RailsAiBridge.configuration.registry.registry_manifest_path
+      end
+      private_class_method :manifest_path
+
+      # @api private
+      def self.load_manifest
+        path = manifest_path
+        return nil unless File.exist?(path)
+
+        Registry::RegistryManifest.from_file(path)
+      rescue ArgumentError => error
+        Rails.logger&.error { "[rails-ai-bridge] Context provider manifest load failed: #{error.message}" }
+        nil
+      end
+      private_class_method :load_manifest
+
+      # Formats the context providers section of a registry manifest as markdown.
+      #
+      # Single responsibility: converts manifest data into display-ready markdown.
+      # Does not know about MCP, tools, or configuration.
+      #
+      # @api private
+      class ContextProviderFormatter
+        include Registry::Truncatable
+
+        # @param manifest [Registry::RegistryManifest]
+        def initialize(manifest)
+          @manifest = manifest
+        end
+
+        # @return [String] markdown string
+        def format
+          providers = @manifest.context_providers
+          return 'No context providers are declared in the registry manifest.' if providers.empty?
+
+          lines = ["# Context Providers (#{providers.length})", '']
+          lines << '| Provider | Type | Endpoint | Optional | Tools |'
+          lines << '|----------|------|----------|----------|-------|'
+          providers.each do |name, provider|
+            lines << format_row(name, provider)
+          end
+          lines.join("\n")
+        end
+
+        private
+
+        def format_row(name, provider)
+          tools = provider.tools.map { |tool| format_tool(tool) }.join(', ')
+          optional = provider.optional? ? 'yes' : 'no'
+          "| **#{sanitize_markdown(name)}** | #{sanitize_markdown(provider.type)} | " \
+            "#{truncate(sanitize_markdown(provider.endpoint), ENDPOINT_MAX_LENGTH)} | " \
+            "#{optional} | #{sanitize_markdown(tools)} |"
+        end
+
+        def format_tool(tool)
+          return tool.name if tool.simple?
+
+          "#{tool.name} → #{tool.field}"
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/tools/list_registry.rb
+++ b/lib/rails_ai_bridge/tools/list_registry.rb
@@ -28,7 +28,7 @@ module RailsAiBridge
         To use skill registry tools, create a registry manifest file.
         See `#{SETUP_DOC_PATH}` for a step-by-step guide.
 
-        Quick start — add `config/rails_ai_bridge_registry.json` to your Rails app:
+        Quick start — add `config/rails_ai_bridge/registry.json` to your Rails app:
 
         ```json
         {
@@ -42,7 +42,7 @@ module RailsAiBridge
 
         ```ruby
         RailsAiBridge.configure do |config|
-          config.registry.registry_manifest_path = "config/rails_ai_bridge_registry.json"
+          config.registry.registry_manifest_path = "config/rails_ai_bridge/registry.json"
         end
         ```
 
@@ -56,7 +56,7 @@ module RailsAiBridge
                   'Use type=skills to list available skills, type=agents for workflows, ' \
                   'type=packs to see loaded packs with version and priority. ' \
                   'Optional pack: filter narrows skills/agents to one pack. ' \
-                  'Requires config/rails_ai_bridge_registry.json — see docs/skill-registry-guide.md.'
+                  'Requires config/rails_ai_bridge/registry.json — see docs/skill-registry-guide.md.'
 
       input_schema(
         properties: {

--- a/spec/lib/rails_ai_bridge/config/registry_spec.rb
+++ b/spec/lib/rails_ai_bridge/config/registry_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RailsAiBridge::Config::Registry do
     it 'sets default values' do
       config = described_class.new
 
-      expect(config.registry_manifest_path).to eq('config/rails_ai_bridge_registry.json')
+      expect(config.registry_manifest_path).to eq('config/rails_ai_bridge/registry.json')
       expect(config.skill_cache_dir).to eq(File.expand_path('~/.rails-ai-bridge/cache'))
       expect(config.skill_packs).to be_nil
       expect(config.local_registry_paths).to eq([])
@@ -30,6 +30,76 @@ RSpec.describe RailsAiBridge::Config::Registry do
       config.registry_manifest_path = 'custom/registry.json'
 
       expect(config.registry_manifest_path).to eq('custom/registry.json')
+    end
+
+    context 'with backward-compatibility fallback' do
+      let(:config) { described_class.new }
+
+      it 'returns the new default when neither path exists' do
+        allow(File).to receive(:exist?).with(described_class::DEFAULT_REGISTRY_MANIFEST_PATH).and_return(false)
+        allow(File).to receive(:exist?).with(described_class::LEGACY_REGISTRY_MANIFEST_PATH).and_return(false)
+
+        expect(config.registry_manifest_path).to eq(described_class::DEFAULT_REGISTRY_MANIFEST_PATH)
+      end
+
+      it 'falls back to the legacy path when only the legacy path exists' do
+        allow(File).to receive(:exist?).with(described_class::DEFAULT_REGISTRY_MANIFEST_PATH).and_return(false)
+        allow(File).to receive(:exist?).with(described_class::LEGACY_REGISTRY_MANIFEST_PATH).and_return(true)
+
+        expect(config.registry_manifest_path).to eq(described_class::LEGACY_REGISTRY_MANIFEST_PATH)
+      end
+
+      it 'uses the new default when it exists' do
+        allow(File).to receive(:exist?).with(described_class::DEFAULT_REGISTRY_MANIFEST_PATH).and_return(true)
+
+        expect(config.registry_manifest_path).to eq(described_class::DEFAULT_REGISTRY_MANIFEST_PATH)
+      end
+
+      it 'does not apply fallback when a custom path is set' do
+        config.registry_manifest_path = 'custom/registry.json'
+
+        expect(config.registry_manifest_path).to eq('custom/registry.json')
+      end
+    end
+  end
+
+  describe '#lockfile_path' do
+    it 'allows setting a custom path' do
+      config = described_class.new
+      config.lockfile_path = 'custom/registry.lock'
+
+      expect(config.lockfile_path).to eq('custom/registry.lock')
+    end
+
+    it 'allows disabling lockfile verification with nil' do
+      config = described_class.new
+      config.lockfile_path = nil
+
+      expect(config.lockfile_path).to be_nil
+    end
+
+    context 'with backward-compatibility fallback' do
+      let(:config) { described_class.new }
+
+      it 'returns the new default when neither path exists' do
+        allow(File).to receive(:exist?).with(described_class::DEFAULT_LOCKFILE_PATH).and_return(false)
+        allow(File).to receive(:exist?).with(described_class::LEGACY_LOCKFILE_PATH).and_return(false)
+
+        expect(config.lockfile_path).to eq(described_class::DEFAULT_LOCKFILE_PATH)
+      end
+
+      it 'falls back to the legacy path when only the legacy path exists' do
+        allow(File).to receive(:exist?).with(described_class::DEFAULT_LOCKFILE_PATH).and_return(false)
+        allow(File).to receive(:exist?).with(described_class::LEGACY_LOCKFILE_PATH).and_return(true)
+
+        expect(config.lockfile_path).to eq(described_class::LEGACY_LOCKFILE_PATH)
+      end
+
+      it 'uses the new default when it exists' do
+        allow(File).to receive(:exist?).with(described_class::DEFAULT_LOCKFILE_PATH).and_return(true)
+
+        expect(config.lockfile_path).to eq(described_class::DEFAULT_LOCKFILE_PATH)
+      end
     end
   end
 
@@ -86,7 +156,7 @@ RSpec.describe RailsAiBridge::Configuration do
     it 'has default registry configuration' do
       config = described_class.new
 
-      expect(config.registry.registry_manifest_path).to eq('config/rails_ai_bridge_registry.json')
+      expect(config.registry.registry_manifest_path).to eq('config/rails_ai_bridge/registry.json')
       expect(config.registry.skill_cache_dir).to eq(File.expand_path('~/.rails-ai-bridge/cache'))
       expect(config.registry.skill_packs).to be_nil
       expect(config.registry.local_registry_paths).to eq([])

--- a/spec/lib/rails_ai_bridge/doctor/checkers/registry_checker_spec.rb
+++ b/spec/lib/rails_ai_bridge/doctor/checkers/registry_checker_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::Doctor::Checkers::RegistryChecker do
+  let(:app) { Rails.application }
+  let(:checker) { described_class.new(app) }
+  let(:registry_config) { RailsAiBridge.configuration.registry }
+
+  describe '#call' do
+    context 'when the manifest file is missing' do
+      before do
+        allow(registry_config).to receive(:registry_manifest_path).and_return('/nonexistent/manifest.json')
+        allow(File).to receive(:exist?).with('/nonexistent/manifest.json').and_return(false)
+      end
+
+      it 'returns a warn check' do
+        result = checker.call
+        expect(result.status).to eq(:warn)
+        expect(result.message).to include('not found')
+        expect(result.fix).to include('skill-registry-guide')
+      end
+    end
+
+    context 'when the manifest contains invalid JSON' do
+      before do
+        allow(registry_config).to receive(:registry_manifest_path).and_return('/tmp/invalid.json')
+        allow(File).to receive(:exist?).with('/tmp/invalid.json').and_return(true)
+        allow(File).to receive(:read).with('/tmp/invalid.json').and_return('{ invalid json }')
+        allow(RailsAiBridge::Registry::RegistryManifest).to receive(:from_file)
+          .and_raise(ArgumentError, 'invalid JSON')
+      end
+
+      it 'returns a fail check' do
+        result = checker.call
+        expect(result.status).to eq(:fail)
+        expect(result.message).to include('invalid JSON')
+      end
+    end
+
+    context 'when the manifest fails schema validation' do
+      before do
+        allow(registry_config).to receive(:registry_manifest_path).and_return('/tmp/bad_schema.json')
+        allow(File).to receive(:exist?).with('/tmp/bad_schema.json').and_return(true)
+        allow(File).to receive(:read).with('/tmp/bad_schema.json').and_return('{"version": 123}')
+        allow(RailsAiBridge::Registry::RegistryManifest).to receive(:from_file)
+          .and_return(instance_double(RailsAiBridge::Registry::RegistryManifest))
+        allow(RailsAiBridge::Registry::RegistryManifest).to receive(:validate!)
+          .and_raise(RailsAiBridge::Registry::RegistryManifest::ValidationError, "'version' must be a String")
+      end
+
+      it 'returns a fail check' do
+        result = checker.call
+        expect(result.status).to eq(:fail)
+        expect(result.message).to include('schema validation')
+        expect(result.fix).to include('skill-registry-guide')
+      end
+    end
+
+    context 'when the resolver returns nil' do
+      let(:manifest_hash) { { 'version' => '1.0.0', 'packs' => {}, 'default_stack' => [] } }
+
+      before do
+        allow(File).to receive(:exist?).with('/tmp/valid.json').and_return(true)
+        allow(File).to receive(:read).with('/tmp/valid.json').and_return(JSON.generate(manifest_hash))
+        allow(RailsAiBridge::Registry::RegistryManifest).to receive_messages(from_file: instance_double(RailsAiBridge::Registry::RegistryManifest), validate!: manifest_hash)
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(nil)
+        allow(registry_config).to receive_messages(registry_manifest_path: '/tmp/valid.json', lockfile_path: nil)
+      end
+
+      it 'returns a warn check' do
+        result = checker.call
+        expect(result.status).to eq(:warn)
+        expect(result.message).to include('resolver returned nil')
+        expect(result.fix).to include('git')
+      end
+    end
+
+    context 'when the lockfile is configured but missing' do
+      let(:manifest_hash) { { 'version' => '1.0.0', 'packs' => {}, 'default_stack' => [] } }
+      let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver) }
+
+      before do
+        allow(File).to receive(:exist?).with('/tmp/valid.json').and_return(true)
+        allow(File).to receive(:read).with('/tmp/valid.json').and_return(JSON.generate(manifest_hash))
+        allow(RailsAiBridge::Registry::RegistryManifest).to receive_messages(from_file: instance_double(RailsAiBridge::Registry::RegistryManifest), validate!: manifest_hash)
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(registry_config).to receive_messages(registry_manifest_path: '/tmp/valid.json', lockfile_path: '/tmp/missing.lock')
+        allow(File).to receive(:exist?).with('/tmp/missing.lock').and_return(false)
+      end
+
+      it 'returns a warn check' do
+        result = checker.call
+        expect(result.status).to eq(:warn)
+        expect(result.message).to include('Lockfile not found')
+        expect(result.fix).to include('ai:registry:lock')
+      end
+    end
+
+    context 'when everything passes' do
+      let(:manifest_hash) { { 'version' => '1.0.0', 'packs' => {}, 'default_stack' => [] } }
+      let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver) }
+
+      before do
+        allow(File).to receive(:exist?).with('/tmp/valid.json').and_return(true)
+        allow(File).to receive(:read).with('/tmp/valid.json').and_return(JSON.generate(manifest_hash))
+        allow(RailsAiBridge::Registry::RegistryManifest).to receive_messages(from_file: instance_double(RailsAiBridge::Registry::RegistryManifest), validate!: manifest_hash)
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(registry_config).to receive_messages(registry_manifest_path: '/tmp/valid.json', lockfile_path: nil)
+      end
+
+      it 'returns a pass check' do
+        result = checker.call
+        expect(result.status).to eq(:pass)
+        expect(result.message).to include('valid and resolvable')
+        expect(result.fix).to be_nil
+      end
+    end
+
+    context 'when everything passes with a valid lockfile' do
+      let(:manifest_hash) { { 'version' => '1.0.0', 'packs' => {}, 'default_stack' => [] } }
+      let(:resolver) { instance_double(RailsAiBridge::Registry::Resolver) }
+
+      before do
+        allow(File).to receive(:exist?).with('/tmp/valid.json').and_return(true)
+        allow(File).to receive(:read).with('/tmp/valid.json').and_return(JSON.generate(manifest_hash))
+        allow(RailsAiBridge::Registry::RegistryManifest).to receive_messages(from_file: instance_double(RailsAiBridge::Registry::RegistryManifest), validate!: manifest_hash)
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(registry_config).to receive_messages(registry_manifest_path: '/tmp/valid.json', lockfile_path: '/tmp/valid.lock')
+        allow(File).to receive(:exist?).with('/tmp/valid.lock').and_return(true)
+      end
+
+      it 'returns a pass check' do
+        result = checker.call
+        expect(result.status).to eq(:pass)
+        expect(result.message).to include('valid and resolvable')
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/doctor_spec.rb
+++ b/spec/lib/rails_ai_bridge/doctor_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe RailsAiBridge::Doctor do
       expect(names).to include('View MCP tool', 'Stimulus MCP tool', 'Bridge metadata')
     end
 
-    it 'runs 16 total checks' do
-      expect(result[:checks].size).to eq(16)
+    it 'runs 17 total checks' do
+      expect(result[:checks].size).to eq(17)
     end
 
     it 'checks MCP server buildability' do

--- a/spec/lib/rails_ai_bridge/mcp/registry_integration_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/registry_integration_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Registry tools integration in MCP server' do
         text = response_text('rails_list_registry', type: 'skills')
 
         expect(text).to include('registry manifest')
-        expect(text).to include('config/rails_ai_bridge_registry.json')
+        expect(text).to include('config/rails_ai_bridge/registry.json')
       end
     end
 

--- a/spec/lib/rails_ai_bridge/registry_spec.rb
+++ b/spec/lib/rails_ai_bridge/registry_spec.rb
@@ -172,4 +172,99 @@ RSpec.describe RailsAiBridge::Registry do
       end
     end
   end
+
+  describe '.with_request_resolver' do
+    let(:config) { RailsAiBridge::Config::Registry.new }
+
+    before do
+      described_class.invalidate_resolver_cache!
+      described_class.clear_request_resolver!
+    end
+
+    after do
+      described_class.invalidate_resolver_cache!
+      described_class.clear_request_resolver!
+    end
+
+    it 'memoizes the resolver across multiple build_resolver calls within the block' do
+      calls = 0
+      allow(described_class).to receive(:build_resolver_uncached).and_wrap_original do |original, cfg|
+        calls += 1
+        original.call(cfg)
+      end
+
+      Dir.mktmpdir do |dir|
+        manifest_path = File.join(dir, 'registry.json')
+        File.write(manifest_path, JSON.generate(version: '1.0.0', packs: {}, default_stack: []))
+        config.registry_manifest_path = manifest_path
+        config.skill_packs = nil
+        config.local_registry_paths = []
+        allow(RailsAiBridge::Registry::PackDetector).to receive(:detect).and_return([])
+
+        described_class.invalidate_resolver_cache!
+
+        described_class.with_request_resolver do
+          first = described_class.build_resolver(config)
+          second = described_class.build_resolver(config)
+
+          expect(first).to equal(second)
+          expect(calls).to eq(1)
+        end
+      end
+    end
+
+    it 'clears the request-scoped resolver after the block exits' do
+      Dir.mktmpdir do |dir|
+        manifest_path = File.join(dir, 'registry.json')
+        File.write(manifest_path, JSON.generate(version: '1.0.0', packs: {}, default_stack: []))
+        config.registry_manifest_path = manifest_path
+        config.skill_packs = nil
+        config.local_registry_paths = []
+        allow(RailsAiBridge::Registry::PackDetector).to receive(:detect).and_return([])
+
+        described_class.invalidate_resolver_cache!
+
+        described_class.with_request_resolver do
+          described_class.build_resolver(config)
+        end
+
+        expect(described_class.send(:request_resolver?)).to be(false)
+      end
+    end
+
+    it 'clears the request-scoped resolver even when the block raises' do
+      Dir.mktmpdir do |dir|
+        manifest_path = File.join(dir, 'registry.json')
+        File.write(manifest_path, JSON.generate(version: '1.0.0', packs: {}, default_stack: []))
+        config.registry_manifest_path = manifest_path
+        config.skill_packs = nil
+        config.local_registry_paths = []
+        allow(RailsAiBridge::Registry::PackDetector).to receive(:detect).and_return([])
+
+        described_class.invalidate_resolver_cache!
+
+        expect do
+          described_class.with_request_resolver do
+            described_class.build_resolver(config)
+            raise 'boom'
+          end
+        end.to raise_error('boom')
+
+        expect(described_class.send(:request_resolver?)).to be(false)
+      end
+    end
+
+    it 'does not memoize nil results (manifest missing)' do
+      config.registry_manifest_path = '/nonexistent/path/registry.json'
+
+      described_class.with_request_resolver do
+        first = described_class.build_resolver(config)
+        second = described_class.build_resolver(config)
+
+        expect(first).to be_nil
+        expect(second).to be_nil
+        expect(described_class.send(:request_resolver?)).to be(false)
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/resources_spec.rb
+++ b/spec/lib/rails_ai_bridge/resources_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe RailsAiBridge::Resources do
       templates = described_class.build_templates
 
       expect(templates).to be_an(Array)
-      expect(templates.size).to eq(3)
+      expect(templates.size).to eq(4)
 
       model_template = templates.find { |t| t.uri_template == 'rails://models/{name}' }
       expect(model_template.name).to eq('Model Details')

--- a/spec/lib/rails_ai_bridge/server_spec.rb
+++ b/spec/lib/rails_ai_bridge/server_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe RailsAiBridge::Server do
   end
 
   describe 'TOOLS constant' do
-    it 'includes all 16 built-in tools' do
-      expect(RailsAiBridge::Server::TOOLS.length).to eq(16)
+    it 'includes all 17 built-in tools' do
+      expect(RailsAiBridge::Server::TOOLS.length).to eq(17)
     end
 
     it 'includes the registry tool classes' do

--- a/spec/lib/rails_ai_bridge/tools/list_context_providers_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/list_context_providers_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_ai_bridge/registry/context_provider_definition'
+require 'rails_ai_bridge/registry/context_tool_spec'
+
+RSpec.describe RailsAiBridge::Tools::ListContextProviders do
+  let(:response) { described_class.call(**params) }
+  let(:content)  { response.content.first[:text] }
+  let(:params)   { {} }
+
+  def build_provider(type: 'mcp', endpoint: 'https://example.com/mcp', optional: false, tools: [])
+    RailsAiBridge::Registry::ContextProviderDefinition.new(
+      type: type,
+      endpoint: endpoint,
+      optional: optional,
+      tools: tools
+    )
+  end
+
+  def simple_tool(name)
+    RailsAiBridge::Registry::ContextToolSpec.new(name: name, field: nil, arguments: nil)
+  end
+
+  def mapped_tool(name:, field:, arguments: nil)
+    RailsAiBridge::Registry::ContextToolSpec.new(name: name, field: field, arguments: arguments)
+  end
+
+  # ── setup message (no manifest) ────────────────────────────────────────────
+
+  context 'when no registry manifest is configured' do
+    before do
+      allow(described_class).to receive_messages(
+        load_manifest: nil,
+        manifest_path: 'config/rails_ai_bridge/registry.json'
+      )
+    end
+
+    it 'mentions registry manifest' do
+      expect(content).to include('registry manifest')
+    end
+
+    it 'mentions the manifest path' do
+      expect(content).to include('config/rails_ai_bridge/registry.json')
+    end
+
+    it 'includes a quick-start JSON snippet' do
+      expect(content).to include('"version"')
+    end
+  end
+
+  # ── context providers present ──────────────────────────────────────────────
+
+  context 'when context providers are declared' do
+    let(:providers) do
+      {
+        'docs-server' => build_provider(
+          type: 'mcp',
+          endpoint: 'https://docs.example.com/mcp',
+          optional: false,
+          tools: [simple_tool('search_docs'), mapped_tool(name: 'get_page', field: 'page_content')]
+        ),
+        'wiki-server' => build_provider(
+          type: 'mcp',
+          endpoint: 'https://wiki.example.com/mcp',
+          optional: true,
+          tools: [simple_tool('search_wiki')]
+        )
+      }
+    end
+    let(:manifest) do
+      instance_double(RailsAiBridge::Registry::RegistryManifest, context_providers: providers)
+    end
+
+    before { allow(described_class).to receive(:load_manifest).and_return(manifest) }
+
+    it 'returns a markdown header' do
+      expect(content).to include('# Context Providers')
+    end
+
+    it 'includes the total count' do
+      expect(content).to include('(2)')
+    end
+
+    it 'lists each provider name' do
+      expect(content).to include('docs-server')
+      expect(content).to include('wiki-server')
+    end
+
+    it 'shows the type for each provider' do
+      expect(content).to include('mcp')
+    end
+
+    it 'shows the endpoint for each provider' do
+      expect(content).to include('https://docs.example.com/mcp')
+      expect(content).to include('https://wiki.example.com/mcp')
+    end
+
+    it 'shows the optional flag' do
+      expect(content).to include('yes')
+      expect(content).to include('no')
+    end
+
+    it 'lists simple tool specs by name' do
+      expect(content).to include('search_docs')
+      expect(content).to include('search_wiki')
+    end
+
+    it 'lists mapped tool specs with field routing' do
+      expect(content).to include('get_page → page_content')
+    end
+  end
+
+  # ── no context providers (empty) ───────────────────────────────────────────
+
+  context 'when the manifest has no context providers' do
+    let(:manifest) do
+      instance_double(RailsAiBridge::Registry::RegistryManifest, context_providers: {})
+    end
+
+    before { allow(described_class).to receive(:load_manifest).and_return(manifest) }
+
+    it 'returns an empty message' do
+      expect(content).to include('No context providers')
+    end
+  end
+
+  # ── response shape ─────────────────────────────────────────────────────────
+
+  context 'when returning the MCP response for declared providers' do
+    let(:providers) { { 'docs-server' => build_provider(tools: [simple_tool('search_docs')]) } }
+    let(:manifest) do
+      instance_double(RailsAiBridge::Registry::RegistryManifest, context_providers: providers)
+    end
+
+    before { allow(described_class).to receive(:load_manifest).and_return(manifest) }
+
+    it 'returns an MCP::Tool::Response' do
+      expect(response).to be_a(MCP::Tool::Response)
+    end
+
+    it 'returns content with a text entry' do
+      expect(response.content).to be_a(Array)
+      expect(response.content.first[:type]).to eq('text')
+      expect(response.content.first[:text]).to be_a(String)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/tools/list_registry_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/list_registry_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RailsAiBridge::Tools::ListRegistry do
     end
 
     it 'mentions the default manifest path' do
-      expect(content).to include('config/rails_ai_bridge_registry.json')
+      expect(content).to include('config/rails_ai_bridge/registry.json')
     end
 
     it 'includes a quick-start JSON snippet' do

--- a/spec/lib/rails_ai_bridge/tools/resolve_skill_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/resolve_skill_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RailsAiBridge::Tools::ResolveSkill do
     end
 
     it 'includes the configured manifest path' do
-      expect(content).to include('config/rails_ai_bridge_registry.json')
+      expect(content).to include('config/rails_ai_bridge/registry.json')
     end
   end
 

--- a/spec/lib/rails_ai_bridge/tools/use_skill_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/use_skill_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RailsAiBridge::Tools::UseSkill do
     end
 
     it 'includes the configured manifest path' do
-      expect(content).to include('config/rails_ai_bridge_registry.json')
+      expect(content).to include('config/rails_ai_bridge/registry.json')
     end
   end
 

--- a/spec/lib/rails_ai_bridge/tools_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'MCP Tool Integration' do
     end
 
     it 'builds with all tools registered' do
-      expect(server.tools.size).to eq(16)
+      expect(server.tools.size).to eq(17)
       expect(server.tools.keys).to contain_exactly(
         'rails_get_schema',
         'rails_get_routes',
@@ -54,7 +54,8 @@ RSpec.describe 'MCP Tool Integration' do
         'rails_list_registry',
         'rails_resolve_skill',
         'rails_use_skill',
-        'rails_use_agent'
+        'rails_use_agent',
+        'rails_list_context_providers'
       )
     end
 


### PR DESCRIPTION
## Summary

Group D of the 4.2.0 release plan — the headline registry feature work.

## Changes

### Task 1: `rails_list_context_providers` MCP tool and dynamic resources (#147)
- **New tool**: `lib/rails_ai_bridge/tools/list_context_providers.rb` — reads the registry manifest's `context_providers` section and returns a formatted markdown list with each provider's type, endpoint, optional flag, and tool specs (simple + mapped).
- **Dynamic MCP resources**: `lib/rails_ai_bridge/resources.rb` now registers each context provider as a readable resource at `rails://context-providers/{name}`, plus a resource template. Static resource reads route context-provider URIs to the manifest lookup.
- **Tool registration**: Added `Tools::ListContextProviders` to `Server::TOOLS` (now 17 built-in tools).
- **Specs**: `spec/lib/rails_ai_bridge/tools/list_context_providers_spec.rb` — covers providers present, empty, no manifest, and response shape.
- **Docs**: Updated tool count 16 → 17 in `README.md`, `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`; added the new tool to the README tool table.

### Task 2: Registry health checker for Doctor (#145)
- **New checker**: `lib/rails_ai_bridge/doctor/checkers/registry_checker.rb` — checks manifest path exists, JSON parses, `RegistryManifest.validate!` passes, `Registry.build_resolver` returns non-nil, and lockfile exists (when configured). Returns pass/warn/fail with actionable fix hints.
- **Registration**: Added `check_registry: Checkers::RegistryChecker` to `Doctor::CHECKS` (now 17 checks).
- **Specs**: `spec/lib/rails_ai_bridge/doctor/checkers/registry_checker_spec.rb` — covers all states (pass, warn, fail, missing manifest, invalid JSON, validation failure, missing lockfile).

### Task 3: Standardize registry manifest and lockfile path defaults (#155)
- **New defaults**: `config/rails_ai_bridge/registry.json` (manifest) and `config/rails_ai_bridge/registry.lock` (lockfile), replacing the inconsistent `config/rails_ai_bridge_registry.json` and `config/rails_ai_bridge/directory.lock`.
- **Backward-compatibility fallback**: When the new default path doesn't exist but the legacy path does, the getter returns the legacy path. Custom user-set paths are never overridden.
- **Specs**: Added fallback coverage in `spec/lib/rails_ai_bridge/config/registry_spec.rb`.
- **Docs**: Updated all path references in `README.md`, `docs/skill-registry-guide.md`, `docs/registry-resolution.md`, `docs/devin-setup.md`, rake task descriptions, and tool setup messages.

### Task 4: Request-level resolver memoization (#159)
- **Thread-local request scope**: `Registry.with_request_resolver { ... }` memoizes the resolver for the duration of a block so multiple `build_resolver` calls within one request cycle share a single resolver. Nil results are never memoized.
- **Integration**: `InstrumentedTool#call` now wraps every tool invocation in `Registry.with_request_resolver`, ensuring registry tools called in the same MCP request share the resolver and avoiding mid-request rebuilds when the TTL cache expires.
- **Specs**: Added `with_request_resolver` coverage in `spec/lib/rails_ai_bridge/registry_spec.rb` — memoization, cleanup on exit, cleanup on error, nil non-memoization.

## Test Results
- `bundle exec rspec`: 2382 examples, 0 failures
- `bundle exec rubocop`: 438 files inspected, no offenses