### PR TITLE
fix: allow nil preset and document HTTP MCP auth defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Inherited controller filters** (#190) — `rails_get_controllers` lists `before_action` / `after_action` filters from the controller and its ancestors. Filters whose `only` / `except` do not apply to any action are omitted. `detail: summary` stays at filter names; `standard` / `full` include the defining class. ActionFilter `only`/`except` conditions are parsed on Rails 7.1+.
 - **MCP exclusion parity spec** (#186) — `spec/lib/rails_ai_bridge/mcp/exclusion_parity_spec.rb` fails when `Server::TOOLS` or resource templates grow without a policy entry, and asserts `excluded_models`, `excluded_tables`, `:regulated`, and `disabled_introspection_categories` do not leak omitted names through listing tools or `rails://` resources. Composite `rails_get_context` is a listing-surface policy row, invoked only when that tool is already in `Server::TOOLS` (#181).
-- **`rails_explain_symbol` MCP tool** (#192) — optional in-process explanation of a `symbol` or `query` from a **local** CodeGraph index (`.codegraph/`). Runs `codegraph explore` with a timeout and argv arrays (no shell, no network). Missing index or CLI failure returns setup instructions (`codegraph init` / `codegraph index`) instead of raising. Always registered so doc-parity stays a single tool list.
-- **`rails_get_context` MCP tool** (#181) — in-process composite for one model, controller, or feature (table + model + routes + controller actions/filters + cheap related tests). Reuses `[VERIFIED]` / `[INFERRED]` tags from #187. No HTTP; provider fan-out stays on a different name.
+- **`rails_explain_symbol` MCP tool** (#192) — optional in-process explanation of a `symbol` or `query` from a **local** CodeGraph index (`.codegraph/`). Runs `codegraph explore` with a timeout and argv arrays (no shell, no network). Missing index or CLI failure returns setup instructions (`codegraph init` / `codegraph index`) instead of raising. Always registered so doc-parity stays a single tool list. Built-in MCP tools: **19**.
+- **`rails_get_context` MCP tool** (#181) — in-process composite for one model, controller, or feature (table + model + routes + controller actions/filters + cheap related tests). Reuses `[VERIFIED]` / `[INFERRED]` tags from #187. No HTTP; provider fan-out stays on a different name. Built-in MCP tools: **19**.
 - **Confidence tags on schema and model MCP tools** (#187) — `rails_get_schema` and `rails_get_model_details` markdown now marks facts as `[VERIFIED]` (live ActiveRecord reflection or rubydex/Prism) or `[INFERRED]` (source-regex macros and static schema parses). Missing sections are omitted rather than tagged empty.
 - **Shared anti-hallucination rules in compact assistant files** (#188) — compact Claude, Cursor, Copilot, Codex, Gemini, and `AGENTS.md` output now include a short verify-before-write block from `SharedAssistantGuidance`. Disable with `config.output.anti_hallucination_rules = false` (default: on).
 - **`rails_get_routes` URL helpers and required params** (#191) — named routes now include the Rails path helper (from the route set's declared name, e.g. `post_path`) and required parameter names (from Journey `required_parts`). Unnamed routes are left without a helper. Summary stays a compact per-controller overview (counts plus one sample helper); standard/full list helpers and required params (paginated).
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`Config::Introspection#preset=` accepts `nil`** — `preset = nil` now sets `@preset` to `nil` and leaves `introspectors` unchanged, so around-hooks can restore an unset preset. Named presets (`:standard`, `:regulated`, `:full`) are unchanged.
 - **MCP `fetch_section` honored disabled introspectors** (#186) — `Introspector#selected_introspectors` now intersects `only:` with `effective_introspectors`, so `:regulated` and `disabled_introspection_categories` cannot be bypassed by `rails_get_schema` / `rails://schema`.
 - **Excluded association names no longer leak via model details** (#186) — associations, generated accessors, and rubydex `similar_models` that name an excluded model or table are omitted from MCP output.
 - **`similar_models` honors `excluded_tables`** (#186) — rubydex sibling names such as `PatientRecord` are dropped when only `patient_records` is excluded (`ExclusionHelper.excluded_class_or_table?`).
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **HTTP MCP auth defaults documented more clearly** — README and SECURITY.md now lead with: HTTP MCP is unauthenticated unless you set a token or `require_http_auth`; bind to `127.0.0.1` unless you add auth. Default remains `require_http_auth = false`.
 - **`ViewFileAnalyzer` symlink escape** (#185) — existing view files are resolved with `File.realpath` and compared against the realpath of every configured `app/views` root (including custom Rails paths). A symlink under views that points outside every root now raises `SecurityError` instead of emitting the target file contents.
 
 ## [4.2.0] - 2026-08-13

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Compact files are ordered for usefulness: primary domain models, busy endpoints,
 - MCP tools are **read-only**. They inspect Rails structure; they do not write files or mutate the database.
 - `database_stats` is **opt-in** because it queries PostgreSQL table statistics.
 - Generated assistant context avoids credential values and suppresses secret-bearing config paths such as `.env*`, Rails credentials, `master.key`, private key material, and custom `config/secrets` or `config/private` files.
-- HTTP MCP should stay bound to `127.0.0.1` unless you add authentication and network controls. See [docs/mcp-security.md](docs/mcp-security.md).
+- HTTP MCP is unauthenticated unless you set a token or `require_http_auth`. Bind to `127.0.0.1` unless you add auth. See [docs/mcp-security.md](docs/mcp-security.md).
 
 ---
 
@@ -400,6 +400,11 @@ Codex reads `AGENTS.md` at the repository root. MCP can be configured in `.codex
 
 ### HTTP transport (alternative for all clients)
 
+HTTP MCP is unauthenticated unless you set a token (`http_mcp_token` /
+`RAILS_AI_BRIDGE_MCP_TOKEN`, or a resolver/JWT decoder) or
+`require_http_auth`. Bind to `127.0.0.1` unless you add auth. The default
+remains `require_http_auth = false`.
+
 If stdio MCP fails (usually a Ruby version manager PATH issue), start the HTTP server instead:
 
 ```bash
@@ -417,7 +422,7 @@ RailsAiBridge.configure do |config|
 end
 ```
 
-Point your AI client to `http://localhost:3000/mcp` (or whichever port your Rails server uses) using transport type `SSE`. Keep the endpoint bound to localhost unless you add authentication. See [docs/mcp-security.md](docs/mcp-security.md) for production hardening.
+Point your AI client to `http://127.0.0.1:3000/mcp` (or whichever port your Rails server uses) using transport type `SSE`. See [docs/mcp-security.md](docs/mcp-security.md) and [SECURITY.md](SECURITY.md) for production hardening.
 
 ### Claude Desktop (standalone app)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,11 @@ please report it responsibly:
 
 ## HTTP MCP authentication
 
+HTTP MCP is unauthenticated unless you set a token (`http_mcp_token` /
+`RAILS_AI_BRIDGE_MCP_TOKEN`, or a resolver/JWT decoder) or
+`require_http_auth`. Bind the endpoint to `127.0.0.1` unless you add auth.
+`require_http_auth` stays **`false`** by default.
+
 For day-to-day hardening (tokens, `require_http_auth`, proxies, stdio threat model),
 see **[docs/mcp-security.md](docs/mcp-security.md)**.
 

--- a/lib/rails_ai_bridge/config/introspection.rb
+++ b/lib/rails_ai_bridge/config/introspection.rb
@@ -122,9 +122,17 @@ module RailsAiBridge
 
       # Switch the active introspector list to a named preset.
       #
-      # @param name [Symbol, String] preset key from {Configuration::PRESETS}
+      # +nil+ clears the tracked preset name and leaves {#introspectors} unchanged
+      # so around-hooks can restore an unset preset without rewriting the list.
+      #
+      # @param name [Symbol, String, nil] preset key from {Configuration::PRESETS}, or +nil+
       # @raise [ArgumentError] when the preset is unknown
       def preset=(name)
+        if name.nil?
+          @preset = nil
+          return
+        end
+
         name = name.to_sym
         raise ArgumentError, "Unknown preset: #{name}. Valid presets: #{Configuration::PRESETS.keys.join(', ')}" unless Configuration::PRESETS.key?(name)
 

--- a/spec/lib/rails_ai_bridge/config/introspection_spec.rb
+++ b/spec/lib/rails_ai_bridge/config/introspection_spec.rb
@@ -62,6 +62,28 @@ RSpec.describe RailsAiBridge::Config::Introspection do
     it 'raises on unknown preset' do
       expect { introspection.preset = :unknown }.to raise_error(ArgumentError, /Unknown preset/)
     end
+
+    it 'assigns nil without raising and does not change introspectors' do
+      introspection.preset = :full
+      previous = introspection.introspectors.dup
+
+      expect { introspection.preset = nil }.not_to raise_error
+      expect(introspection.preset).to be_nil
+      expect(introspection.introspectors).to eq(previous)
+    end
+
+    it 'assigns :regulated' do
+      introspection.preset = :regulated
+      expect(introspection.preset).to eq(:regulated)
+      expect(introspection.introspectors).to eq(RailsAiBridge::Configuration::PRESETS[:regulated])
+    end
+
+    it 'assigns :standard' do
+      introspection.preset = :full
+      introspection.preset = :standard
+      expect(introspection.preset).to eq(:standard)
+      expect(introspection.introspectors).to eq(RailsAiBridge::Configuration::PRESETS[:standard])
+    end
   end
 
   describe '#effective_introspectors' do

--- a/spec/lib/rails_ai_bridge/mcp/exclusion_parity_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/exclusion_parity_spec.rb
@@ -106,11 +106,8 @@ RSpec.describe 'MCP exclusion parity' do
     RailsAiBridge::ContextProvider.reset!
     example.run
   ensure
-    if original[:preset]
-      config.preset = original[:preset]
-    else
-      config.introspectors = original[:introspectors]
-    end
+    config.introspectors = original[:introspectors]
+    config.preset = original[:preset]
     config.excluded_models = original[:excluded_models]
     config.excluded_tables = original[:excluded_tables]
     config.disabled_introspection_categories = original[:disabled_categories]

--- a/spec/lib/rails_ai_bridge/tools/get_context_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_context_spec.rb
@@ -267,12 +267,13 @@ RSpec.describe RailsAiBridge::Tools::GetContext do
     context 'when preset is :regulated but cached sections still contain schema' do
       around do |example|
         config = RailsAiBridge.configuration
+        previous_preset = config.preset
         previous_introspectors = config.introspectors.dup
         config.preset = :regulated
         example.run
       ensure
-        # +preset=+ rejects nil; default Configuration#preset is unset until assigned.
         config.introspectors = previous_introspectors
+        config.preset = previous_preset
       end
 
       let(:params) { { model: 'User' } }


### PR DESCRIPTION
## Summary

- `Config::Introspection#preset=` accepts `nil`: sets `@preset` to `nil` and does **not** change `introspectors`, so around-hooks can restore an unset preset. `:standard` and `:regulated` still replace the introspector list as before.
- HTTP MCP docs (README + SECURITY.md) now lead with the actual default: the endpoint is unauthenticated unless you set a token or `require_http_auth`. Bind to `127.0.0.1` unless you add auth. **`require_http_auth` remains `false`.**
- CHANGELOG Unreleased tool-count wording now says **19** built-in MCP tools.

## Test plan

- [x] `bundle exec rspec spec/lib/rails_ai_bridge/config/introspection_spec.rb` — nil does not raise; `:regulated` and `:standard` still work
- [x] Related specs: `configuration_spec`, `get_context_spec`, `exclusion_parity_spec`, `doc_parity_spec` (120 examples)
- [x] RuboCop on touched Ruby files
