### PR TITLE
fix: keep namespaced exclusions from colliding on demodulized stems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Namespaced model exclusions no longer collide on the last path segment** — `excluded_models: ['User']` still matches `User` / `Users` / `users` / `UsersController`, but not `Admin::User`, `Admin::UsersController`, `UserSession`, or `Superuser`. `excluded_models: ['Admin::User']` matches `Admin::User` and `Admin::UsersController` only. Table-only exclusions are unchanged (`patient_records` still drops `PatientRecord`).
 - **MCP `fetch_section` honored disabled introspectors** (#186) — `Introspector#selected_introspectors` now intersects `only:` with `effective_introspectors`, so `:regulated` and `disabled_introspection_categories` cannot be bypassed by `rails_get_schema` / `rails://schema`.
 - **Excluded association names no longer leak via model details** (#186) — associations, generated accessors, and rubydex `similar_models` that name an excluded model or table are omitted from MCP output.
 - **`similar_models` honors `excluded_tables`** (#186) — rubydex sibling names such as `PatientRecord` are dropped when only `patient_records` is excluded (`ExclusionHelper.excluded_class_or_table?`).

--- a/lib/rails_ai_bridge/exclusion_helper.rb
+++ b/lib/rails_ai_bridge/exclusion_helper.rb
@@ -22,6 +22,8 @@ module RailsAiBridge
 
     # Returns +true+ when +name+ is an excluded model or maps to an excluded table.
     # Accepts rubydex-decorated tokens such as +PatientRecord::<PatientRecord>+.
+    # Demodulized bases match only when the module prefix is the same
+    # (+User+ vs +UsersController+, not +User+ vs +Admin::User+).
     #
     # @param name [String, nil] class, association, controller, or route token
     # @param config [#excluded_models, #excluded_table?]
@@ -33,7 +35,7 @@ module RailsAiBridge
       if config.respond_to?(:excluded_models)
         models = Array(config.excluded_models).map(&:to_s)
         return true if models.any? { |excluded| token == excluded || token.start_with?("#{excluded}::") }
-        return true if class_stems(token).any? { |stem| models.include?(stem.singularize.camelize) }
+        return true if models.any? { |excluded| namespaced_base_match?(token, excluded) }
       end
 
       return false unless config.respond_to?(:excluded_table?)
@@ -41,12 +43,36 @@ module RailsAiBridge
       class_stems(token).any? { |stem| config.excluded_table?(stem) }
     end
 
-    # Strips rubydex decoration (+Class::<Class>+) from a related-model token.
+    # Strips rubydex decoration (+Class::<Class>+) from a related-model token
+    # and normalizes route-style +admin/users+ paths to +admin::users+.
     #
     # @param name [String, nil]
     # @return [String]
     def normalize_class_token(name)
-      name.to_s.sub(/::<[^>]*>\z/, '')
+      name.to_s.sub(/::<[^>]*>\z/, '').gsub('/', '::')
+    end
+
+    # True when demodulized bases match and both tokens share a module prefix.
+    #
+    # @param token [String]
+    # @param excluded [String]
+    # @return [Boolean]
+    def namespaced_base_match?(token, excluded)
+      return false unless module_prefix(token).casecmp?(module_prefix(excluded))
+
+      classify_base(token) == classify_base(excluded)
+    end
+
+    # @param name [String]
+    # @return [String]
+    def module_prefix(name)
+      name.to_s.deconstantize
+    end
+
+    # @param name [String]
+    # @return [String]
+    def classify_base(name)
+      name.to_s.demodulize.sub(/Controller\z/, '').singularize.camelize
     end
 
     # Table-name candidates for a class or route/controller token.

--- a/lib/rails_ai_bridge/introspectors/controller_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/controller_introspector.rb
@@ -56,9 +56,7 @@ module RailsAiBridge
       # @param ctrl [Class]
       # @return [Boolean]
       def excluded_controller?(ctrl)
-        base = ctrl.name.demodulize.sub(/Controller\z/, '')
-        ExclusionHelper.excluded_class_or_table?(ctrl.name, config) ||
-          ExclusionHelper.excluded_class_or_table?(base, config)
+        ExclusionHelper.excluded_class_or_table?(ctrl.name, config)
       end
 
       def extract_controller_details(ctrl)

--- a/lib/rails_ai_bridge/introspectors/route_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/route_introspector.rb
@@ -39,12 +39,8 @@ module RailsAiBridge
       # @param route [Hash]
       # @return [Boolean]
       def excluded_route?(route)
-        tokens = [
-          route[:controller],
-          route[:controller].to_s.split('/').last,
-          route[:name]
-        ]
-        tokens.concat(route_path_tokens(route[:path]))
+        tokens = [route[:controller], route[:name]]
+        tokens.concat(route_path_tokens(route[:path])) unless route[:controller].to_s.include?('/')
         tokens.compact.any? { |token| ExclusionHelper.excluded_class_or_table?(token, config) }
       end
 

--- a/spec/lib/rails_ai_bridge/exclusion_helper_spec.rb
+++ b/spec/lib/rails_ai_bridge/exclusion_helper_spec.rb
@@ -94,5 +94,26 @@ RSpec.describe RailsAiBridge::ExclusionHelper do
       expect(described_class.excluded_class_or_table?('UserSession', config)).to be false
       expect(described_class.excluded_class_or_table?('Superuser', config)).to be false
     end
+
+    it 'does not treat a namespaced class as excluded when only the un-namespaced model is listed' do
+      config.excluded_models += %w[User]
+
+      expect(described_class.excluded_class_or_table?('Admin::User', config)).to be false
+      expect(described_class.excluded_class_or_table?('Admin::UsersController', config)).to be false
+    end
+
+    it 'matches a namespaced model and its controller when that namespaced class is listed' do
+      config.excluded_models += %w[Admin::User]
+
+      expect(described_class.excluded_class_or_table?('Admin::User', config)).to be true
+      expect(described_class.excluded_class_or_table?('Admin::UsersController', config)).to be true
+    end
+
+    it 'does not treat an un-namespaced class as excluded when only the namespaced model is listed' do
+      config.excluded_models += %w[Admin::User]
+
+      expect(described_class.excluded_class_or_table?('User', config)).to be false
+      expect(described_class.excluded_class_or_table?('UsersController', config)).to be false
+    end
   end
 end


### PR DESCRIPTION
## Summary

Leftover edge after #186: `ExclusionHelper.excluded_class_or_table?` built stems from the last `::` segment, so `Admin::User` became `user` and matched `excluded_models: ['User']`.

Demodulized bases now match only when the module prefix is the same (`deconstantize` / `split('::')`). Controllers pass the full class name; namespaced routes no longer also match on the last path segment.

## Matching rules

- `excluded_models=['User']` matches `User`, `Users`, `users`, `UsersController`
- `excluded_models=['User']` does **not** match `Admin::User`, `Admin::UsersController`, `UserSession`, `Superuser`
- `excluded_models=['Admin::User']` matches `Admin::User` and `Admin::UsersController`
- `excluded_models=['Admin::User']` does **not** match `User` or `UsersController`
- Table-only exclusions unchanged (`patient_records` still drops `PatientRecord`)

## Test plan

- [x] TDD: added failing cases in `spec/lib/rails_ai_bridge/exclusion_helper_spec.rb` (2 failed for the right reason)
- [x] `bundle exec rspec spec/lib/rails_ai_bridge/exclusion_helper_spec.rb` — 19 examples, 0 failures
- [x] Related exclusion/controller/route/parity specs — 78 examples, 0 failures
- [x] Full suite — **2594 examples, 0 failures**
- [x] RuboCop on changed files — no offenses

Do not merge until reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exclusion matching for namespaced models and controllers.
  * Prevented exclusions from incorrectly applying across different namespaces.
  * Preserved existing table-only exclusion behavior.
  * Improved route exclusion handling for namespaced controllers and route paths.
  * Normalized route-style namespace separators for more reliable matching.

* **Tests**
  * Added coverage for namespaced, unnamespaced, and cross-namespace exclusion scenarios.

* **Documentation**
  * Updated the changelog and matching behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->