### PR TITLE
fix(security): reject ViewFileAnalyzer symlink escapes (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **`ViewFileAnalyzer` symlink escape** (#185) — existing view files are resolved with `File.realpath` and compared against the realpath of every configured `app/views` root (including custom Rails paths). A symlink under views that points outside every root now raises `SecurityError` instead of emitting the target file contents.
+
 ## [4.2.0] - 2026-08-13
 
 ### Added

--- a/lib/rails_ai_bridge/view_file_analyzer.rb
+++ b/lib/rails_ai_bridge/view_file_analyzer.rb
@@ -52,7 +52,8 @@ module RailsAiBridge
         candidates = allowed_view_candidates(context, relative_path)
         raise SecurityError, "Path not allowed: #{relative_path}" if candidates.empty?
 
-        existing_file_candidate(candidates, relative_path)
+        view_file = existing_file_candidate(candidates, relative_path)
+        contained_existing_view_file(context, view_file, relative_path)
       end
 
       # Builds allowed candidates for a requested path across all configured view roots.
@@ -77,6 +78,43 @@ module RailsAiBridge
         raise Errno::ENOENT, relative_path unless requested
 
         requested
+      end
+
+      # Re-checks an existing candidate after resolving symlinks.
+      #
+      # @param context [ViewContext] root/app path resolution context
+      # @param view_file [ViewFile] lexically allowed existing candidate
+      # @param relative_path [String] original requested path for error reporting
+      # @return [ViewFile] candidate whose path is the resolved realpath
+      # @raise [SecurityError] when the real path escapes every allowed view root
+      def contained_existing_view_file(context, view_file, relative_path)
+        real_path = File.realpath(view_file.path)
+        raise SecurityError, "Path not allowed: #{relative_path}" unless contained_in_real_view_root?(context, real_path)
+
+        ViewFile.new(path: real_path, relative_path: view_file.relative_path)
+      end
+
+      # Checks whether a resolved path remains inside any configured view root.
+      #
+      # @param context [ViewContext] root/app path resolution context
+      # @param real_path [String] File.realpath of the existing view file
+      # @return [Boolean] true when the file is inside at least one view root
+      def contained_in_real_view_root?(context, real_path)
+        view_roots(context).any? { |views_root| path_inside_real_root?(real_path, views_root) }
+      end
+
+      # Compares a resolved file path against the realpath of one view root.
+      #
+      # @param real_path [String] File.realpath of the existing view file
+      # @param views_root [String] configured view root path
+      # @return [Boolean] true when the file is inside this root
+      def path_inside_real_root?(real_path, views_root)
+        return false unless File.directory?(views_root)
+
+        real_root = File.realpath(views_root)
+        real_path == real_root || real_path.start_with?("#{real_root}/")
+      rescue Errno::ENOENT
+        false
       end
 
       # Returns logical view roots from configured Rails paths or the conventional fallback.

--- a/spec/lib/rails_ai_bridge/view_file_analyzer_spec.rb
+++ b/spec/lib/rails_ai_bridge/view_file_analyzer_spec.rb
@@ -15,6 +15,29 @@ RSpec.describe RailsAiBridge::ViewFileAnalyzer do
       expect(result[:content]).to include('<h1>Posts</h1>')
     end
 
+    it 'extracts renders, turbo frames, and stimulus metadata from a view file' do
+      Dir.mktmpdir('rails-ai-bridge-view-metadata') do |dir|
+        app_root = Pathname.new(dir)
+        views_dir = app_root.join('app/views/widgets')
+        FileUtils.mkdir_p(views_dir)
+        File.write(views_dir.join('index.html.erb'), <<~ERB)
+          <%= turbo_frame_tag "widget_list" do %>
+            <div data-controller="widget-search filter" data-action="input->widget-search#perform click->filter#toggle">
+              <%= render "widgets/card" %>
+              <%= render partial: "shared/flash" %>
+            </div>
+          <% end %>
+        ERB
+
+        result = described_class.call(root: app_root, relative_path: 'widgets/index.html.erb')
+
+        expect(result[:renders]).to eq(['shared/flash', 'widgets/card'])
+        expect(result[:turbo_frames]).to eq(['widget_list'])
+        expect(result[:stimulus_controllers]).to eq(%w[filter widget-search])
+        expect(result[:stimulus_actions]).to eq(['click->filter#toggle', 'input->widget-search#perform'])
+      end
+    end
+
     it 'returns metadata for a view under a configured custom app/views path' do
       Dir.mktmpdir('rails-ai-bridge-view-detail') do |dir|
         app_root = Pathname.new(dir)
@@ -47,6 +70,55 @@ RSpec.describe RailsAiBridge::ViewFileAnalyzer do
       expect do
         described_class.call(root:, relative_path: 'missing/template.html.erb')
       end.to raise_error(Errno::ENOENT)
+    end
+
+    it 'raises SecurityError when a symlink under app/views points outside views' do
+      Dir.mktmpdir('rails-ai-bridge-view-symlink') do |dir|
+        app_root = Pathname.new(dir)
+        views_dir = app_root.join('app/views/leaks')
+        FileUtils.mkdir_p(views_dir)
+        secret = app_root.join('secret.txt')
+        File.write(secret, 'TOP SECRET')
+        File.symlink(secret, views_dir.join('secret.html.erb'))
+
+        expect do
+          described_class.call(root: app_root, relative_path: 'leaks/secret.html.erb')
+        end.to raise_error(SecurityError, /Path not allowed/)
+      end
+    end
+
+    it 'raises SecurityError when a symlink under a custom views path escapes every configured root' do
+      Dir.mktmpdir('rails-ai-bridge-view-custom-symlink') do |dir|
+        app_root = Pathname.new(dir)
+        views_dir = app_root.join('interface/templates')
+        FileUtils.mkdir_p(views_dir.join('reports'))
+        secret = app_root.join('credentials.txt')
+        File.write(secret, 'LEAK')
+        File.symlink(secret, views_dir.join('reports/show.html.erb'))
+        app = double('Rails::Application', root: app_root, paths: { 'app/views' => [views_dir.to_s] })
+
+        expect do
+          described_class.call(root: app_root, app:, relative_path: 'reports/show.html.erb')
+        end.to raise_error(SecurityError, /Path not allowed/)
+      end
+    end
+
+    it 'allows a symlink that resolves into another configured app/views root' do
+      Dir.mktmpdir('rails-ai-bridge-view-cross-root') do |dir|
+        app_root = Pathname.new(dir)
+        primary = app_root.join('interface/templates')
+        secondary = app_root.join('admin/templates')
+        FileUtils.mkdir_p(primary.join('reports'))
+        FileUtils.mkdir_p(secondary)
+        File.write(secondary.join('shared.html.erb'), '<%= turbo_frame_tag "shared" %>')
+        File.symlink(secondary.join('shared.html.erb'), primary.join('reports/show.html.erb'))
+        app = double('Rails::Application', root: app_root, paths: { 'app/views' => [primary.to_s, secondary.to_s] })
+
+        result = described_class.call(root: app_root, app:, relative_path: 'reports/show.html.erb')
+
+        expect(result[:content]).to include('turbo_frame_tag "shared"')
+        expect(result[:turbo_frames]).to include('shared')
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Harden `ViewFileAnalyzer` so `rails_get_view` cannot follow a symlink (or `..`) out of configured view roots.

Existing files are resolved with `File.realpath` and accepted only when that path stays inside the realpath of at least one configured `app/views` root (including custom Rails paths via `PathResolver`). Lexical `..` / absolute escapes still raise `SecurityError`; allowed-but-missing paths still raise `Errno::ENOENT`.

Closes #185

## TDD

1. Characterization specs for valid views and extractors (renders / turbo frames / stimulus) passed on current code.
2. New symlink-escape examples failed because `SecurityError` was not raised (content would have been leaked).
3. Minimal realpath containment check made those examples pass.

## Test plan

- [x] `bundle exec rspec spec/lib/rails_ai_bridge/view_file_analyzer_spec.rb` — 9 examples, 0 failures
- [x] `bundle exec rspec` — 2436 examples, 0 failures
- [x] `bundle exec rubocop` on touched analyzer files — clean

## Remaining risks

- A dangling or circular symlink is not given a dedicated error; `File.file?` / `File.realpath` still surface `ENOENT` or `ELOOP`.
- Prefix containment uses `start_with?("#{real_root}/")` (same style as the previous lexical check), not `Pathname` pairwise comparison.
- Case-insensitive or bind-mounted filesystems can make two distinct configured roots share a realpath; that is treated as the same root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added protection against symlink-based view file access outside configured view directories.
  * Symlinks resolving within another configured view directory remain supported.
  * Includes protection for custom Rails view paths.

* **Bug Fixes**
  * Improved view metadata handling for renders, Turbo Frames, and Stimulus controllers and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->