### PR TITLE
chore(deps): update simplecov 1.1, sqlite3, rubocop-rails, upload-artifact v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         run: bundle exec rake perf:compare
 
       - name: Upload perf baseline artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-baseline
           path: spec/support/perf_baseline.json

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development, :test do
   gem 'rubocop-rails', '~> 2.35'
   gem 'rubocop-rails-omakase', '~> 1.0'
   gem 'rubocop-rspec', '~> 3.10'
-  gem 'simplecov', '~> 1.0.0'
+  gem 'simplecov', '~> 1.1.0'
   gem 'skunk', '~> 0.5'
   gem 'sqlite3', '~> 2.9'
 end

--- a/Gemfile-mutation.lock
+++ b/Gemfile-mutation.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-ai-bridge (4.1.0)
+    rails-ai-bridge (4.2.0)
       mcp (>= 1.0, < 2.0)
       railties (>= 7.1, < 10.0)
       rubydex (~> 0.3.0)
@@ -371,7 +371,7 @@ GEM
     rubydex (0.3.0-x86_64-linux)
     securerandom (0.4.1)
     sexp_processor (4.17.5)
-    simplecov (1.0.3)
+    simplecov (1.1.1)
     simpleidn (0.2.3)
     skunk (0.5.4)
       rubycritic (>= 4.5.2, < 5.0)
@@ -435,7 +435,7 @@ DEPENDENCIES
   rubocop-rails (~> 2.35)
   rubocop-rails-omakase (~> 1.0)
   rubocop-rspec (~> 3.10)
-  simplecov (~> 1.0.0)
+  simplecov (~> 1.1.0)
   skunk (~> 0.5)
   sqlite3 (~> 2.9)
 
@@ -526,7 +526,7 @@ CHECKSUMS
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3.1) sha256=ccd11a36bfc171bf9c66d585d14c0ece91c0c9dde840aae60c0118d6f5c9c52a
-  rails-ai-bridge (4.1.0)
+  rails-ai-bridge (4.2.0)
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   railties (8.1.3.1) sha256=2388a232579a00cefea4487de66c8553c3408c1300abdc6cf1799d86ffb04487
@@ -559,7 +559,7 @@ CHECKSUMS
   rubydex (0.3.0-x86_64-linux) sha256=dfe4026591f226b4a1b53f82f86dc14fad2e7c221ee8a5be99a0a46bf2d58b04
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   sexp_processor (4.17.5) sha256=ae2b48ba98353d5d465ce8759836b7a05f2e12c5879fcd14d7815b026de32f0e
-  simplecov (1.0.3) sha256=38ef0514f16ae7562f0d0f4df02610071115103d301b6de7dacbcc000082e39b
+  simplecov (1.1.1) sha256=25825ef13f0b2e74694d769817dad6ab8e90131dabdaa666e522fea105521e78
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   skunk (0.5.4) sha256=627331dc78aec1fdf614feabcf05a88ca84025e364be27aeddca5d7531d1b682
   sorbet-runtime (0.6.13425) sha256=92f55873199d8bb259ce20c4fc02d95b63e8d6c0c5abba60b7c67054f175f147


### PR DESCRIPTION
## Why

Replaces Dependabot PRs #193 (`actions/upload-artifact` 4 → 7) and #194 (`simplecov` `~> 1.0.0` → `~> 1.1.0`) with one maintainer PR that actually updates the constraints and CI pin. Those Dependabot PRs are left open so they can be closed after this lands.

## What changed

- `Gemfile`: `simplecov` constraint is now `~> 1.1.0`.
- `bundle update simplecov sqlite3 rubocop-rails` resolved locally to **simplecov 1.1.1**, **sqlite3 2.9.6**, **rubocop-rails 2.37.0**. `Gemfile.lock` remains gitignored; CI will pick the new simplecov via the Gemfile constraint.
- `.github/workflows/ci.yml`: `actions/upload-artifact@v4` → `@v7` (perf baseline artifact only).

## SimpleCov 1.1 report layout

1.1 writes a single self-contained `coverage/index.html` (plus `coverage.json`); there is no `coverage_data.js`. The repo has no scripts or docs that assumed the old multi-file HTML layout, so nothing else was updated.

## Verification

- `bundle exec rspec`: **2432 examples, 0 failures** (94.13% line coverage)
- `bundle exec rubocop`: **443 files inspected, no offenses**

## CI risks

- **Skunk** and **mutation** jobs are `continue-on-error` / advisory; they may already be red on `main` and should not block this PR.
- **upload-artifact v6+** requires Actions Runner ≥ 2.327.1 and runs on Node 24. GitHub-hosted `ubuntu-latest` is fine; self-hosted runners would need that minimum if this repo ever used them.
- Perf job stays advisory (`continue-on-error: true`); artifact upload API is unchanged for our single-file `spec/support/perf_baseline.json` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated performance artifact handling.
  * Updated the development and test code coverage tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->