### PR TITLE
test: raise branch coverage for introspection and Rubydex paths

### DIFF
--- a/spec/lib/rails_ai_bridge/fingerprinter/cached_snapshot_spec.rb
+++ b/spec/lib/rails_ai_bridge/fingerprinter/cached_snapshot_spec.rb
@@ -98,4 +98,24 @@ RSpec.describe RailsAiBridge::Fingerprinter::CachedSnapshot do
       expect(RailsAiBridge::Fingerprinter).to have_received(:snapshot).twice
     end
   end
+
+  describe 'effective_ttl from configuration' do
+    it 'uses configuration snapshot_ttl when set' do
+      original_ttl = RailsAiBridge.configuration.snapshot_ttl
+      RailsAiBridge.configuration.snapshot_ttl = 100
+      allow(RailsAiBridge::Fingerprinter).to receive(:snapshot).with(app).and_return(fingerprint_a)
+
+      described_class.fetch(app)
+
+      cache = described_class.instance_variable_get(:@cache)
+      entry = cache.values.first
+      # Even after subtracting default TTL (5), the entry should still be valid
+      entry[:fetched_at] -= 10
+      result = described_class.fetch(app)
+      expect(result).to eq(fingerprint_a)
+      expect(RailsAiBridge::Fingerprinter).to have_received(:snapshot).once
+    ensure
+      RailsAiBridge.configuration.snapshot_ttl = original_ttl
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspector_spec.rb
@@ -163,4 +163,51 @@ RSpec.describe RailsAiBridge::Introspector do
       end
     end
   end
+
+  describe '#selected_introspectors' do
+    it 'returns all effective introspectors when only is nil' do
+      expect(introspector.selected_introspectors(nil)).to eq(RailsAiBridge.configuration.effective_introspectors)
+    end
+
+    it 'filters to only requested introspectors that are in the allowed set' do
+      allowed = RailsAiBridge.configuration.effective_introspectors
+      target = allowed.first
+      result = introspector.selected_introspectors([target])
+      expect(result).to eq([target])
+    end
+
+    it 'returns empty array when only contains no allowed introspectors' do
+      result = introspector.selected_introspectors(%i[nonexistent fake])
+      expect(result).to eq([])
+    end
+
+    it 'includes additional_introspectors keys in allowed set' do
+      custom = Class.new { def initialize(_app); end; def call = {}; }
+      RailsAiBridge.configuration.additional_introspectors[:my_custom] = custom
+
+      result = introspector.selected_introspectors([:my_custom])
+      expect(result).to include(:my_custom)
+    end
+  end
+
+  describe '#resolve_introspector' do
+    it 'raises ConfigurationError for unknown introspector' do
+      expect { introspector.resolve_introspector(:nonexistent) }
+        .to raise_error(RailsAiBridge::ConfigurationError, /Unknown introspector/)
+    end
+
+    it 'resolves additional_introspectors before builtins' do
+      custom = Class.new { def initialize(_app); end; def call = {}; }
+      RailsAiBridge.configuration.additional_introspectors[:custom] = custom
+
+      expect(introspector.resolve_introspector(:custom)).to be_a(custom)
+    end
+  end
+
+  describe '#app_name' do
+    it 'returns the application module name' do
+      expect(introspector.app_name).to be_a(String)
+      expect(introspector.app_name).not_to be_empty
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspector_spec.rb
@@ -182,11 +182,18 @@ RSpec.describe RailsAiBridge::Introspector do
     end
 
     it 'includes additional_introspectors keys in allowed set' do
-      custom = Class.new { def initialize(_app); end; def call = {}; }
+      custom = Class.new do
+        def initialize(_app); end
+
+        def call = {}
+      end
+      saved = RailsAiBridge.configuration.additional_introspectors.dup
       RailsAiBridge.configuration.additional_introspectors[:my_custom] = custom
 
       result = introspector.selected_introspectors([:my_custom])
       expect(result).to include(:my_custom)
+    ensure
+      RailsAiBridge.configuration.additional_introspectors.replace(saved)
     end
   end
 
@@ -197,10 +204,17 @@ RSpec.describe RailsAiBridge::Introspector do
     end
 
     it 'resolves additional_introspectors before builtins' do
-      custom = Class.new { def initialize(_app); end; def call = {}; }
+      custom = Class.new do
+        def initialize(_app); end
+
+        def call = {}
+      end
+      saved = RailsAiBridge.configuration.additional_introspectors.dup
       RailsAiBridge.configuration.additional_introspectors[:custom] = custom
 
       expect(introspector.resolve_introspector(:custom)).to be_a(custom)
+    ensure
+      RailsAiBridge.configuration.additional_introspectors.replace(saved)
     end
   end
 

--- a/spec/lib/rails_ai_bridge/introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspector_spec.rb
@@ -210,9 +210,9 @@ RSpec.describe RailsAiBridge::Introspector do
         def call = {}
       end
       saved = RailsAiBridge.configuration.additional_introspectors.dup
-      RailsAiBridge.configuration.additional_introspectors[:custom] = custom
+      RailsAiBridge.configuration.additional_introspectors[:schema] = custom
 
-      expect(introspector.resolve_introspector(:custom)).to be_a(custom)
+      expect(introspector.resolve_introspector(:schema)).to be_a(custom)
     ensure
       RailsAiBridge.configuration.additional_introspectors.replace(saved)
     end

--- a/spec/lib/rails_ai_bridge/introspectors/action_mailbox_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/action_mailbox_introspector_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe RailsAiBridge::Introspectors::ActionMailboxIntrospector do
     context 'with a mailbox file' do
       let(:mailboxes_dir) { Rails.root.join('app/mailboxes').to_s }
       let(:mailbox_file) { File.join(mailboxes_dir, 'forwards_mailbox.rb') }
+      let!(:dir_existed) { File.directory?(mailboxes_dir) }
 
       before do
         FileUtils.mkdir_p(mailboxes_dir)
@@ -37,7 +38,10 @@ RSpec.describe RailsAiBridge::Introspectors::ActionMailboxIntrospector do
         RUBY
       end
 
-      after { FileUtils.rm_f(mailbox_file) }
+      after do
+        FileUtils.rm_f(mailbox_file)
+        FileUtils.rmdir(mailboxes_dir) if !dir_existed && File.directory?(mailboxes_dir) && Dir.empty?(mailboxes_dir)
+      end
 
       it 'discovers mailbox classes' do
         expect(result[:mailboxes].size).to eq(1)
@@ -52,6 +56,7 @@ RSpec.describe RailsAiBridge::Introspectors::ActionMailboxIntrospector do
 
     context 'with application_mailbox.rb and a mailbox without routing' do
       let(:mailboxes_dir) { Rails.root.join('app/mailboxes').to_s }
+      let!(:dir_existed) { File.directory?(mailboxes_dir) }
 
       before do
         FileUtils.mkdir_p(mailboxes_dir)
@@ -62,6 +67,7 @@ RSpec.describe RailsAiBridge::Introspectors::ActionMailboxIntrospector do
       after do
         FileUtils.rm_f(File.join(mailboxes_dir, 'application_mailbox.rb'))
         FileUtils.rm_f(File.join(mailboxes_dir, 'bounces_mailbox.rb'))
+        FileUtils.rmdir(mailboxes_dir) if !dir_existed && File.directory?(mailboxes_dir) && Dir.empty?(mailboxes_dir)
       end
 
       it 'skips application_mailbox.rb' do

--- a/spec/lib/rails_ai_bridge/introspectors/action_mailbox_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/action_mailbox_introspector_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RailsAiBridge::Introspectors::ActionMailboxIntrospector do
         RUBY
       end
 
-      after { FileUtils.rm_rf(mailboxes_dir) }
+      after { FileUtils.rm_f(mailbox_file) }
 
       it 'discovers mailbox classes' do
         expect(result[:mailboxes].size).to eq(1)
@@ -47,6 +47,64 @@ RSpec.describe RailsAiBridge::Introspectors::ActionMailboxIntrospector do
       it 'extracts routing patterns' do
         routing = result[:mailboxes].first[:routing]
         expect(routing).to be_an(Array)
+      end
+    end
+
+    context 'with application_mailbox.rb and a mailbox without routing' do
+      let(:mailboxes_dir) { Rails.root.join('app/mailboxes').to_s }
+
+      before do
+        FileUtils.mkdir_p(mailboxes_dir)
+        File.write(File.join(mailboxes_dir, 'application_mailbox.rb'), "class ApplicationMailbox < ActionMailbox::Base\nend\n")
+        File.write(File.join(mailboxes_dir, 'bounces_mailbox.rb'), "class BouncesMailbox < ApplicationMailbox\n  def process\n  end\nend\n")
+      end
+
+      after do
+        FileUtils.rm_f(File.join(mailboxes_dir, 'application_mailbox.rb'))
+        FileUtils.rm_f(File.join(mailboxes_dir, 'bounces_mailbox.rb'))
+      end
+
+      it 'skips application_mailbox.rb' do
+        names = result[:mailboxes].pluck(:name)
+        expect(names).not_to include('ApplicationMailbox')
+        expect(names).to include('BouncesMailbox')
+      end
+
+      it 'returns empty routing for mailbox without routing rules' do
+        bounce = result[:mailboxes].find { |m| m[:name] == 'BouncesMailbox' }
+        expect(bounce[:routing]).to eq([])
+      end
+    end
+
+    context 'with an unreadable mailbox file' do
+      let(:mailboxes_dir) { Rails.root.join('app/mailboxes').to_s }
+      let(:bad_file) { File.join(mailboxes_dir, 'bad_mailbox.rb') }
+
+      before do
+        FileUtils.mkdir_p(mailboxes_dir)
+        File.write(bad_file, 'class BadMailbox; end')
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(bad_file).and_raise(StandardError, 'read error')
+      end
+
+      after do
+        allow(File).to receive(:read).and_call_original
+        FileUtils.rm_f(bad_file)
+      end
+
+      it 'skips unreadable mailbox files' do
+        expect(result[:mailboxes]).to eq([])
+      end
+    end
+
+    context 'when app.root raises' do
+      let(:bad_app) { double('Rails::Application') }
+      let(:result) { described_class.new(bad_app).call }
+
+      before { allow(bad_app).to receive(:root).and_raise(StandardError, 'root boom') }
+
+      it 'returns error hash' do
+        expect(result[:error]).to eq('root boom')
       end
     end
   end

--- a/spec/lib/rails_ai_bridge/introspectors/action_text_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/action_text_introspector_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe RailsAiBridge::Introspectors::ActionTextIntrospector do
     context 'when extract_rich_text_fields raises an error' do
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] })
+                                     paths: { 'app/models' => [] })
       end
 
       before do

--- a/spec/lib/rails_ai_bridge/introspectors/action_text_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/action_text_introspector_spec.rb
@@ -72,5 +72,24 @@ RSpec.describe RailsAiBridge::Introspectors::ActionTextIntrospector do
         )
       end
     end
+
+    context 'when extract_rich_text_fields raises an error' do
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] })
+      end
+
+      before do
+        resolver = instance_double(RailsAiBridge::PathResolver)
+        allow(RailsAiBridge::PathResolver).to receive(:new).and_return(resolver)
+        allow(resolver).to receive(:files_for).and_raise(StandardError, 'boom')
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns empty array for rich_text_fields on error' do
+        expect(described_class.new(custom_app).call[:rich_text_fields]).to eq([])
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/active_storage_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/active_storage_introspector_spec.rb
@@ -193,6 +193,15 @@ RSpec.describe RailsAiBridge::Introspectors::ActiveStorageIntrospector do
     end
 
     context 'with directory in direct_upload scan' do
+      let(:views_dir) { Rails.root.join('app/views') }
+      let(:subdir) { views_dir.join('subdir') }
+
+      before do
+        FileUtils.mkdir_p(subdir)
+      end
+
+      after { FileUtils.rm_rf(subdir) }
+
       it 'skips directories in direct upload scan' do
         expect(result[:direct_upload]).to be false
       end

--- a/spec/lib/rails_ai_bridge/introspectors/active_storage_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/active_storage_introspector_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe RailsAiBridge::Introspectors::ActiveStorageIntrospector do
       expect(result[:installed]).to be(true).or be(false)
     end
 
+    context 'when ActiveStorage is defined' do
+      before { stub_const('ActiveStorage', Module.new) }
+
+      it 'returns installed as true' do
+        expect(result[:installed]).to be true
+      end
+    end
+
     context 'with configured Rails paths' do
       let(:app_root) { Pathname.new(Dir.mktmpdir('rails-ai-bridge-active-storage')) }
       let(:models_dir) { app_root.join('domain/models') }
@@ -103,6 +111,90 @@ RSpec.describe RailsAiBridge::Introspectors::ActiveStorageIntrospector do
           type: 'has_one_attached'
         )
         expect(custom_result[:direct_upload]).to be true
+      end
+    end
+
+    context 'when extract_attachments raises' do
+      before { allow(introspector).to receive(:extract_attachments).and_raise(StandardError, 'attachments boom') }
+
+      it 'returns error hash' do
+        expect(result[:error]).to eq('attachments boom')
+      end
+    end
+
+    context 'with unreadable model file' do
+      let(:bad_model) { Rails.root.join('app/models/bad_attachment.rb').to_s }
+
+      before do
+        File.write(bad_model, 'class BadAttachment; end')
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(bad_model).and_raise(StandardError, 'read error')
+      end
+
+      after do
+        allow(File).to receive(:read).and_call_original
+        FileUtils.rm_f(bad_model)
+      end
+
+      it 'returns empty attachments array' do
+        expect(result[:attachments]).to eq([])
+      end
+    end
+
+    context 'with no storage.yml' do
+      let(:bad_app) { double('Rails::Application') }
+      let(:result) { described_class.new(bad_app).call }
+
+      before do
+        allow(bad_app).to receive_messages(root: Pathname.new('/nonexistent'), paths: {})
+      end
+
+      it 'returns empty storage_services' do
+        expect(result[:storage_services]).to eq([])
+      end
+    end
+
+    context 'with unreadable storage.yml' do
+      let(:storage_path) { Rails.root.join('config/storage.yml').to_s }
+      let(:original_content) { File.exist?(storage_path) ? File.read(storage_path) : nil }
+
+      before do
+        File.write(storage_path, 'invalid: yaml: content: [') unless File.exist?(storage_path)
+        allow(YAML).to receive(:load_file).and_raise(StandardError, 'yaml error')
+      end
+
+      after do
+        if original_content
+          File.write(storage_path, original_content)
+        else
+          FileUtils.rm_f(storage_path)
+        end
+      end
+
+      it 'returns empty storage_services on error' do
+        expect(result[:storage_services]).to eq([])
+      end
+    end
+
+    context 'with direct_upload in javascript file' do
+      let(:js_dir) { Rails.root.join('app/javascript') }
+      let(:js_file) { js_dir.join('upload.js') }
+
+      before do
+        FileUtils.mkdir_p(js_dir)
+        File.write(js_file, 'const upload = new DirectUpload(file, url)')
+      end
+
+      after { FileUtils.rm_rf(js_dir) }
+
+      it 'detects direct upload from javascript' do
+        expect(result[:direct_upload]).to be true
+      end
+    end
+
+    context 'with directory in direct_upload scan' do
+      it 'skips directories in direct upload scan' do
+        expect(result[:direct_upload]).to be false
       end
     end
   end

--- a/spec/lib/rails_ai_bridge/introspectors/active_storage_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/active_storage_introspector_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe RailsAiBridge::Introspectors::ActiveStorageIntrospector do
 
     context 'with unreadable storage.yml' do
       let(:storage_path) { Rails.root.join('config/storage.yml').to_s }
-      let(:original_content) { File.exist?(storage_path) ? File.read(storage_path) : nil }
+      let!(:original_content) { File.exist?(storage_path) ? File.read(storage_path) : nil }
 
       before do
         File.write(storage_path, 'invalid: yaml: content: [') unless File.exist?(storage_path)
@@ -179,13 +179,17 @@ RSpec.describe RailsAiBridge::Introspectors::ActiveStorageIntrospector do
     context 'with direct_upload in javascript file' do
       let(:js_dir) { Rails.root.join('app/javascript') }
       let(:js_file) { js_dir.join('upload.js') }
+      let!(:dir_existed) { File.directory?(js_dir) }
 
       before do
         FileUtils.mkdir_p(js_dir)
         File.write(js_file, 'const upload = new DirectUpload(file, url)')
       end
 
-      after { FileUtils.rm_rf(js_dir) }
+      after do
+        FileUtils.rm_f(js_file)
+        FileUtils.rmdir(js_dir) if !dir_existed && File.directory?(js_dir)
+      end
 
       it 'detects direct upload from javascript' do
         expect(result[:direct_upload]).to be true

--- a/spec/lib/rails_ai_bridge/introspectors/asset_pipeline_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/asset_pipeline_introspector_spec.rb
@@ -71,4 +71,171 @@ RSpec.describe RailsAiBridge::Introspectors::AssetPipelineIntrospector do
       end
     end
   end
+
+  describe '#call with custom app root' do
+    let(:app_root) { Pathname.new(Dir.mktmpdir('asset-pipeline')) }
+    let(:custom_app) { double('Rails::Application', root: app_root) }
+    let(:introspector) { described_class.new(custom_app) }
+    let(:result) { introspector.call }
+
+    after { FileUtils.rm_rf(app_root) }
+
+    context 'with propshaft in Gemfile.lock' do
+      before { File.write(app_root.join('Gemfile.lock'), "propshaft (0.9.0)\n") }
+
+      it 'detects propshaft pipeline' do
+        expect(result[:pipeline]).to eq('propshaft')
+      end
+    end
+
+    context 'with sprockets in Gemfile.lock' do
+      before { File.write(app_root.join('Gemfile.lock'), "sprockets (4.2.0)\n") }
+
+      it 'detects sprockets pipeline' do
+        expect(result[:pipeline]).to eq('sprockets')
+      end
+    end
+
+    context 'with tailwindcss-rails in Gemfile.lock' do
+      before { File.write(app_root.join('Gemfile.lock'), "tailwindcss-rails (2.0.0)\n") }
+
+      it 'detects tailwindcss CSS framework' do
+        expect(result[:css_framework]).to eq('tailwindcss')
+      end
+    end
+
+    context 'with bootstrap in Gemfile.lock' do
+      before { File.write(app_root.join('Gemfile.lock'), "bootstrap (5.0.0)\n") }
+
+      it 'detects bootstrap CSS framework' do
+        expect(result[:css_framework]).to eq('bootstrap')
+      end
+    end
+
+    context 'with bootstrap in package.json' do
+      before do
+        File.write(app_root.join('Gemfile.lock'), "rails (7.1.0)\n")
+        File.write(app_root.join('package.json'), '{"dependencies": {"bootstrap": "5.0"}}')
+      end
+
+      it 'detects bootstrap CSS framework from package.json' do
+        expect(result[:css_framework]).to eq('bootstrap')
+      end
+    end
+
+    context 'with bulma in package.json' do
+      before do
+        File.write(app_root.join('Gemfile.lock'), "rails (7.1.0)\n")
+        File.write(app_root.join('package.json'), '{"dependencies": {"bulma": "0.9"}}')
+      end
+
+      it 'detects bulma CSS framework' do
+        expect(result[:css_framework]).to eq('bulma')
+      end
+    end
+
+    context 'with esbuild in package.json' do
+      before do
+        File.write(app_root.join('package.json'), '{"dependencies": {"esbuild": "0.15"}}')
+      end
+
+      it 'detects esbuild as js_bundler' do
+        expect(result[:js_bundler]).to eq('esbuild')
+      end
+    end
+
+    context 'with webpack config directory' do
+      before { FileUtils.mkdir_p(app_root.join('config/webpack')) }
+
+      it 'detects webpack as js_bundler' do
+        expect(result[:js_bundler]).to eq('webpack')
+      end
+    end
+
+    context 'with webpack in package.json' do
+      before { File.write(app_root.join('package.json'), '{"dependencies": {"webpack": "5.0"}}') }
+
+      it 'detects webpack as js_bundler from package.json' do
+        expect(result[:js_bundler]).to eq('webpack')
+      end
+    end
+
+    context 'with rollup in package.json' do
+      before { File.write(app_root.join('package.json'), '{"dependencies": {"rollup": "3.0"}}') }
+
+      it 'detects rollup as js_bundler' do
+        expect(result[:js_bundler]).to eq('rollup')
+      end
+    end
+
+    context 'with manifest.js and package.json' do
+      before do
+        FileUtils.mkdir_p(app_root.join('app/assets/config'))
+        File.write(app_root.join('app/assets/config/manifest.js'), '// manifest')
+        File.write(app_root.join('package.json'), '{}')
+      end
+
+      it 'includes manifest.js and package.json in manifest_files' do
+        expect(result[:manifest_files]).to include('manifest.js', 'package.json')
+      end
+    end
+
+    context 'with unreadable Gemfile.lock' do
+      before do
+        path = app_root.join('Gemfile.lock').to_s
+        File.write(path, "propshaft (0.9.0)\n")
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(path).and_raise(StandardError, 'permission denied')
+      end
+
+      after { allow(File).to receive(:read).and_call_original }
+
+      it 'returns none for pipeline on read error' do
+        expect(result[:pipeline]).to eq('none')
+      end
+    end
+
+    context 'with unreadable package.json' do
+      before do
+        File.write(app_root.join('Gemfile.lock'), "rails (7.1.0)\n")
+        path = app_root.join('package.json').to_s
+        File.write(path, '{"bulma": "0.9"}')
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(path).and_raise(StandardError, 'permission denied')
+      end
+
+      after { allow(File).to receive(:read).and_call_original }
+
+      it 'returns nil for css_framework on read error' do
+        expect(result[:css_framework]).to be_nil
+      end
+    end
+
+    context 'with unreadable importmap.rb' do
+      before do
+        path = app_root.join('config/importmap.rb').to_s
+        FileUtils.mkdir_p(app_root.join('config'))
+        File.write(path, 'pin "application"')
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(path).and_raise(StandardError, 'permission denied')
+      end
+
+      after { allow(File).to receive(:read).and_call_original }
+
+      it 'returns empty array for importmap_pins on read error' do
+        expect(result[:importmap_pins]).to eq([])
+      end
+    end
+  end
+
+  describe '#call when app.root raises' do
+    let(:bad_app) { double('Rails::Application') }
+    let(:result) { described_class.new(bad_app).call }
+
+    before { allow(bad_app).to receive(:root).and_raise(StandardError, 'root boom') }
+
+    it 'returns error hash' do
+      expect(result[:error]).to eq('root boom')
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/auth_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/auth_introspector_spec.rb
@@ -154,5 +154,93 @@ RSpec.describe RailsAiBridge::Introspectors::AuthIntrospector do
         )
       end
     end
+
+    context 'with rack-cors gem and cors initializer' do
+      let(:lockfile) { Rails.root.join('Gemfile.lock').to_s }
+      let(:cors_init) { Rails.root.join('config/initializers/cors.rb').to_s }
+      let(:original_content) { File.exist?(lockfile) ? File.read(lockfile) : nil }
+
+      before do
+        File.write(lockfile, "    rack-cors (2.0.0)\n") unless File.exist?(lockfile)
+        FileUtils.mkdir_p(File.dirname(cors_init))
+        File.write(cors_init, '# CORS config')
+      end
+
+      after do
+        if original_content
+          File.write(lockfile, original_content)
+        else
+          FileUtils.rm_f(lockfile)
+        end
+        FileUtils.rm_f(cors_init)
+      end
+
+      it 'detects CORS as configured' do
+        expect(result[:security][:cors]).to eq({ configured: true })
+      end
+    end
+
+    context 'with rack-cors gem but no cors initializer' do
+      let(:lockfile) { Rails.root.join('Gemfile.lock').to_s }
+      let(:original_content) { File.exist?(lockfile) ? File.read(lockfile) : nil }
+
+      before do
+        File.write(lockfile, "    rack-cors (2.0.0)\n") unless File.exist?(lockfile)
+      end
+
+      after do
+        if original_content
+          File.write(lockfile, original_content)
+        else
+          FileUtils.rm_f(lockfile)
+        end
+      end
+
+      it 'detects CORS as not configured' do
+        expect(result[:security][:cors]).to eq({ configured: false })
+      end
+    end
+
+    context 'when detect_authentication raises' do
+      before { allow(introspector).to receive(:detect_authentication).and_raise(StandardError, 'auth boom') }
+
+      it 'returns error hash' do
+        expect(result[:error]).to eq('auth boom')
+      end
+    end
+  end
+
+  describe 'private methods' do
+    describe '#gem_present?' do
+      it 'returns false when Gemfile.lock does not exist' do
+        allow(introspector).to receive(:root).and_return('/nonexistent')
+        expect(introspector.send(:gem_present?, 'rack-cors')).to be false
+      end
+
+      it 'returns false on file read error' do
+        lockfile = Rails.root.join('Gemfile.lock').to_s
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(lockfile).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(lockfile).and_raise(StandardError, 'read error')
+        expect(introspector.send(:gem_present?, 'rack-cors')).to be false
+      ensure
+        allow(File).to receive(:read).and_call_original
+      end
+    end
+
+    describe '#scan_models_for error handling' do
+      it 'returns empty array on error' do
+        allow(introspector.path_resolver).to receive(:files_for).and_raise(StandardError, 'files error')
+        expect(introspector.send(:scan_models_for, /devise/)).to eq([])
+      end
+    end
+
+    describe '#policy_names error handling' do
+      it 'returns empty array on error' do
+        allow(introspector.path_resolver).to receive(:files_for).and_raise(StandardError, 'policies error')
+        expect(introspector.send(:policy_names)).to eq([])
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/auth_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/auth_introspector_spec.rb
@@ -158,21 +158,26 @@ RSpec.describe RailsAiBridge::Introspectors::AuthIntrospector do
     context 'with rack-cors gem and cors initializer' do
       let(:lockfile) { Rails.root.join('Gemfile.lock').to_s }
       let(:cors_init) { Rails.root.join('config/initializers/cors.rb').to_s }
-      let(:original_content) { File.exist?(lockfile) ? File.read(lockfile) : nil }
+      let!(:original_lockfile) { File.exist?(lockfile) ? File.read(lockfile) : nil }
+      let!(:original_cors) { File.exist?(cors_init) ? File.read(cors_init) : nil }
 
       before do
-        File.write(lockfile, "    rack-cors (2.0.0)\n") unless File.exist?(lockfile)
+        File.write(lockfile, "    rack-cors (2.0.0)\n")
         FileUtils.mkdir_p(File.dirname(cors_init))
         File.write(cors_init, '# CORS config')
       end
 
       after do
-        if original_content
-          File.write(lockfile, original_content)
+        if original_lockfile
+          File.write(lockfile, original_lockfile)
         else
           FileUtils.rm_f(lockfile)
         end
-        FileUtils.rm_f(cors_init)
+        if original_cors
+          File.write(cors_init, original_cors)
+        else
+          FileUtils.rm_f(cors_init)
+        end
       end
 
       it 'detects CORS as configured' do
@@ -182,10 +187,10 @@ RSpec.describe RailsAiBridge::Introspectors::AuthIntrospector do
 
     context 'with rack-cors gem but no cors initializer' do
       let(:lockfile) { Rails.root.join('Gemfile.lock').to_s }
-      let(:original_content) { File.exist?(lockfile) ? File.read(lockfile) : nil }
+      let!(:original_content) { File.exist?(lockfile) ? File.read(lockfile) : nil }
 
       before do
-        File.write(lockfile, "    rack-cors (2.0.0)\n") unless File.exist?(lockfile)
+        File.write(lockfile, "    rack-cors (2.0.0)\n")
       end
 
       after do

--- a/spec/lib/rails_ai_bridge/introspectors/config_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/config_introspector_spec.rb
@@ -128,13 +128,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
     context 'with cache_store as an Array' do
       let(:custom_config) do
         double('ApplicationConfig', cache_store: [:redis_cache, 'redis://localhost'],
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       after { FileUtils.rm_rf(custom_app.root) }
@@ -148,13 +148,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
       let(:store_obj) { Object.new }
       let(:custom_config) do
         double('ApplicationConfig', cache_store: store_obj,
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       after { FileUtils.rm_rf(custom_app.root) }
@@ -167,13 +167,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
     context 'when cache_store raises an error' do
       let(:custom_config) do
         double('ApplicationConfig', time_zone: 'UTC',
-               session_store: ActionDispatch::Session::CookieStore)
+                                    session_store: ActionDispatch::Session::CookieStore)
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       before do
@@ -192,13 +192,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
     context 'when session_store is nil' do
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: nil, time_zone: 'UTC')
+                                    session_store: nil, time_zone: 'UTC')
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       after { FileUtils.rm_rf(custom_app.root) }
@@ -214,9 +214,9 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       before do
@@ -235,13 +235,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
     context 'when app does not respond to active_job' do
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       before do
@@ -260,14 +260,14 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
       let(:active_job_config) { double('ActiveJobConfig', queue_adapter: :sidekiq) }
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC',
-               active_job: active_job_config)
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC',
+                                    active_job: active_job_config)
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       before do
@@ -286,14 +286,14 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
       let(:active_job_config) { double('ActiveJobConfig', queue_adapter: :sidekiq) }
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC',
-               active_job: active_job_config)
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC',
+                                    active_job: active_job_config)
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       before do
@@ -313,14 +313,14 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
       let(:cable_config) { double('CableConfig', adapter: :redis) }
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC',
-               active_job: active_job_config, action_cable: cable_config)
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC',
+                                    active_job: active_job_config, action_cable: cable_config)
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       before do
@@ -338,13 +338,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
     context 'when middleware raises an error' do
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       before do
@@ -364,13 +364,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
       let(:app_root) { Pathname.new(Dir.mktmpdir('no-init')) }
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
       end
       let(:custom_app) do
         double('Rails::Application', root: app_root,
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       before do
@@ -388,13 +388,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
     context 'when credentials do not respond to config' do
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials'))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials'))
       end
 
       before do
@@ -413,13 +413,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
     context 'when credentials raise an error' do
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+                                    session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
       end
       let(:custom_app) do
         double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials'))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials'))
       end
 
       before do
@@ -440,13 +440,13 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
       let(:app_root) { Pathname.new(Dir.mktmpdir) }
       let(:custom_config) do
         double('ApplicationConfig', cache_store: :memory_store,
-               session_store: ActionDispatch::Session::CookieStore)
+                                    session_store: ActionDispatch::Session::CookieStore)
       end
       let(:custom_app) do
         double('Rails::Application', root: app_root,
-               paths: { 'app/models' => [] }, config: custom_config,
-               middleware: ActionDispatch::MiddlewareStack.new,
-               credentials: double('Credentials', config: {}))
+                                     paths: { 'app/models' => [] }, config: custom_config,
+                                     middleware: ActionDispatch::MiddlewareStack.new,
+                                     credentials: double('Credentials', config: {}))
       end
 
       before do

--- a/spec/lib/rails_ai_bridge/introspectors/config_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/config_introspector_spec.rb
@@ -124,5 +124,342 @@ RSpec.describe RailsAiBridge::Introspectors::ConfigIntrospector do
         expect(described_class.new(custom_app).call[:current_attributes]).to include('Current')
       end
     end
+
+    context 'with cache_store as an Array' do
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: [:redis_cache, 'redis://localhost'],
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns the first element as the cache store name' do
+        expect(described_class.new(custom_app).call[:cache_store]).to eq('redis_cache')
+      end
+    end
+
+    context 'with cache_store as a non-Symbol non-Array object' do
+      let(:store_obj) { Object.new }
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: store_obj,
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns the class name of the store object' do
+        expect(described_class.new(custom_app).call[:cache_store]).to eq(store_obj.class.name)
+      end
+    end
+
+    context 'when cache_store raises an error' do
+      let(:custom_config) do
+        double('ApplicationConfig', time_zone: 'UTC',
+               session_store: ActionDispatch::Session::CookieStore)
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      before do
+        allow(custom_config).to receive(:cache_store).and_raise(StandardError, 'boom')
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(false)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns unknown for cache_store' do
+        expect(described_class.new(custom_app).call[:cache_store]).to eq('unknown')
+      end
+    end
+
+    context 'when session_store is nil' do
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: nil, time_zone: 'UTC')
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns nil for session_store' do
+        expect(described_class.new(custom_app).call[:session_store]).to be_nil
+      end
+    end
+
+    context 'when session_store raises an error' do
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store, time_zone: 'UTC')
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      before do
+        allow(custom_config).to receive(:session_store).and_raise(StandardError, 'boom')
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(false)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns unknown for session_store' do
+        expect(described_class.new(custom_app).call[:session_store]).to eq('unknown')
+      end
+    end
+
+    context 'when app does not respond to active_job' do
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      before do
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(false)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns unknown for queue_adapter' do
+        expect(described_class.new(custom_app).call[:queue_adapter]).to eq('unknown')
+      end
+    end
+
+    context 'when queue_adapter is a Symbol' do
+      let(:active_job_config) { double('ActiveJobConfig', queue_adapter: :sidekiq) }
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC',
+               active_job: active_job_config)
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      before do
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(true)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns the symbol as a string' do
+        expect(described_class.new(custom_app).call[:queue_adapter]).to eq('sidekiq')
+      end
+    end
+
+    context 'when app does not respond to action_cable' do
+      let(:active_job_config) { double('ActiveJobConfig', queue_adapter: :sidekiq) }
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC',
+               active_job: active_job_config)
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      before do
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(true)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns unknown for cable_adapter' do
+        expect(described_class.new(custom_app).call[:cable_adapter]).to eq('unknown')
+      end
+    end
+
+    context 'when cable_adapter is a Symbol' do
+      let(:active_job_config) { double('ActiveJobConfig', queue_adapter: :sidekiq) }
+      let(:cable_config) { double('CableConfig', adapter: :redis) }
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC',
+               active_job: active_job_config, action_cable: cable_config)
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      before do
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(true)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(true)
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns the symbol as a string' do
+        expect(described_class.new(custom_app).call[:cable_adapter]).to eq('redis')
+      end
+    end
+
+    context 'when middleware raises an error' do
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      before do
+        allow(custom_app).to receive(:middleware).and_raise(StandardError, 'boom')
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(false)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns empty array for middleware_stack' do
+        expect(described_class.new(custom_app).call[:middleware_stack]).to eq([])
+      end
+    end
+
+    context 'when config/initializers does not exist' do
+      let(:app_root) { Pathname.new(Dir.mktmpdir('no-init')) }
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: app_root,
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      before do
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(false)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+      end
+
+      after { FileUtils.rm_rf(app_root) }
+
+      it 'returns empty array for initializers' do
+        expect(described_class.new(custom_app).call[:initializers]).to eq([])
+      end
+    end
+
+    context 'when credentials do not respond to config' do
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials'))
+      end
+
+      before do
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(false)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+        RailsAiBridge.configuration.expose_credentials_key_names = true
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns empty array for credentials_keys' do
+        expect(described_class.new(custom_app).call[:credentials_keys]).to eq([])
+      end
+    end
+
+    context 'when credentials raise an error' do
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: ActionDispatch::Session::CookieStore, time_zone: 'UTC')
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: Pathname.new(Dir.mktmpdir),
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials'))
+      end
+
+      before do
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(false)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+        allow(custom_app).to receive(:credentials).and_raise(StandardError, 'boom')
+        RailsAiBridge.configuration.expose_credentials_key_names = true
+      end
+
+      after { FileUtils.rm_rf(custom_app.root) }
+
+      it 'returns empty array for credentials_keys on error' do
+        expect(described_class.new(custom_app).call[:credentials_keys]).to eq([])
+      end
+    end
+
+    context 'when app.config.time_zone raises an error' do
+      let(:app_root) { Pathname.new(Dir.mktmpdir) }
+      let(:custom_config) do
+        double('ApplicationConfig', cache_store: :memory_store,
+               session_store: ActionDispatch::Session::CookieStore)
+      end
+      let(:custom_app) do
+        double('Rails::Application', root: app_root,
+               paths: { 'app/models' => [] }, config: custom_config,
+               middleware: ActionDispatch::MiddlewareStack.new,
+               credentials: double('Credentials', config: {}))
+      end
+
+      before do
+        allow(custom_config).to receive(:time_zone).and_raise(StandardError, 'tz boom')
+        allow(custom_config).to receive(:respond_to?).with(:active_job).and_return(false)
+        allow(custom_config).to receive(:respond_to?).with(:action_cable).and_return(false)
+      end
+
+      after { FileUtils.rm_rf(app_root) }
+
+      it 'returns error hash' do
+        expect(described_class.new(custom_app).call[:error]).to eq('tz boom')
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/controller_introspector/filter_extractor_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/controller_introspector/filter_extractor_spec.rb
@@ -177,4 +177,137 @@ RSpec.describe RailsAiBridge::Introspectors::ControllerIntrospector::FilterExtra
         .not_to include('authenticate_user!')
     end
   end
+
+  describe 'private method edge cases' do
+    describe '#controller_actions' do
+      it 'returns empty array when controller does not respond to action_methods' do
+        ctrl = Object.new
+        extractor = described_class.new(ctrl)
+        expect(extractor.send(:controller_actions)).to eq([])
+      end
+
+      it 'returns empty array on error' do
+        ctrl = double('Ctrl')
+        allow(ctrl).to receive(:action_methods).and_raise(StandardError, 'actions error')
+        extractor = described_class.new(ctrl)
+        expect(extractor.send(:controller_actions)).to eq([])
+      end
+    end
+
+    describe '#controller_lineage' do
+      it 'returns only the controller when it is not a Class' do
+        ctrl = Object.new
+        extractor = described_class.new(ctrl)
+        expect(extractor.send(:controller_lineage)).to eq([ctrl])
+      end
+    end
+
+    describe '#safe_callbacks' do
+      it 'returns empty array on error' do
+        klass = double('Klass')
+        allow(klass).to receive(:_process_action_callbacks).and_raise(StandardError, 'callbacks error')
+        extractor = described_class.new(Object.new)
+        expect(extractor.send(:safe_callbacks, klass)).to eq([])
+      end
+    end
+
+    describe '#framework_controller?' do
+      it 'returns true for ActionController::Base' do
+        extractor = described_class.new(ApplicationController)
+        expect(extractor.send(:framework_controller?, ActionController::Base)).to be true
+      end
+
+      it 'returns true for nil name' do
+        anon = Class.new
+        extractor = described_class.new(ApplicationController)
+        expect(extractor.send(:framework_controller?, anon)).to be true
+      end
+
+      it 'returns false for user-defined controllers' do
+        extractor = described_class.new(ApplicationController)
+        expect(extractor.send(:framework_controller?, PostsController)).to be false
+      end
+    end
+
+    describe '#extract_action_conditions with nil' do
+      it 'returns empty array for nil conditions' do
+        extractor = described_class.new(ApplicationController)
+        expect(extractor.send(:extract_action_conditions, nil)).to eq([])
+      end
+    end
+
+    describe '#parse_action_condition with ActionFilter' do
+      it 'extracts actions from ActionFilter object' do
+        condition = double('ActionFilter')
+        allow(condition).to receive(:instance_variable_defined?).with(:@actions).and_return(true)
+        allow(condition).to receive(:instance_variable_get).with(:@actions).and_return(%i[index show])
+        extractor = described_class.new(ApplicationController)
+        expect(extractor.send(:parse_action_condition, condition)).to eq(%w[index show])
+      end
+
+      it 'returns nil when condition has no @actions and no action_name match' do
+        condition = double('Condition')
+        allow(condition).to receive(:instance_variable_defined?).with(:@actions).and_return(false)
+        allow(condition).to receive(:to_s).and_return('some_condition?')
+        extractor = described_class.new(ApplicationController)
+        expect(extractor.send(:parse_action_condition, condition)).to be_nil
+      end
+    end
+
+    describe '#included_in_effective_chain? with empty child chain' do
+      it 'returns true when child chain is empty' do
+        ctrl = Object.new
+        ctrl.define_singleton_method(:_process_action_callbacks) { [] }
+        extractor = described_class.new(ctrl)
+        callback = TestHelpers.build_callback(filter: :test_filter, kind: :before)
+        expect(extractor.send(:included_in_effective_chain?, callback)).to be true
+      end
+    end
+
+    describe '#inherited_into_child_chain? edge cases' do
+      it 'returns false when controller is not a Class' do
+        ctrl = Object.new
+        extractor = described_class.new(ctrl)
+        expect(extractor.send(:inherited_into_child_chain?)).to be false
+      end
+
+      it 'returns false when parent does not respond to _process_action_callbacks' do
+        ctrl = Class.new do
+          def self.name
+            'TestNoCallbacksParent'
+          end
+        end
+        extractor = described_class.new(ctrl)
+        expect(extractor.send(:inherited_into_child_chain?)).to be false
+      end
+
+      it 'returns false when parent chain is empty' do
+        parent = Class.new(ApplicationController) do
+          def self.name
+            'EmptyChainParent'
+          end
+        end
+        allow(parent).to receive(:_process_action_callbacks).and_return([])
+        ctrl = Class.new(parent) do
+          def self.name
+            'EmptyChainChild'
+          end
+        end
+        allow(ctrl).to receive(:_process_action_callbacks).and_return([])
+        extractor = described_class.new(ctrl)
+        expect(extractor.send(:inherited_into_child_chain?)).to be false
+      end
+    end
+
+    describe '#source_class_name with framework controller owner' do
+      it 'returns nil when the callback owner is a framework controller' do
+        extractor = described_class.new(ApplicationController)
+        # ActionController::Base is a framework controller
+        callback = TestHelpers.build_callback(filter: :test_filter, kind: :before)
+        allow(ActionController::Base).to receive(:_process_action_callbacks).and_return([callback])
+        result = extractor.send(:source_class_name, callback)
+        expect(result).to be_nil
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/controller_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/controller_introspector_spec.rb
@@ -194,5 +194,131 @@ RSpec.describe RailsAiBridge::Introspectors::ControllerIntrospector do
         expect(details[:respond_to_formats]).to eq(['json'])
       end
     end
+
+    context 'when ActionController is not defined' do
+      before { hide_const('ActionController::Base') }
+
+      it 'returns empty controllers hash' do
+        expect(result[:controllers]).to eq({})
+      end
+    end
+
+    context 'when a controller raises during extraction' do
+      before do
+        allow(introspector).to receive(:extract_controller_details).and_raise(StandardError, 'ctrl boom')
+        allow(Rails.logger).to receive(:debug)
+      end
+
+      it 'captures per-controller errors' do
+        expect(result[:controllers].values).to all(include(error: 'ctrl boom'))
+      end
+    end
+
+    context 'when call raises at top level' do
+      before { allow(introspector).to receive(:eager_load_controllers!).and_raise(StandardError, 'eager boom') }
+
+      it 'returns error hash' do
+        expect(result[:error]).to eq('eager boom')
+      end
+    end
+  end
+
+  describe 'private methods' do
+    describe '#extract_strong_params' do
+      it 'returns empty array for nil source' do
+        expect(introspector.send(:extract_strong_params, nil)).to eq([])
+      end
+
+      it 'finds params methods' do
+        source = "def user_params\n  params.require(:user)\nend\ndef post_params\nend\n"
+        expect(introspector.send(:extract_strong_params, source)).to contain_exactly('user_params', 'post_params')
+      end
+    end
+
+    describe '#extract_respond_to' do
+      it 'returns empty array for nil source' do
+        expect(introspector.send(:extract_respond_to, nil)).to eq([])
+      end
+
+      it 'returns empty array when no respond_to block' do
+        expect(introspector.send(:extract_respond_to, 'def index; end')).to eq([])
+      end
+    end
+
+    describe '#read_source' do
+      it 'returns nil when source path is nil' do
+        ctrl = double('Ctrl', name: 'Nonexistent')
+        allow(introspector).to receive(:source_path).and_return(nil)
+        expect(introspector.send(:read_source, ctrl)).to be_nil
+      end
+
+      it 'returns nil when file does not exist' do
+        ctrl = double('Ctrl', name: 'Nonexistent')
+        allow(introspector).to receive(:source_path).and_return('/nonexistent.rb')
+        expect(introspector.send(:read_source, ctrl)).to be_nil
+      end
+
+      it 'returns nil on file read error' do
+        ctrl = double('Ctrl', name: 'Bad')
+        path = '/tmp/test_ctrl_read.rb'
+        File.write(path, 'class Bad; end')
+        allow(introspector).to receive(:source_path).and_return(path)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(path).and_raise(StandardError, 'read error')
+        expect(introspector.send(:read_source, ctrl)).to be_nil
+      ensure
+        allow(File).to receive(:read).and_call_original
+        FileUtils.rm_f(path)
+      end
+    end
+
+    describe '#extract_actions error handling' do
+      it 'returns empty array on error' do
+        ctrl = double('Ctrl')
+        allow(ctrl).to receive(:action_methods).and_raise(StandardError, 'actions error')
+        expect(introspector.send(:extract_actions, ctrl)).to eq([])
+      end
+    end
+
+    describe '#extract_concerns error handling' do
+      it 'returns empty array on error' do
+        ctrl = double('Ctrl')
+        allow(ctrl).to receive(:ancestors).and_raise(StandardError, 'concerns error')
+        expect(introspector.send(:extract_concerns, ctrl)).to eq([])
+      end
+    end
+
+    describe '#api_controller?' do
+      it 'returns false when ActionController::API is not defined' do
+        ctrl = double('Ctrl')
+        hide_const('ActionController::API')
+        expect(introspector.send(:api_controller?, ctrl)).to be false
+      end
+    end
+
+    describe '#eager_load_controllers!' do
+      it 'does not call eager_load! when config.eager_load is true' do
+        allow(Rails.application.config).to receive(:eager_load).and_return(true)
+        allow(Rails.application).to receive(:eager_load!)
+        expect(Rails.application).not_to receive(:eager_load!)
+        introspector.send(:eager_load_controllers!)
+      end
+
+      it 'rescues errors from eager_load!' do
+        allow(Rails.application.config).to receive(:eager_load).and_return(false)
+        allow(Rails.application).to receive(:eager_load!).and_raise(StandardError, 'load error')
+        expect { introspector.send(:eager_load_controllers!) }.not_to raise_error
+      end
+    end
+
+    describe '#discover_controllers without ActionController::API' do
+      it 'still discovers controllers when API is not defined' do
+        # Ensure PostsController is loaded
+        expect(PostsController.name).to eq('PostsController')
+        hide_const('ActionController::API')
+        controllers = introspector.send(:discover_controllers)
+        expect(controllers).to include(PostsController)
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/convention_detector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/convention_detector_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe RailsAiBridge::Introspectors::ConventionDetector do
     let(:app_root) { Pathname.new(Dir.mktmpdir('conventions')) }
     let(:custom_app) do
       double('Rails::Application', root: app_root,
-             config: double('Config', api_only: true),
-             paths: {})
+                                   config: double('Config', api_only: true),
+                                   paths: {})
     end
     let(:introspector) { described_class.new(custom_app) }
     let(:result) { introspector.call }

--- a/spec/lib/rails_ai_bridge/introspectors/convention_detector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/convention_detector_spec.rb
@@ -40,39 +40,157 @@ RSpec.describe RailsAiBridge::Introspectors::ConventionDetector do
       expect(result[:config_files]).not_to include('config/credentials.yml.enc')
       expect(result[:config_files]).not_to include('config/master.key')
     end
+  end
 
-    context 'with custom Rails directory paths' do
-      let(:tmpdir) { Dir.mktmpdir('rails-ai-bridge-conventions') }
-      let(:service_dir) { File.join(tmpdir, 'domain', 'services') }
-      let(:models_dir) { File.join(tmpdir, 'domain', 'models') }
-      let(:custom_app) do
-        instance_double(
-          Rails::Application,
-          root: Pathname.new(tmpdir),
-          config: instance_double(Rails::Application::Configuration, api_only: false),
-          paths: {
-            'app/services' => [service_dir],
-            'app/models' => [models_dir]
-          }
-        )
-      end
-      let(:introspector) { described_class.new(custom_app) }
+  describe '#call with custom app root' do
+    let(:app_root) { Pathname.new(Dir.mktmpdir('conventions')) }
+    let(:custom_app) do
+      double('Rails::Application', root: app_root,
+             config: double('Config', api_only: true),
+             paths: {})
+    end
+    let(:introspector) { described_class.new(custom_app) }
+    let(:result) { introspector.call }
 
+    after { FileUtils.rm_rf(app_root) }
+
+    it 'detects api_only architecture' do
+      expect(result[:architecture]).to include('api_only')
+    end
+
+    context 'with various architecture directories' do
       before do
-        FileUtils.mkdir_p(service_dir)
-        FileUtils.mkdir_p(models_dir)
-        File.write(File.join(service_dir, 'sync_customer.rb'), "class SyncCustomer\nend\n")
-        File.write(File.join(models_dir, 'secure_profile.rb'), "class SecureProfile\n  encrypts :ssn\nend\n")
+        FileUtils.mkdir_p(app_root.join('app/graphql'))
+        FileUtils.mkdir_p(app_root.join('app/api'))
+        FileUtils.mkdir_p(app_root.join('app/forms'))
+        FileUtils.mkdir_p(app_root.join('app/queries'))
+        FileUtils.mkdir_p(app_root.join('app/presenters'))
+        FileUtils.mkdir_p(app_root.join('app/components'))
+        FileUtils.mkdir_p(app_root.join('app/models/concerns'))
+        FileUtils.mkdir_p(app_root.join('app/controllers/concerns'))
+        FileUtils.mkdir_p(app_root.join('app/validators'))
+        FileUtils.mkdir_p(app_root.join('app/policies'))
+        FileUtils.mkdir_p(app_root.join('app/serializers'))
+        FileUtils.mkdir_p(app_root.join('app/notifiers'))
+        FileUtils.mkdir_p(app_root.join('app/javascript/controllers'))
+        FileUtils.mkdir_p(app_root.join('app/decorators'))
+        FileUtils.mkdir_p(app_root.join('.github/workflows'))
+        FileUtils.mkdir_p(app_root.join('app/views/pwa'))
+        FileUtils.mkdir_p(app_root.join('config'))
+        File.write(app_root.join('config/importmap.rb'), 'pin "application"')
+        File.write(app_root.join('Dockerfile'), 'FROM ruby:3.3')
+        File.write(app_root.join('config/deploy.yml'), 'service: app')
       end
 
-      after { FileUtils.remove_entry(tmpdir) }
-
-      it 'detects architecture from configured Rails paths without exposing absolute paths' do
-        expect(result[:architecture]).to include('service_objects')
-        expect(result[:patterns]).to include('encrypted_attributes')
-        expect(result[:directory_structure]).to include('app/services' => 1, 'app/models' => 1)
-        expect(result[:directory_structure].keys.join).not_to include(tmpdir)
+      it 'detects all architecture features' do
+        arch = result[:architecture]
+        expect(arch).to include('graphql', 'grape_api', 'form_objects', 'query_objects',
+                                'presenters', 'view_components', 'hotwire', 'stimulus',
+                                'importmaps', 'concerns_models', 'concerns_controllers',
+                                'validators', 'policies', 'serializers', 'notifiers',
+                                'pwa', 'docker', 'kamal', 'ci_github_actions')
       end
+    end
+
+    context 'with model patterns' do
+      before do
+        FileUtils.mkdir_p(app_root.join('app/models'))
+        File.write(app_root.join('app/models/user.rb'), <<~RUBY)
+          class User < ApplicationRecord
+            has_many :posts, polymorphic: true
+            acts_as_paranoid
+            has_paper_trail
+            aasm column: :status
+            acts_as_tenant :account
+            searchkick
+            acts_as_taggable_on :tags
+            friendly_id :slug
+            acts_as_nested_set
+            encrypts :ssn
+            normalizes :email
+          end
+        RUBY
+      end
+
+      it 'detects all source patterns' do
+        patterns = result[:patterns]
+        expect(patterns).to include('polymorphic', 'soft_delete', 'versioning',
+                                    'state_machine', 'multi_tenancy', 'searchable',
+                                    'taggable', 'sluggable', 'nested_set',
+                                    'encrypted_attributes', 'normalizations')
+      end
+    end
+
+    context 'with unreadable model file' do
+      before do
+        FileUtils.mkdir_p(app_root.join('app/models'))
+        path = app_root.join('app/models/bad.rb').to_s
+        File.write(path, 'class Bad; end')
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(path).and_raise(StandardError, 'read error')
+      end
+
+      after { allow(File).to receive(:read).and_call_original }
+
+      it 'handles file read errors gracefully in detect_patterns' do
+        expect(result[:patterns]).to be_an(Array)
+      end
+    end
+
+    context 'with no Gemfile.lock' do
+      it 'returns false for gem_present?' do
+        expect(introspector.send(:gem_present?, 'turbo-rails')).to be false
+      end
+    end
+
+    context 'with Gemfile.lock containing turbo-rails' do
+      before { File.write(app_root.join('Gemfile.lock'), "    turbo-rails (2.0.0)\n") }
+
+      it 'detects gem presence' do
+        expect(introspector.send(:gem_present?, 'turbo-rails')).to be true
+      end
+    end
+  end
+
+  describe '.log_error' do
+    it 'logs warning and handles missing Rails.logger' do
+      error = StandardError.new('test error')
+      expect { described_class.log_error(error) }.not_to raise_error
+    end
+  end
+
+  describe '#call with custom Rails directory paths' do
+    let(:tmpdir) { Dir.mktmpdir('rails-ai-bridge-conventions') }
+    let(:service_dir) { File.join(tmpdir, 'domain', 'services') }
+    let(:models_dir) { File.join(tmpdir, 'domain', 'models') }
+    let(:custom_app) do
+      instance_double(
+        Rails::Application,
+        root: Pathname.new(tmpdir),
+        config: instance_double(Rails::Application::Configuration, api_only: false),
+        paths: {
+          'app/services' => [service_dir],
+          'app/models' => [models_dir]
+        }
+      )
+    end
+    let(:introspector) { described_class.new(custom_app) }
+    let(:result) { introspector.call }
+
+    before do
+      FileUtils.mkdir_p(service_dir)
+      FileUtils.mkdir_p(models_dir)
+      File.write(File.join(service_dir, 'sync_customer.rb'), "class SyncCustomer\nend\n")
+      File.write(File.join(models_dir, 'secure_profile.rb'), "class SecureProfile\n  encrypts :ssn\nend\n")
+    end
+
+    after { FileUtils.remove_entry(tmpdir) }
+
+    it 'detects architecture from configured Rails paths without exposing absolute paths' do
+      expect(result[:architecture]).to include('service_objects')
+      expect(result[:patterns]).to include('encrypted_attributes')
+      expect(result[:directory_structure]).to include('app/services' => 1, 'app/models' => 1)
+      expect(result[:directory_structure].keys.join).not_to include(tmpdir)
     end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/database_stats_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/database_stats_introspector_spec.rb
@@ -31,5 +31,51 @@ RSpec.describe RailsAiBridge::Introspectors::DatabaseStatsIntrospector do
         { table: 'users', approximate_rows: 75_000, size_bucket: 'medium' }
       )
     end
+
+    it 'returns error hash on connection error' do
+      allow(ActiveRecord::Base).to receive(:connection).and_raise(StandardError, 'connection failed')
+
+      result = introspector.call
+      expect(result[:error]).to eq('connection failed')
+    end
+
+    context 'when ActiveRecord is not defined' do
+      before { hide_const('ActiveRecord') }
+
+      it 'returns skipped with reason' do
+        result = introspector.call
+        expect(result[:skipped]).to be(true)
+        expect(result[:reason]).to eq('ActiveRecord not available')
+      end
+    end
+
+    context 'with MySQL adapter' do
+      it 'returns skipped with adapter name in reason' do
+        connection = instance_double(
+          ActiveRecord::ConnectionAdapters::AbstractAdapter,
+          adapter_name: 'MySQL'
+        )
+        allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+
+        result = introspector.call
+        expect(result[:skipped]).to be(true)
+        expect(result[:reason]).to include('mysql')
+      end
+    end
+
+    context 'with empty PostgreSQL result' do
+      it 'returns zero total_tables' do
+        connection = instance_double(
+          ActiveRecord::ConnectionAdapters::AbstractAdapter,
+          adapter_name: 'PostgreSQL',
+          select_all: []
+        )
+        allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+
+        result = introspector.call
+        expect(result[:total_tables]).to eq(0)
+        expect(result[:tables]).to eq([])
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/devops_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/devops_introspector_spec.rb
@@ -108,4 +108,138 @@ RSpec.describe RailsAiBridge::Introspectors::DevOpsIntrospector do
       end
     end
   end
+
+  describe '#call with custom app root' do
+    let(:app_root) { Pathname.new(Dir.mktmpdir('devops')) }
+    let(:custom_app) { double('Rails::Application', root: app_root) }
+    let(:introspector) { described_class.new(custom_app) }
+    let(:result) { introspector.call }
+
+    after { FileUtils.rm_rf(app_root) }
+
+    context 'with kamal deploy config' do
+      before { FileUtils.mkdir_p(app_root.join('config')); File.write(app_root.join('config/deploy.yml'), 'service: app') }
+
+      it 'detects kamal as deployment tool' do
+        expect(result[:deployment]).to eq('kamal')
+      end
+    end
+
+    context 'with Capfile' do
+      before { File.write(app_root.join('Capfile'), "require 'capistrano/setup'") }
+
+      it 'detects capistrano as deployment tool' do
+        expect(result[:deployment]).to eq('capistrano')
+      end
+    end
+
+    context 'with app.json (heroku)' do
+      before { File.write(app_root.join('app.json'), '{"name": "app"}') }
+
+      it 'detects heroku as deployment tool' do
+        expect(result[:deployment]).to eq('heroku')
+      end
+    end
+
+    context 'with Procfile (heroku)' do
+      before { File.write(app_root.join('Procfile'), 'web: bundle exec puma') }
+
+      it 'detects heroku as deployment tool from Procfile' do
+        expect(result[:deployment]).to eq('heroku')
+      end
+    end
+
+    context 'with Procfile.dev' do
+      before { File.write(app_root.join('Procfile.dev'), "web: puma\njs: yarn build") }
+
+      it 'parses Procfile.dev entries' do
+        files = result[:procfile].map { |p| p[:file] }
+        expect(files).to include('Procfile.dev')
+      end
+    end
+
+    context 'with Procfile with comments and empty lines' do
+      before do
+        File.write(app_root.join('Procfile'), <<~PROCFILE)
+          # This is a comment
+
+          web: bundle exec puma
+        PROCFILE
+      end
+
+      it 'skips comments and empty lines' do
+        entries = result[:procfile].flat_map { |p| p[:entries] }
+        expect(entries.size).to eq(1)
+        expect(entries.first[:name]).to eq('web')
+      end
+    end
+
+    context 'with Procfile with malformed line' do
+      before { File.write(app_root.join('Procfile'), 'just-a-line-without-colon') }
+
+      it 'skips lines without colon' do
+        entries = result[:procfile].flat_map { |p| p[:entries] }
+        expect(entries).to eq([])
+      end
+    end
+
+    context 'with empty Procfile' do
+      before { File.write(app_root.join('Procfile'), '') }
+
+      it 'returns empty procfile array' do
+        expect(result[:procfile]).to eq([])
+      end
+    end
+
+    context 'with puma.rb but no recognizable config' do
+      before do
+        FileUtils.mkdir_p(app_root.join('config'))
+        File.write(app_root.join('config/puma.rb'), '# just a comment')
+      end
+
+      it 'returns nil for puma when no config extracted' do
+        expect(result[:puma]).to be_nil
+      end
+    end
+
+    context 'with Dockerfile with single FROM' do
+      before do
+        File.write(app_root.join('Dockerfile'), 'FROM ruby:3.3-slim')
+        File.write(app_root.join('docker-compose.yml'), 'version: 3')
+      end
+
+      it 'detects single-stage build and compose file' do
+        expect(result[:docker][:multi_stage]).to be false
+        expect(result[:docker][:compose]).to be true
+      end
+    end
+
+    context 'with no routes.rb' do
+      it 'returns nil for health_check' do
+        expect(result[:health_check]).to be_nil
+      end
+    end
+
+    context 'with routes.rb without health check' do
+      before do
+        FileUtils.mkdir_p(app_root.join('config'))
+        File.write(app_root.join('config/routes.rb'), 'Rails.application.routes.draw { resources :posts }')
+      end
+
+      it 'returns nil for health_check when no health route' do
+        expect(result[:health_check]).to be_nil
+      end
+    end
+  end
+
+  describe '#call when app.root raises' do
+    let(:bad_app) { double('Rails::Application') }
+    let(:result) { described_class.new(bad_app).call }
+
+    before { allow(bad_app).to receive(:root).and_raise(StandardError, 'root boom') }
+
+    it 'returns error hash' do
+      expect(result[:error]).to eq('root boom')
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/devops_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/devops_introspector_spec.rb
@@ -118,7 +118,10 @@ RSpec.describe RailsAiBridge::Introspectors::DevOpsIntrospector do
     after { FileUtils.rm_rf(app_root) }
 
     context 'with kamal deploy config' do
-      before { FileUtils.mkdir_p(app_root.join('config')); File.write(app_root.join('config/deploy.yml'), 'service: app') }
+      before do
+        FileUtils.mkdir_p(app_root.join('config'))
+        File.write(app_root.join('config/deploy.yml'), 'service: app')
+      end
 
       it 'detects kamal as deployment tool' do
         expect(result[:deployment]).to eq('kamal')
@@ -153,7 +156,7 @@ RSpec.describe RailsAiBridge::Introspectors::DevOpsIntrospector do
       before { File.write(app_root.join('Procfile.dev'), "web: puma\njs: yarn build") }
 
       it 'parses Procfile.dev entries' do
-        files = result[:procfile].map { |p| p[:file] }
+        files = result[:procfile].pluck(:file)
         expect(files).to include('Procfile.dev')
       end
     end

--- a/spec/lib/rails_ai_bridge/introspectors/engine_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/engine_introspector_spec.rb
@@ -96,4 +96,78 @@ RSpec.describe RailsAiBridge::Introspectors::EngineIntrospector do
       expect(result[:error]).to be_nil
     end
   end
+
+  describe '#call with no routes.rb' do
+    let(:app_root) { Pathname.new(Dir.mktmpdir('no-routes')) }
+    let(:custom_app) { double('Rails::Application', root: app_root) }
+    let(:result) { described_class.new(custom_app).call }
+
+    after { FileUtils.rm_rf(app_root) }
+
+    it 'returns empty array for mounted_engines when routes.rb does not exist' do
+      expect(result[:mounted_engines]).to eq([])
+    end
+  end
+
+  describe '#call with mount without path (fallback regex)' do
+    let(:app_root) { Pathname.new(Dir.mktmpdir('engine-fallback')) }
+    let(:routes_path) { app_root.join('config/routes.rb') }
+    let(:custom_app) { double('Rails::Application', root: app_root) }
+    let(:result) { described_class.new(custom_app).call }
+
+    before do
+      FileUtils.mkdir_p(app_root.join('config'))
+      File.write(routes_path, <<~RUBY)
+        Rails.application.routes.draw do
+          mount Sidekiq::Web
+          resources :posts
+        end
+      RUBY
+    end
+
+    after { FileUtils.rm_rf(app_root) }
+
+    it 'discovers engines via fallback regex with unknown path' do
+      sidekiq = result[:mounted_engines].find { |e| e[:engine] == 'Sidekiq::Web' }
+      expect(sidekiq).not_to be_nil
+      expect(sidekiq[:path]).to eq('unknown')
+      expect(sidekiq[:category]).to eq('admin')
+    end
+  end
+
+  describe '#call with unknown engine (not in KNOWN_ENGINES)' do
+    let(:app_root) { Pathname.new(Dir.mktmpdir('engine-unknown')) }
+    let(:routes_path) { app_root.join('config/routes.rb') }
+    let(:custom_app) { double('Rails::Application', root: app_root) }
+    let(:result) { described_class.new(custom_app).call }
+
+    before do
+      FileUtils.mkdir_p(app_root.join('config'))
+      File.write(routes_path, <<~RUBY)
+        Rails.application.routes.draw do
+          mount SomeCustom::Engine => "/custom"
+        end
+      RUBY
+    end
+
+    after { FileUtils.rm_rf(app_root) }
+
+    it 'includes engine without category or description' do
+      engine = result[:mounted_engines].find { |e| e[:engine] == 'SomeCustom::Engine' }
+      expect(engine).not_to be_nil
+      expect(engine).not_to have_key(:category)
+      expect(engine).not_to have_key(:description)
+    end
+  end
+
+  describe '#call when app.root raises' do
+    let(:bad_app) { double('Rails::Application') }
+    let(:result) { described_class.new(bad_app).call }
+
+    before { allow(bad_app).to receive(:root).and_raise(StandardError, 'root boom') }
+
+    it 'returns error hash' do
+      expect(result[:error]).to eq('root boom')
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/i18n_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/i18n_introspector_spec.rb
@@ -62,5 +62,45 @@ RSpec.describe RailsAiBridge::Introspectors::I18nIntrospector do
         expect(bad_file[:parse_error]).to be true
       end
     end
+
+    context 'with a .rb locale file' do
+      let(:rb_locale) { Rails.root.join('config/locales/custom.rb').to_s }
+
+      before { File.write(rb_locale, "I18n.backend.store_translations(:en, hello: 'Hi')") }
+      after { FileUtils.rm_f(rb_locale) }
+
+      it 'includes .rb locale files without key_count' do
+        rb_file = result[:locale_files].find { |f| f[:file] == 'custom.rb' }
+        expect(rb_file).not_to be_nil
+        expect(rb_file).not_to have_key(:key_count)
+      end
+    end
+  end
+
+  describe '#call with no config/locales directory' do
+    let(:app_root) { Pathname.new(Dir.mktmpdir('no-locales')) }
+    let(:custom_app) { double('Rails::Application', root: app_root) }
+    let(:result) { described_class.new(custom_app).call }
+
+    after { FileUtils.rm_rf(app_root) }
+
+    it 'returns empty array for locale_files' do
+      expect(result[:locale_files]).to eq([])
+    end
+
+    it 'returns 0 for total_locale_files' do
+      expect(result[:total_locale_files]).to eq(0)
+    end
+  end
+
+  describe '#call when app.root raises' do
+    let(:bad_app) { double('Rails::Application') }
+    let(:result) { described_class.new(bad_app).call }
+
+    before { allow(bad_app).to receive(:root).and_raise(StandardError, 'root boom') }
+
+    it 'returns error hash' do
+      expect(result[:error]).to eq('root boom')
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/job_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/job_introspector_spec.rb
@@ -129,5 +129,123 @@ RSpec.describe RailsAiBridge::Introspectors::JobIntrospector do
         expect(result).to eq({ jobs: [], mailers: [], channels: [] })
       end
     end
+
+    context 'when ActiveJob is not defined' do
+      before { hide_const('ActiveJob::Base') }
+
+      it 'returns empty jobs array' do
+        expect(result[:jobs]).to eq([])
+      end
+    end
+
+    context 'when ActionMailer is not defined' do
+      before { hide_const('ActionMailer::Base') }
+
+      it 'returns empty mailers array' do
+        expect(result[:mailers]).to eq([])
+      end
+    end
+
+    context 'when ActionCable is not defined' do
+      before { hide_const('ActionCable::Channel::Base') }
+
+      it 'returns empty channels array' do
+        expect(result[:channels]).to eq([])
+      end
+    end
+
+    context 'with framework jobs filtered out' do
+      before do
+        framework_job = Class.new(ActiveJob::Base) do
+          def self.name
+            'ActionMailer::MailDeliveryJob'
+          end
+
+          def self.queue_name
+            'mailers'
+          end
+        end
+        turbo_job = Class.new(ActiveJob::Base) do
+          def self.name
+            'Turbo::Streams::BroadcastStreamJob'
+          end
+
+          def self.queue_name
+            'default'
+          end
+        end
+        sentry_job = Class.new(ActiveJob::Base) do
+          def self.name
+            'Sentry::SendEventJob'
+          end
+
+          def self.queue_name
+            'default'
+          end
+        end
+        app_job = Class.new(ActiveJob::Base) do
+          def self.name
+            'ProcessOrderJob'
+          end
+
+          def self.queue_name
+            'default'
+          end
+
+          def self.priority
+            nil
+          end
+        end
+        allow(ActiveJob::Base).to receive(:descendants).and_return([framework_job, turbo_job, sentry_job, app_job])
+      end
+
+      it 'excludes framework jobs' do
+        names = result[:jobs].map { |j| j[:name] }
+        expect(names).to eq(['ProcessOrderJob'])
+      end
+    end
+
+    context 'with mailer having no instance methods' do
+      before do
+        empty_mailer = Class.new(ActionMailer::Base) do
+          def self.name
+            'EmptyMailer'
+          end
+
+          def self.delivery_method
+            :test
+          end
+        end
+        allow(ActionMailer::Base).to receive(:descendants).and_return([empty_mailer])
+      end
+
+      it 'excludes mailers with no actions' do
+        names = result[:mailers].map { |m| m[:name] }
+        expect(names).not_to include('EmptyMailer')
+      end
+    end
+
+    context 'with ApplicationCable::Channel filtered out' do
+      before do
+        app_channel = Class.new(ActionCable::Channel::Base) do
+          def self.name
+            'ApplicationCable::Channel'
+          end
+        end
+        real_channel = Class.new(ActionCable::Channel::Base) do
+          def self.name
+            'ChatChannel'
+          end
+
+          def subscribed; end
+        end
+        allow(ActionCable::Channel::Base).to receive(:descendants).and_return([app_channel, real_channel])
+      end
+
+      it 'excludes ApplicationCable::Channel' do
+        names = result[:channels].map { |c| c[:name] }
+        expect(names).to eq(['ChatChannel'])
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/job_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/job_introspector_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe RailsAiBridge::Introspectors::JobIntrospector do
       end
 
       it 'excludes framework jobs' do
-        names = result[:jobs].map { |j| j[:name] }
+        names = result[:jobs].pluck(:name)
         expect(names).to eq(['ProcessOrderJob'])
       end
     end
@@ -220,7 +220,7 @@ RSpec.describe RailsAiBridge::Introspectors::JobIntrospector do
       end
 
       it 'excludes mailers with no actions' do
-        names = result[:mailers].map { |m| m[:name] }
+        names = result[:mailers].pluck(:name)
         expect(names).not_to include('EmptyMailer')
       end
     end
@@ -243,7 +243,7 @@ RSpec.describe RailsAiBridge::Introspectors::JobIntrospector do
       end
 
       it 'excludes ApplicationCable::Channel' do
-        names = result[:channels].map { |c| c[:name] }
+        names = result[:channels].pluck(:name)
         expect(names).to eq(['ChatChannel'])
       end
     end

--- a/spec/lib/rails_ai_bridge/introspectors/middleware_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/middleware_introspector_spec.rb
@@ -87,4 +87,139 @@ RSpec.describe RailsAiBridge::Introspectors::MiddlewareIntrospector do
       expect(result[:error]).to be_nil
     end
   end
+
+  describe '#call with no app/middleware directory' do
+    let(:result) { introspector.call }
+
+    before { FileUtils.rm_rf(middleware_dir) }
+
+    it 'returns empty custom_middleware array' do
+      expect(result[:custom_middleware]).to eq([])
+    end
+  end
+
+  describe '#call with middleware patterns' do
+    let(:result) { introspector.call }
+
+    before do
+      File.write(File.join(middleware_dir, 'auth_middleware.rb'), <<~RUBY)
+        class AuthMiddleware
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            token = env['HTTP_AUTHORIZATION']
+            @app.call(env)
+          end
+        end
+      RUBY
+
+      File.write(File.join(middleware_dir, 'cors_middleware.rb'), <<~RUBY)
+        class CorsMiddleware
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            headers = { 'Access-Control-Allow-Origin' => '*' }
+            @app.call(env)
+          end
+        end
+      RUBY
+
+      File.write(File.join(middleware_dir, 'rate_limiter.rb'), <<~RUBY)
+        class RateLimiter
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            @app.call(env)
+          end
+        end
+      RUBY
+
+      File.write(File.join(middleware_dir, 'cache_middleware.rb'), <<~RUBY)
+        class CacheMiddleware
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            etag = env['HTTP_IF_NONE_MATCH']
+            @app.call(env)
+          end
+        end
+      RUBY
+
+      File.write(File.join(middleware_dir, 'error_handler.rb'), <<~RUBY)
+        class ErrorHandler
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            @app.call(env)
+          rescue StandardError => e
+            [500, {}, ['error']]
+          end
+        end
+      RUBY
+    end
+
+    it 'detects authentication pattern' do
+      auth = result[:custom_middleware].find { |m| m[:class_name] == 'AuthMiddleware' }
+      expect(auth[:detected_patterns]).to include('authentication')
+    end
+
+    it 'detects cors pattern' do
+      cors = result[:custom_middleware].find { |m| m[:class_name] == 'CorsMiddleware' }
+      expect(cors[:detected_patterns]).to include('cors')
+    end
+
+    it 'detects rate_limiting pattern' do
+      rate = result[:custom_middleware].find { |m| m[:class_name] == 'RateLimiter' }
+      expect(rate[:detected_patterns]).to include('rate_limiting')
+    end
+
+    it 'detects caching pattern' do
+      cache = result[:custom_middleware].find { |m| m[:class_name] == 'CacheMiddleware' }
+      expect(cache[:detected_patterns]).to include('caching')
+    end
+
+    it 'detects error_handling pattern' do
+      err = result[:custom_middleware].find { |m| m[:class_name] == 'ErrorHandler' }
+      expect(err[:detected_patterns]).to include('error_handling')
+    end
+  end
+
+  describe '#call with unreadable middleware file' do
+    let(:bad_file) { File.join(middleware_dir, 'bad_middleware.rb') }
+    let(:result) { introspector.call }
+
+    before do
+      File.write(bad_file, 'class BadMiddleware; end')
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(bad_file).and_raise(StandardError, 'read error')
+    end
+
+    after { allow(File).to receive(:read).and_call_original }
+
+    it 'includes error entry for unreadable middleware' do
+      bad = result[:custom_middleware].find { |m| m[:file] == 'app/middleware/bad_middleware.rb' }
+      expect(bad[:error]).to eq('read error')
+    end
+  end
+
+  describe '#call when app.root raises' do
+    let(:bad_app) { double('Rails::Application') }
+    let(:result) { described_class.new(bad_app).call }
+
+    before { allow(bad_app).to receive(:root).and_raise(StandardError, 'root boom') }
+
+    it 'returns error hash' do
+      expect(result[:error]).to eq('root boom')
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/migration_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/migration_introspector_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe RailsAiBridge::Introspectors::MigrationIntrospector do
 
     it 'detects pending migrations after schema version' do
       pending = result[:pending]
-      pending_versions = pending.map { |m| m[:version] }
+      pending_versions = pending.pluck(:version)
       expect(pending_versions).to include('20240320090000')
       expect(pending_versions).not_to include('20240101120000')
     end
@@ -136,6 +136,7 @@ RSpec.describe RailsAiBridge::Introspectors::MigrationIntrospector do
       original_schema
       FileUtils.rm_f(schema_path)
     end
+
     after do
       if original_schema
         File.write(schema_path, original_schema)

--- a/spec/lib/rails_ai_bridge/introspectors/migration_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/migration_introspector_spec.rb
@@ -87,6 +87,8 @@ RSpec.describe RailsAiBridge::Introspectors::MigrationIntrospector do
     let(:result) { introspector.call }
 
     before { FileUtils.rm_rf(migrate_dir) }
+    # Clean up migration files created by the outer before hook
+    after { FileUtils.rm_rf(migrate_dir) }
 
     it 'returns total of 0' do
       expect(result[:total]).to eq(0)

--- a/spec/lib/rails_ai_bridge/introspectors/migration_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/migration_introspector_spec.rb
@@ -82,4 +82,127 @@ RSpec.describe RailsAiBridge::Introspectors::MigrationIntrospector do
       expect(result[:error]).to be_nil
     end
   end
+
+  describe '#call with no migrate dir' do
+    let(:result) { introspector.call }
+
+    before { FileUtils.rm_rf(migrate_dir) }
+
+    it 'returns total of 0' do
+      expect(result[:total]).to eq(0)
+    end
+
+    it 'returns empty migration_stats' do
+      expect(result[:migration_stats]).to eq({})
+    end
+  end
+
+  describe '#call with schema version' do
+    let(:schema_path) { File.join(app.root.to_s, 'db/schema.rb') }
+    let(:original_schema) { File.exist?(schema_path) ? File.read(schema_path) : nil }
+    let(:result) { introspector.call }
+
+    before do
+      original_schema
+      File.write(schema_path, "ActiveRecord::Schema[7.1].define(version: 2024_02_15_08_00_00) do\nend\n")
+    end
+
+    after do
+      if original_schema
+        File.write(schema_path, original_schema)
+      else
+        FileUtils.rm_f(schema_path)
+      end
+    end
+
+    it 'detects schema version from schema.rb' do
+      expect(result[:schema_version]).to eq('20240215080000')
+    end
+
+    it 'detects pending migrations after schema version' do
+      pending = result[:pending]
+      pending_versions = pending.map { |m| m[:version] }
+      expect(pending_versions).to include('20240320090000')
+      expect(pending_versions).not_to include('20240101120000')
+    end
+  end
+
+  describe '#call with no schema.rb' do
+    let(:schema_path) { File.join(app.root.to_s, 'db/schema.rb') }
+    let(:original_schema) { File.exist?(schema_path) ? File.read(schema_path) : nil }
+    let(:result) { introspector.call }
+
+    before do
+      original_schema
+      FileUtils.rm_f(schema_path)
+    end
+    after do
+      if original_schema
+        File.write(schema_path, original_schema)
+      else
+        FileUtils.rm_f(schema_path)
+      end
+    end
+
+    it 'returns nil schema_version' do
+      expect(result[:schema_version]).to be_nil
+    end
+
+    it 'returns empty pending migrations when no schema version' do
+      expect(result[:pending]).to eq([])
+    end
+  end
+
+  describe '#call with unreadable migration file' do
+    let(:bad_migration) { File.join(migrate_dir, '20240101000000_bad.rb') }
+    let(:result) { introspector.call }
+
+    before do
+      File.write(bad_migration, 'not valid ruby')
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(bad_migration).and_raise(StandardError, 'read error')
+    end
+
+    after { allow(File).to receive(:read).and_call_original }
+
+    it 'includes error entry for unreadable migration' do
+      bad = result[:recent].find { |m| m[:version] == 'unknown' }
+      expect(bad).not_to be_nil
+      expect(bad[:name]).to eq('20240101000000_bad.rb')
+      expect(bad[:error]).to eq('read error')
+    end
+  end
+
+  describe '#call with short version migration' do
+    let(:short_version_migration) { File.join(migrate_dir, '123_create_short.rb') }
+    let(:result) { introspector.call }
+
+    before do
+      File.write(short_version_migration, <<~RUBY)
+        class CreateShort < ActiveRecord::Migration[7.1]
+          def change
+            create_table :shorts
+          end
+        end
+      RUBY
+    end
+
+    after { FileUtils.rm_f(short_version_migration) }
+
+    it 'groups short version migrations under unknown year' do
+      stats = result[:migration_stats]
+      expect(stats[:by_year]).to have_key('unknown')
+    end
+  end
+
+  describe '#call when app.root raises' do
+    let(:bad_app) { double('Rails::Application') }
+    let(:result) { described_class.new(bad_app).call }
+
+    before { allow(bad_app).to receive(:root).and_raise(StandardError, 'root boom') }
+
+    it 'returns error hash' do
+      expect(result[:error]).to eq('root boom')
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/model_introspector_spec.rb
@@ -113,6 +113,67 @@ RSpec.describe RailsAiBridge::Introspectors::ModelIntrospector do
     end
   end
 
+  describe '#call with excluded_models configured' do
+    subject(:result) { described_class.new(Rails.application).call }
+
+    before { RailsAiBridge.configuration.excluded_models << 'User' }
+    after { RailsAiBridge.configuration.excluded_models.delete('User') }
+
+    it 'omits excluded models by name' do
+      expect(result).not_to have_key('User')
+      expect(result).to have_key('Post')
+    end
+  end
+
+  describe 'error handling in #call' do
+    it 'captures per-model errors as { error: } hashes' do
+      bad_model = double('BadModel', name: 'BadModel', table_name: 'bad_models',
+                                     abstract_class?: false, ancestors: [],
+                                     validators: [], defined_enums: {})
+      allow(bad_model).to receive(:respond_to?).with(:defined_enums).and_return(true)
+      allow(introspector).to receive(:discover_models).and_return([bad_model])
+      allow(introspector).to receive(:extract_model_details).and_raise(StandardError, 'model boom')
+
+      result = introspector.call
+      expect(result['BadModel']).to eq({ error: 'model boom' })
+    end
+  end
+
+  describe 'extract_scopes edge cases' do
+    it 'returns empty array when source path is nil' do
+      model = double('Model', name: 'Nonexistent')
+      expect(introspector.send(:extract_scopes, model)).to eq([])
+    end
+
+    it 'returns empty array on file read error' do
+      model = double('Model', name: 'User')
+      allow(introspector).to receive(:model_source_path).and_return('/fake/path.rb')
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('/fake/path.rb').and_return(true)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with('/fake/path.rb').and_raise(StandardError, 'read error')
+      expect(introspector.send(:extract_scopes, model)).to eq([])
+    end
+  end
+
+  describe 'extract_enums edge cases' do
+    it 'returns empty hash when model does not respond to defined_enums' do
+      model = double('Model')
+      allow(model).to receive(:respond_to?).with(:defined_enums).and_return(false)
+      expect(introspector.send(:extract_enums, model)).to eq({})
+    end
+  end
+
+  describe 'sanitize_options' do
+    it 'rejects Proc and Regexp values and stringifies the rest' do
+      options = { if: -> { true }, unless: /admin/, message: 'hello', allow_nil: true }
+      result = introspector.send(:sanitize_options, options)
+      expect(result).to eq({ message: 'hello', allow_nil: 'true' })
+      expect(result).not_to have_key(:if)
+      expect(result).not_to have_key(:unless)
+    end
+  end
+
   describe '#extract_source_macros (private)' do
     let(:fixture_model) { Rails.root.join('app/models/employee.rb').to_s }
     let(:fake_model) { double(name: 'Employee') }

--- a/spec/lib/rails_ai_bridge/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/model_introspector_spec.rb
@@ -116,8 +116,13 @@ RSpec.describe RailsAiBridge::Introspectors::ModelIntrospector do
   describe '#call with excluded_models configured' do
     subject(:result) { described_class.new(Rails.application).call }
 
-    before { RailsAiBridge.configuration.excluded_models << 'User' }
-    after { RailsAiBridge.configuration.excluded_models.delete('User') }
+    let!(:saved_excluded) { RailsAiBridge.configuration.excluded_models.dup }
+
+    before do
+      RailsAiBridge.configuration.excluded_models << 'User'
+    end
+
+    after { RailsAiBridge.configuration.excluded_models.replace(saved_excluded) }
 
     it 'omits excluded models by name' do
       expect(result).not_to have_key('User')

--- a/spec/lib/rails_ai_bridge/introspectors/model_semantic_enrichment_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/model_semantic_enrichment_spec.rb
@@ -112,5 +112,40 @@ RSpec.describe RailsAiBridge::Introspectors::ModelSemanticEnrichment do
       allow(adapter).to receive(:get_declaration).and_raise(StandardError)
       expect(instance.send(:calculate_complexity_score, model)).to be_nil
     end
+
+    it 'calculates score with nil definitions, ancestors, and descendants' do
+      decl = { type: 'class' }
+      allow(adapter).to receive(:get_declaration).with('User').and_return(decl)
+      expect(instance.send(:calculate_complexity_score, model)).to eq(0)
+    end
+  end
+
+  describe '#extract_semantic_summary edge cases' do
+    it 'handles nil definitions, ancestors, and descendants' do
+      decl = { type: 'class' }
+      allow(adapter).to receive(:get_declaration).with('User').and_return(decl)
+      summary = instance.send(:extract_semantic_summary, model)
+      expect(summary).to eq('class with 0 definitions')
+    end
+
+    it 'includes ancestors when present' do
+      decl = { type: 'class', ancestors: ['ApplicationRecord'] }
+      allow(adapter).to receive(:get_declaration).with('User').and_return(decl)
+      summary = instance.send(:extract_semantic_summary, model)
+      expect(summary).to include('inherits from ApplicationRecord')
+    end
+  end
+
+  describe '#find_similar_models with many results' do
+    it 'caps at 10 results' do
+      many = (1..15).map { |i| "Model#{i}" }
+      allow(adapter).to receive(:ancestors).with('User').and_return(['ApplicationRecord'])
+      allow(adapter).to receive(:descendants).with('ApplicationRecord').and_return(['User'] + many)
+      allow(adapter).to receive(:descendants).with('User').and_return([])
+
+      result = instance.send(:find_similar_models, model)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(10)
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/multi_database_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/multi_database_introspector_spec.rb
@@ -82,4 +82,86 @@ RSpec.describe RailsAiBridge::Introspectors::MultiDatabaseIntrospector do
       expect(result[:databases]).to include({ name: 'primary' }, { name: 'animals' })
     end
   end
+
+  describe 'private methods' do
+    describe '#anonymize_db_name' do
+      it 'returns name unchanged for regular names' do
+        expect(introspector.send(:anonymize_db_name, 'my_app_development')).to eq('my_app_development')
+      end
+
+      it 'extracts path from postgres URL' do
+        expect(introspector.send(:anonymize_db_name, 'postgres://localhost/mydb')).to eq('mydb')
+      end
+
+      it 'extracts path from mysql URL' do
+        expect(introspector.send(:anonymize_db_name, 'mysql://localhost/mydb')).to eq('mydb')
+      end
+
+      it 'returns external on URI parse error' do
+        allow(URI).to receive(:parse).and_raise(URI::InvalidURIError)
+        expect(introspector.send(:anonymize_db_name, 'postgres://bad')).to eq('external')
+      end
+
+      it 'returns nil for nil input' do
+        expect(introspector.send(:anonymize_db_name, nil)).to be_nil
+      end
+    end
+
+    describe '#detect_sharding' do
+      it 'returns nil when database.yml does not exist' do
+        expect(introspector.send(:detect_sharding)).to be_nil
+      end
+
+      it 'returns nil on file read error' do
+        config_dir = File.join(root, 'config')
+        FileUtils.mkdir_p(config_dir)
+        db_path = File.join(config_dir, 'database.yml')
+        File.write(db_path, 'development:')
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(db_path).and_raise(StandardError, 'read error')
+        expect(introspector.send(:detect_sharding)).to be_nil
+      ensure
+        allow(File).to receive(:read).and_call_original
+      end
+    end
+
+    describe '#detect_model_connections' do
+      it 'returns empty array when models dir does not exist' do
+        expect(introspector.send(:detect_model_connections)).to eq([])
+      end
+
+      it 'handles file read errors gracefully' do
+        models_dir = File.join(root, 'app/models')
+        FileUtils.mkdir_p(models_dir)
+        bad_file = File.join(models_dir, 'bad.rb')
+        File.write(bad_file, 'class Bad; end')
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(bad_file).and_raise(StandardError, 'read error')
+
+        expect(introspector.send(:detect_model_connections)).to eq([])
+      ensure
+        allow(File).to receive(:read).and_call_original
+      end
+    end
+
+    describe '#discover_replicas error handling' do
+      it 'returns empty array on error' do
+        allow(ActiveRecord::Base).to receive(:configurations).and_raise(StandardError)
+        expect(introspector.send(:discover_replicas)).to eq([])
+      end
+    end
+
+    describe '#discover_databases error handling' do
+      it 'falls back to parse_database_yml on error' do
+        allow(ActiveRecord::Base).to receive(:configurations).and_raise(StandardError)
+        config_dir = File.join(root, 'config')
+        FileUtils.mkdir_p(config_dir)
+        File.write(File.join(config_dir, 'database.yml'), "development:\n  primary:\n")
+        allow(Rails).to receive(:env).and_return('development')
+
+        result = introspector.send(:discover_databases)
+        expect(result).to be_an(Array)
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
@@ -235,8 +235,8 @@ RSpec.describe RailsAiBridge::Introspectors::NonArModelsIntrospector do
       allow(introspector).to receive(:safe_to_process?).and_raise(StandardError, 'processing error')
 
       entries = {}
-      context = RailsAiBridge::Introspectors::NonArModelsIntrospector
-        .const_get(:CollectionContext).new(models_root: '/fake/root', rows: entries)
+      context = described_class
+                .const_get(:CollectionContext).new(models_root: '/fake/root', rows: entries)
 
       expect { introspector.send(:collect_entry, bad_klass, context) }.not_to raise_error
     end

--- a/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
@@ -190,4 +190,103 @@ RSpec.describe RailsAiBridge::Introspectors::NonArModelsIntrospector do
       expect(introspector.instance_variable_get(:@root)).to eq('/path/to/app')
     end
   end
+
+  describe '#sanitize_error_message' do
+    it 'returns default message when input is nil' do
+      expect(introspector.sanitize_error_message(nil)).to eq('Introspection failed')
+    end
+
+    it 'returns default message when input is empty' do
+      expect(introspector.sanitize_error_message('')).to eq('Introspection failed')
+    end
+
+    it 'returns sanitized message unchanged when under 200 chars' do
+      expect(introspector.sanitize_error_message('short error')).to eq('short error')
+    end
+  end
+
+  describe '#safe_to_process? (private)' do
+    it 'returns false for class with blank name' do
+      klass = Class.new
+      allow(klass).to receive(:name).and_return(nil)
+      expect(introspector.send(:safe_to_process?, klass)).to be false
+    end
+
+    it 'returns false for class with dot in name' do
+      klass = double('Class', name: 'Foo.Bar')
+      expect(introspector.send(:safe_to_process?, klass)).to be false
+    end
+
+    it 'returns false for class with invalid name pattern' do
+      klass = double('Class', name: 'lower_case')
+      expect(introspector.send(:safe_to_process?, klass)).to be false
+    end
+
+    it 'returns true for valid non-AR class' do
+      klass = double('Class', name: 'MyService')
+      allow(klass).to receive(:<).with(ActiveRecord::Base).and_return(false)
+      expect(introspector.send(:safe_to_process?, klass)).to be true
+    end
+  end
+
+  describe '#collect_entry error handling (private)' do
+    it 'logs error and continues when collect_entry raises' do
+      bad_klass = double('BadClass', name: 'BadClass')
+      allow(introspector).to receive(:safe_to_process?).and_raise(StandardError, 'processing error')
+
+      entries = {}
+      context = RailsAiBridge::Introspectors::NonArModelsIntrospector
+        .const_get(:CollectionContext).new(models_root: '/fake/root', rows: entries)
+
+      expect { introspector.send(:collect_entry, bad_klass, context) }.not_to raise_error
+    end
+  end
+
+  describe '#record_if_non_ar_model (private)' do
+    it 'skips classes with blank name' do
+      klass = double('Class', name: nil)
+      context = double('CollectionContext')
+      expect(introspector.send(:record_if_non_ar_model, klass, context)).to be_nil
+    end
+
+    it 'skips classes with dot in name' do
+      klass = double('Class', name: 'Foo.Bar')
+      context = double('CollectionContext')
+      expect(introspector.send(:record_if_non_ar_model, klass, context)).to be_nil
+    end
+
+    it 'skips classes with invalid name pattern' do
+      klass = double('Class', name: 'invalid_name')
+      context = double('CollectionContext')
+      expect(introspector.send(:record_if_non_ar_model, klass, context)).to be_nil
+    end
+
+    it 'skips when const_source_location returns nil' do
+      klass = double('Class', name: 'NonexistentClass')
+      allow(klass).to receive(:<).with(ActiveRecord::Base).and_return(false)
+      allow(Object).to receive(:const_source_location).with('NonexistentClass').and_return([])
+      context = double('CollectionContext', models_root: '/fake', rows: {})
+      expect(introspector.send(:record_if_non_ar_model, klass, context)).to be_nil
+    end
+
+    it 'skips when path does not start with models_root' do
+      klass = double('Class', name: 'OutsideClass')
+      allow(klass).to receive(:<).with(ActiveRecord::Base).and_return(false)
+      allow(Object).to receive(:const_source_location).with('OutsideClass').and_return(['/other/path/file.rb'])
+      context = double('CollectionContext', models_root: '/app/models', rows: {})
+      expect(introspector.send(:record_if_non_ar_model, klass, context)).to be_nil
+    end
+  end
+
+  describe '#safe_const_source_location (private)' do
+    it 'returns nil on ArgumentError' do
+      allow(Object).to receive(:const_source_location).and_raise(ArgumentError)
+      expect(introspector.send(:safe_const_source_location, 'Foo')).to be_nil
+    end
+
+    it 'returns nil on NameError' do
+      allow(Object).to receive(:const_source_location).and_raise(NameError)
+      expect(introspector.send(:safe_const_source_location, 'Foo')).to be_nil
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/route_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/route_introspector_spec.rb
@@ -83,4 +83,104 @@ RSpec.describe RailsAiBridge::Introspectors::RouteIntrospector do
       RailsAiBridge.configuration.excluded_tables = original_tables
     end
   end
+
+  describe 'RouteParser' do
+    let(:parser) { RailsAiBridge::Introspectors::RouteIntrospector::RouteParser }
+
+    it 'returns ANY verb when route verb is blank' do
+      route = double('Route', verb: '', name: 'test',
+                              defaults: { controller: 'tests', action: 'index' },
+                              constraints: {})
+      allow(route).to receive(:respond_to?).with(:required_parts).and_return(false)
+      allow(route).to receive(:respond_to?).with(:internal?).and_return(false)
+      path = double('Path', spec: '/tests(.:format)', required_names: [])
+      allow(route).to receive(:path).and_return(path)
+
+      result = parser.new(route).to_h
+      expect(result[:verb]).to eq('ANY')
+    end
+
+    it 'extracts constraints when non-empty' do
+      route = double('Route', verb: 'GET', name: nil,
+                              defaults: { controller: 'tests', action: 'show' },
+                              constraints: { id: /\d+/ })
+      allow(route).to receive(:respond_to?).with(:required_parts).and_return(true)
+      allow(route).to receive(:required_parts).and_return([:id])
+      allow(route).to receive(:respond_to?).with(:internal?).and_return(false)
+      path = double('Path', spec: '/tests/:id(.:format)')
+      allow(route).to receive(:path).and_return(path)
+
+      result = parser.new(route).to_h
+      expect(result[:constraints]).to eq('{id: /\d+/}')
+    end
+
+    it 'returns nil constraints when empty' do
+      route = double('Route', verb: 'GET', name: nil,
+                              defaults: { controller: 'tests', action: 'index' },
+                              constraints: '')
+      allow(route).to receive(:respond_to?).with(:required_parts).and_return(false)
+      allow(route).to receive(:respond_to?).with(:internal?).and_return(false)
+      path = double('Path', spec: '/tests(.:format)', required_names: [])
+      allow(route).to receive(:path).and_return(path)
+
+      result = parser.new(route).to_h
+      expect(result).not_to have_key(:constraints)
+    end
+
+    it 'returns nil constraints when constraints raises' do
+      route = double('Route', verb: 'GET', name: nil,
+                              defaults: { controller: 'tests', action: 'index' })
+      allow(route).to receive(:constraints).and_raise(StandardError, 'boom')
+      allow(route).to receive(:respond_to?).with(:required_parts).and_return(false)
+      allow(route).to receive(:respond_to?).with(:internal?).and_return(false)
+      path = double('Path', spec: '/tests(.:format)', required_names: [])
+      allow(route).to receive(:path).and_return(path)
+
+      result = parser.new(route).to_h
+      expect(result).not_to have_key(:constraints)
+    end
+
+    it 'uses required_names when required_parts is not available' do
+      route = double('Route', verb: 'GET', name: 'test',
+                              defaults: { controller: 'tests', action: 'show' },
+                              constraints: {})
+      allow(route).to receive(:respond_to?).with(:required_parts).and_return(false)
+      allow(route).to receive(:respond_to?).with(:internal?).and_return(false)
+      path = double('Path', spec: '/tests/:id(.:format)', required_names: [:id])
+      allow(route).to receive(:path).and_return(path)
+      allow(path).to receive(:respond_to?).with(:required_names).and_return(true)
+
+      result = parser.new(route).to_h
+      expect(result[:required_params]).to eq(['id'])
+    end
+
+    it 'returns empty required_params when neither required_parts nor required_names available' do
+      route = double('Route', verb: 'GET', name: 'test',
+                              defaults: { controller: 'tests', action: 'index' },
+                              constraints: {})
+      allow(route).to receive(:respond_to?).with(:required_parts).and_return(false)
+      allow(route).to receive(:respond_to?).with(:internal?).and_return(false)
+      path = double('Path', spec: '/tests(.:format)')
+      allow(route).to receive(:path).and_return(path)
+      allow(path).to receive(:respond_to?).with(:required_names).and_return(false)
+
+      result = parser.new(route).to_h
+      expect(result).not_to have_key(:required_params)
+    end
+  end
+
+  describe 'RouteCollection' do
+    let(:collection) { RailsAiBridge::Introspectors::RouteIntrospector::RouteCollection }
+
+    it 'detects API namespaces from route paths' do
+      routes = [
+        { verb: 'GET', path: '/api/v1/users', controller: 'api/v1/users', action: 'index', name: nil, helper: nil, required_params: nil },
+        { verb: 'GET', path: '/api/v2/posts', controller: 'api/v2/posts', action: 'index', name: nil, helper: nil, required_params: nil },
+        { verb: 'GET', path: '/users', controller: 'users', action: 'index', name: nil, helper: nil, required_params: nil }
+      ]
+
+      result = collection.new(routes).to_h
+      expect(result[:api_namespaces]).to include('/api/v1', '/api/v2')
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/route_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/route_introspector_spec.rb
@@ -105,13 +105,13 @@ RSpec.describe RailsAiBridge::Introspectors::RouteIntrospector do
                               defaults: { controller: 'tests', action: 'show' },
                               constraints: { id: /\d+/ })
       allow(route).to receive(:respond_to?).with(:required_parts).and_return(true)
-      allow(route).to receive(:required_parts).and_return([:id])
       allow(route).to receive(:respond_to?).with(:internal?).and_return(false)
       path = double('Path', spec: '/tests/:id(.:format)')
-      allow(route).to receive(:path).and_return(path)
+      allow(route).to receive_messages(required_parts: [:id], path: path)
 
       result = parser.new(route).to_h
-      expect(result[:constraints]).to eq('{id: /\d+/}')
+      # Accept both Ruby 3.4+ "{id: /\d+/}" and older "{:id=>/\d+/}" inspect formats
+      expect(result[:constraints]).to match(%r{\{(?::id=>|id: )/\\d\+/\}})
     end
 
     it 'returns nil constraints when empty' do

--- a/spec/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser_spec.rb
@@ -305,6 +305,131 @@ RSpec.describe RailsAiBridge::Introspectors::Schema::StaticStructureSqlParser do
       DDL
       expect(parse(content)[:tables]['users'][:foreign_keys]).to be_empty
     end
+
+    it 'captures ON UPDATE referential action' do
+      content = <<~DDL
+        CREATE TABLE public.posts (
+            id bigint NOT NULL,
+            user_id bigint
+        );
+        CREATE TABLE public.users (
+            id bigint NOT NULL
+        );
+        ALTER TABLE ONLY public.posts
+            ADD CONSTRAINT fk_rails_abc123 FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE SET NULL;
+      DDL
+      fk = parse(content)[:tables]['posts'][:foreign_keys].first
+      expect(fk[:on_update]).to eq('SET NULL')
+      expect(fk).not_to have_key(:on_delete)
+    end
+
+    it 'captures both ON DELETE and ON UPDATE' do
+      content = <<~DDL
+        CREATE TABLE public.posts (
+            id bigint NOT NULL,
+            user_id bigint
+        );
+        CREATE TABLE public.users (
+            id bigint NOT NULL
+        );
+        ALTER TABLE ONLY public.posts
+            ADD CONSTRAINT fk_rails_abc123 FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE ON UPDATE SET NULL;
+      DDL
+      fk = parse(content)[:tables]['posts'][:foreign_keys].first
+      expect(fk[:on_delete]).to eq('CASCADE')
+      expect(fk[:on_update]).to eq('SET NULL')
+    end
+
+    it 'handles composite foreign keys by keeping the first column' do
+      content = <<~DDL
+        CREATE TABLE public.tags (
+            id bigint NOT NULL
+        );
+        CREATE TABLE public.taggings (
+            id bigint NOT NULL,
+            tag_id bigint,
+            post_id bigint
+        );
+        ALTER TABLE ONLY public.taggings
+            ADD CONSTRAINT fk_tagging FOREIGN KEY (tag_id, post_id) REFERENCES public.tags(id, post_id);
+      DDL
+      fk = parse(content)[:tables]['taggings'][:foreign_keys].first
+      expect(fk[:column]).to eq('tag_id')
+      expect(fk[:primary_key]).to eq('id')
+    end
+  end
+
+  describe 'column type normalization edge cases' do
+    it 'strips trailing NULL to leave the bare type' do
+      content = "CREATE TABLE public.users (\n    email character varying NULL\n);\n"
+      col = parse(content)[:tables]['users'][:columns].first
+      expect(col[:type]).to eq('character varying')
+    end
+
+    it 'strips trailing comma from the last column' do
+      content = "CREATE TABLE public.users (\n    email character varying,\n);\n"
+      col = parse(content)[:tables]['users'][:columns].first
+      expect(col[:type]).to eq('character varying')
+    end
+
+    it 'handles DEFAULT with complex expression' do
+      content = "CREATE TABLE public.users (\n    status integer DEFAULT 1 NOT NULL\n);\n"
+      col = parse(content)[:tables]['users'][:columns].first
+      expect(col[:type]).to eq('integer')
+    end
+  end
+
+  describe 'partition edge cases' do
+    it 'handles a child with inline column list and PARTITION OF on same line as closing paren' do
+      content = <<~DDL
+        CREATE TABLE public.events (
+            id bigint NOT NULL
+        )
+        PARTITION BY RANGE (id);
+
+        CREATE TABLE public.events_q1 (
+            id bigint NOT NULL
+        ) PARTITION OF public.events
+        FOR VALUES FROM (1) TO (100);
+      DDL
+
+      child = parse(content)[:tables]['events_q1']
+      expect(child[:partition_of]).to eq('events')
+      expect(child[:columns].pluck(:name)).to include('id')
+    end
+
+    it 'handles a DEFAULT partition with trailing semicolon' do
+      content = <<~DDL
+        CREATE TABLE public.events (
+            id bigint NOT NULL
+        )
+        PARTITION BY RANGE (id);
+
+        CREATE TABLE public.events_default PARTITION OF public.events DEFAULT;
+      DDL
+
+      child = parse(content)[:tables]['events_default']
+      expect(child[:partition_bound]).to match(/\ADEFAULT\b/i)
+    end
+
+    it 'handles a partition child whose parent is excluded' do
+      config.excluded_tables << 'events'
+      content = <<~DDL
+        CREATE TABLE public.events (
+            id bigint NOT NULL
+        )
+        PARTITION BY RANGE (id);
+
+        CREATE TABLE public.events_q1 PARTITION OF public.events
+        FOR VALUES FROM (1) TO (100);
+      DDL
+
+      # Parent is excluded; child should still be parsed but with empty columns
+      tables = parse(content)[:tables]
+      expect(tables).to have_key('events_q1')
+    ensure
+      config.excluded_tables.clear
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/schema/static_structure_sql_parser_spec.rb
@@ -413,6 +413,7 @@ RSpec.describe RailsAiBridge::Introspectors::Schema::StaticStructureSqlParser do
     end
 
     it 'handles a partition child whose parent is excluded' do
+      original_excluded = config.excluded_tables.dup
       config.excluded_tables << 'events'
       content = <<~DDL
         CREATE TABLE public.events (
@@ -428,7 +429,7 @@ RSpec.describe RailsAiBridge::Introspectors::Schema::StaticStructureSqlParser do
       tables = parse(content)[:tables]
       expect(tables).to have_key('events_q1')
     ensure
-      config.excluded_tables.clear
+      config.excluded_tables.replace(original_excluded)
     end
   end
 

--- a/spec/lib/rails_ai_bridge/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/schema_introspector_spec.rb
@@ -190,11 +190,14 @@ RSpec.describe RailsAiBridge::Introspectors::SchemaIntrospector do
       end
 
       it 'returns nil when no version match found' do
-        allow(introspector).to receive(:schema_file_path).and_return('/tmp/test_schema.rb')
-        File.write('/tmp/test_schema.rb', 'no version here')
+        file = Tempfile.new(['test_schema', '.rb'])
+        file.write('no version here')
+        file.close
+        allow(introspector).to receive(:schema_file_path).and_return(file.path)
         expect(introspector.send(:current_schema_version)).to be_nil
       ensure
-        FileUtils.rm_f('/tmp/test_schema.rb')
+        file&.close
+        file&.unlink
       end
     end
 

--- a/spec/lib/rails_ai_bridge/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/schema_introspector_spec.rb
@@ -151,9 +151,7 @@ RSpec.describe RailsAiBridge::Introspectors::SchemaIntrospector do
 
     context 'when static schema parse raises' do
       before do
-        allow(introspector).to receive(:active_record_connected?).and_return(false)
-        allow(introspector).to receive(:schema_file_path).and_return('/nonexistent/schema.rb')
-        allow(introspector).to receive(:structure_sql_path).and_return('/nonexistent/structure.sql')
+        allow(introspector).to receive_messages(active_record_connected?: false, schema_file_path: '/nonexistent/schema.rb', structure_sql_path: '/nonexistent/structure.sql')
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with('/nonexistent/schema.rb').and_return(true)
         allow(File).to receive(:read).and_call_original
@@ -196,7 +194,7 @@ RSpec.describe RailsAiBridge::Introspectors::SchemaIntrospector do
         File.write('/tmp/test_schema.rb', 'no version here')
         expect(introspector.send(:current_schema_version)).to be_nil
       ensure
-        File.delete('/tmp/test_schema.rb') if File.exist?('/tmp/test_schema.rb')
+        FileUtils.rm_f('/tmp/test_schema.rb')
       end
     end
 

--- a/spec/lib/rails_ai_bridge/introspectors/schema_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/schema_introspector_spec.rb
@@ -148,5 +148,63 @@ RSpec.describe RailsAiBridge::Introspectors::SchemaIntrospector do
         expect(error).to include('structure.sql')
       end
     end
+
+    context 'when static schema parse raises' do
+      before do
+        allow(introspector).to receive(:active_record_connected?).and_return(false)
+        allow(introspector).to receive(:schema_file_path).and_return('/nonexistent/schema.rb')
+        allow(introspector).to receive(:structure_sql_path).and_return('/nonexistent/structure.sql')
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with('/nonexistent/schema.rb').and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with('/nonexistent/schema.rb').and_raise(StandardError, 'read error')
+      end
+
+      after { allow(File).to receive(:read).and_call_original }
+
+      it 'returns error hash with read failure message' do
+        result = introspector.call
+        expect(result[:error]).to include('Failed to read schema file')
+        expect(result[:error]).to include('read error')
+      end
+    end
+  end
+
+  describe 'private methods' do
+    describe '#adapter_name' do
+      it 'returns unknown on error' do
+        allow(ActiveRecord::Base).to receive(:connection).and_raise(StandardError)
+        expect(introspector.send(:adapter_name)).to eq('unknown')
+      end
+    end
+
+    describe '#extract_foreign_keys' do
+      it 'returns empty array on error' do
+        allow(ActiveRecord::Base).to receive(:connection).and_raise(StandardError, 'fk not supported')
+        expect(introspector.send(:extract_foreign_keys, 'users')).to eq([])
+      end
+    end
+
+    describe '#current_schema_version' do
+      it 'returns nil when schema file does not exist' do
+        allow(introspector).to receive(:schema_file_path).and_return('/nonexistent/schema.rb')
+        expect(introspector.send(:current_schema_version)).to be_nil
+      end
+
+      it 'returns nil when no version match found' do
+        allow(introspector).to receive(:schema_file_path).and_return('/tmp/test_schema.rb')
+        File.write('/tmp/test_schema.rb', 'no version here')
+        expect(introspector.send(:current_schema_version)).to be_nil
+      ensure
+        File.delete('/tmp/test_schema.rb') if File.exist?('/tmp/test_schema.rb')
+      end
+    end
+
+    describe '#active_record_connected?' do
+      it 'returns false on StandardError' do
+        allow(ActiveRecord::Base).to receive(:connected?).and_raise(StandardError)
+        expect(introspector.send(:active_record_connected?)).to be false
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/seeds_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/seeds_introspector_spec.rb
@@ -68,4 +68,67 @@ RSpec.describe RailsAiBridge::Introspectors::SeedsIntrospector do
       expect(result[:error]).to be_nil
     end
   end
+
+  describe '#call with no seeds.rb' do
+    let(:introspector) { described_class.new(app) }
+    let(:result) { introspector.call }
+
+    after do
+      FileUtils.rm_f(File.join(db_dir, 'seeds.rb'))
+      FileUtils.rm_rf(File.join(db_dir, 'seeds'))
+    end
+
+    it 'returns nil for seeds_file when db/seeds.rb does not exist' do
+      FileUtils.rm_f(File.join(db_dir, 'seeds.rb'))
+      FileUtils.rm_rf(File.join(db_dir, 'seeds'))
+      expect(result[:seeds_file]).to be_nil
+    end
+
+    it 'returns empty array for seed_files when db/seeds/ does not exist' do
+      FileUtils.rm_f(File.join(db_dir, 'seeds.rb'))
+      FileUtils.rm_rf(File.join(db_dir, 'seeds'))
+      expect(result[:seed_files]).to eq([])
+    end
+
+    it 'returns empty array for models_seeded when no seed files exist' do
+      FileUtils.rm_f(File.join(db_dir, 'seeds.rb'))
+      FileUtils.rm_rf(File.join(db_dir, 'seeds'))
+      expect(result[:models_seeded]).to eq([])
+    end
+  end
+
+  describe '#call with upsert, insert_all, and factory_bot' do
+    let(:result) { introspector.call }
+
+    before do
+      File.write(File.join(db_dir, 'seeds.rb'), <<~RUBY)
+        User.upsert(name: "Admin")
+        Post.insert_all([{ title: "Test" }])
+        FactoryBot.create(:user)
+      RUBY
+    end
+
+    after do
+      FileUtils.rm_f(File.join(db_dir, 'seeds.rb'))
+      FileUtils.rm_rf(File.join(db_dir, 'seeds'))
+    end
+
+    it 'detects upsert, insert_all, and factory_bot usage' do
+      seeds = result[:seeds_file]
+      expect(seeds[:uses_upsert]).to be true
+      expect(seeds[:uses_insert_all]).to be true
+      expect(seeds[:uses_factory_bot]).to be true
+    end
+  end
+
+  describe '#call when app.root raises' do
+    let(:bad_app) { double('Rails::Application') }
+    let(:result) { described_class.new(bad_app).call }
+
+    before { allow(bad_app).to receive(:root).and_raise(StandardError, 'root boom') }
+
+    it 'returns error hash' do
+      expect(result[:error]).to eq('root boom')
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/semantic_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/semantic_introspector_spec.rb
@@ -205,14 +205,12 @@ RSpec.describe RailsAiBridge::Introspectors::SemanticIntrospector do
               { definitions: [1, 2, 3], ancestors: %w[A B], descendants: %w[X Y] }
             when 'ColdClass'
               { definitions: [1], ancestors: [], descendants: [] }
-            else
-              nil
             end
           end
 
           result = introspector.call
           hotspots = result[:complexity_hotspots]
-          names = hotspots.map { |h| h[:name] }
+          names = hotspots.pluck(:name)
           expect(names).to include('HotClass')
           expect(names).not_to include('ColdClass')
           expect(names).not_to include('NilDetailClass')

--- a/spec/lib/rails_ai_bridge/introspectors/semantic_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/semantic_introspector_spec.rb
@@ -74,6 +74,212 @@ RSpec.describe RailsAiBridge::Introspectors::SemanticIntrospector do
         result = introspector.call
         expect(result[:error]).to eq('test error')
       end
+
+      context 'with empty declarations' do
+        before do
+          allow(mock_adapter).to receive_messages(
+            codebase_stats: { total_files: 0, total_declarations: 0 },
+            all_declarations: [],
+            descendants: [],
+            ancestors: [],
+            get_declaration: nil
+          )
+        end
+
+        it 'returns empty patterns, relationships, and hotspots' do
+          result = introspector.call
+          expect(result[:patterns]).to eq({})
+          expect(result[:relationships]).to eq({})
+          expect(result[:complexity_hotspots]).to eq([])
+        end
+      end
+
+      context 'with class name patterns' do
+        before do
+          allow(mock_adapter).to receive_messages(
+            codebase_stats: { total_files: 10 },
+            all_declarations: [
+              { name: 'UserService', type: 'class' },
+              { name: 'SignupForm', type: 'class' },
+              { name: 'UserQuery', type: 'class' },
+              { name: 'UserPresenter', type: 'class' },
+              { name: 'PostDecorator', type: 'class' },
+              { name: 'UserSerializer', type: 'class' },
+              { name: 'PostPolicy', type: 'class' },
+              { name: 'EmailValidator', type: 'class' },
+              { name: 'UserObserver', type: 'class' },
+              { name: 'SignupInteractor', type: 'class' },
+              { name: 'CreateUserCommand', type: 'class' },
+              { name: 'ProcessJob', type: 'class' },
+              { name: 'WelcomeMailer', type: 'class' },
+              { name: 'AuditableConcern', type: 'module' }
+            ],
+            descendants: [],
+            ancestors: ['Object'],
+            get_declaration: nil
+          )
+        end
+
+        it 'detects all naming patterns and concerns' do
+          result = introspector.call
+          patterns = result[:patterns][:common_patterns]
+          expect(patterns).to include('service_objects')
+          expect(patterns).to include('form_objects')
+          expect(patterns).to include('query_objects')
+          expect(patterns).to include('presenters')
+          expect(patterns).to include('serializers')
+          expect(patterns).to include('policies')
+          expect(patterns).to include('validators')
+          expect(patterns).to include('observers')
+          expect(patterns).to include('interactors')
+          expect(patterns).to include('commands')
+          expect(patterns).to include('jobs')
+          expect(patterns).to include('mailers')
+          expect(patterns).to include('concerns(1)')
+        end
+
+        it 'computes namespace distribution' do
+          result = introspector.call
+          expect(result[:patterns][:namespace_distribution]).to be_a(Hash)
+        end
+      end
+
+      context 'with inheritance relationships' do
+        before do
+          allow(mock_adapter).to receive_messages(
+            codebase_stats: { total_files: 5 },
+            all_declarations: [
+              { name: 'Animal', type: 'class' },
+              { name: 'Dog', type: 'class' },
+              { name: 'Cat', type: 'class' },
+              { name: 'Lonely', type: 'class' }
+            ],
+            get_declaration: nil
+          )
+        end
+
+        it 'builds inheritance tree for classes with descendants' do
+          allow(mock_adapter).to receive(:descendants) do |name|
+            case name
+            when 'Animal' then %w[Dog Cat]
+            else []
+            end
+          end
+          allow(mock_adapter).to receive(:ancestors) do |name|
+            case name
+            when 'Lonely' then ['Object']
+            else ['Animal']
+            end
+          end
+
+          result = introspector.call
+          tree = result[:relationships][:inheritance_tree]
+          expect(tree['Animal']).to eq(%w[Dog Cat])
+
+          most_extended = result[:relationships][:most_extended]
+          expect(most_extended.first[:name]).to eq('Animal')
+
+          orphans = result[:relationships][:orphan_classes]
+          expect(orphans).to eq(3) # Dog, Cat, Lonely
+        end
+      end
+
+      context 'with complexity hotspots' do
+        before do
+          allow(mock_adapter).to receive_messages(
+            codebase_stats: { total_files: 3 },
+            all_declarations: [
+              { name: 'HotClass', type: 'class' },
+              { name: 'ColdClass', type: 'class' },
+              { name: 'NilDetailClass', type: 'class' }
+            ],
+            descendants: [],
+            ancestors: []
+          )
+        end
+
+        it 'includes hotspots with score >= 5 and skips low-score and nil-detail' do
+          allow(mock_adapter).to receive(:get_declaration) do |name|
+            case name
+            when 'HotClass'
+              { definitions: [1, 2, 3], ancestors: %w[A B], descendants: %w[X Y] }
+            when 'ColdClass'
+              { definitions: [1], ancestors: [], descendants: [] }
+            else
+              nil
+            end
+          end
+
+          result = introspector.call
+          hotspots = result[:complexity_hotspots]
+          names = hotspots.map { |h| h[:name] }
+          expect(names).to include('HotClass')
+          expect(names).not_to include('ColdClass')
+          expect(names).not_to include('NilDetailClass')
+        end
+      end
+
+      context 'with hotspot detail having nil definitions, ancestors, descendants' do
+        before do
+          allow(mock_adapter).to receive_messages(
+            codebase_stats: { total_files: 1 },
+            all_declarations: [{ name: 'BigClass', type: 'class' }],
+            descendants: [],
+            ancestors: []
+          )
+          allow(mock_adapter).to receive(:get_declaration).and_return({ definitions: nil, ancestors: nil, descendants: nil })
+        end
+
+        it 'handles nil fields in hotspot score calculation' do
+          result = introspector.call
+          # score = 0*2 + 0 + 0*3 = 0, which is < 5, so hotspot is skipped
+          expect(result[:complexity_hotspots]).to eq([])
+        end
+      end
+
+      context 'with namespaced declarations' do
+        before do
+          allow(mock_adapter).to receive_messages(
+            codebase_stats: { total_files: 2 },
+            all_declarations: [
+              { name: 'Admin::UserController', type: 'class' },
+              { name: 'Admin::PostController', type: 'class' },
+              { name: 'Api::V1::BaseController', type: 'class' }
+            ],
+            descendants: [],
+            ancestors: [],
+            get_declaration: nil
+          )
+        end
+
+        it 'groups namespace distribution by top-level namespace' do
+          result = introspector.call
+          ns = result[:patterns][:namespace_distribution]
+          expect(ns['Admin']).to eq(2)
+          expect(ns['Api']).to eq(1)
+        end
+      end
+
+      context 'with hotspot score exactly 5' do
+        before do
+          allow(mock_adapter).to receive_messages(
+            codebase_stats: { total_files: 1 },
+            all_declarations: [{ name: 'Borderline', type: 'class' }],
+            descendants: [],
+            ancestors: []
+          )
+          # score = 2*2 + 1 + 0*3 = 5
+          allow(mock_adapter).to receive(:get_declaration).and_return(
+            { definitions: [1, 2], ancestors: %w[Object], descendants: [] }
+          )
+        end
+
+        it 'includes hotspot when score is exactly 5' do
+          result = introspector.call
+          expect(result[:complexity_hotspots].first[:name]).to eq('Borderline')
+          expect(result[:complexity_hotspots].first[:complexity_score]).to eq(5)
+        end
+      end
     end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/stimulus_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/stimulus_introspector_spec.rb
@@ -117,37 +117,106 @@ RSpec.describe RailsAiBridge::Introspectors::StimulusIntrospector do
       end
     end
 
-    context 'when app/javascript/controllers is configured to a custom directory' do
-      let(:custom_context) do
-        root_path = Dir.mktmpdir('rails-ai-bridge-stimulus-paths')
-        root = Pathname.new(root_path)
-        controllers_dir = root.join('frontend/controllers')
-        app = double('Rails::Application', root:, paths: { 'app/javascript/controllers' => [controllers_dir.to_s] })
-
-        { root_path:, controllers_dir:, introspector: described_class.new(app) }
-      end
-
-      after { FileUtils.rm_rf(custom_context[:root_path]) }
+    context 'when a controller file raises an error during parsing' do
+      let(:controllers_dir) { Rails.root.join('app/javascript/controllers').to_s }
+      let(:bad_file) { File.join(controllers_dir, 'broken_controller.js') }
 
       before do
-        FileUtils.mkdir_p(custom_context[:controllers_dir].join('admin'))
-        File.write(custom_context[:controllers_dir].join('admin/filter_controller.ts'), <<~TS)
-          export default class extends Controller {
-            static targets = ["query"]
+        FileUtils.mkdir_p(controllers_dir)
+        File.write(bad_file, 'valid content')
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(bad_file).and_raise(StandardError, 'read error')
+      end
 
-            apply() {
-              this.queryTarget.value = ""
+      after do
+        FileUtils.rm_rf(Rails.root.join('app/javascript').to_s)
+      end
+
+      it 'returns an error entry for the broken controller' do
+        result = introspector.call
+        controller = result[:controllers].first
+        expect(controller[:name]).to eq('broken_controller.js')
+        expect(controller[:error]).to eq('read error')
+      end
+    end
+
+    context 'when a controller has no static targets/values/outlets/classes' do
+      let(:controllers_dir) { Rails.root.join('app/javascript/controllers').to_s }
+
+      before do
+        FileUtils.mkdir_p(controllers_dir)
+        File.write(File.join(controllers_dir, 'minimal_controller.js'), <<~JS)
+          import { Controller } from "@hotwired/stimulus"
+
+          export default class extends Controller {
+            connect() {
+              console.log("connected")
+            }
+          }
+        JS
+      end
+
+      after do
+        FileUtils.rm_rf(Rails.root.join('app/javascript').to_s)
+      end
+
+      it 'returns empty arrays and hashes for missing static declarations' do
+        result = introspector.call
+        controller = result[:controllers].first
+        expect(controller[:targets]).to eq([])
+        expect(controller[:values]).to eq({})
+        expect(controller[:outlets]).to eq([])
+        expect(controller[:classes]).to eq([])
+      end
+
+      it 'does not include connect as an action' do
+        result = introspector.call
+        expect(result[:controllers].first[:actions]).not_to include('connect')
+      end
+    end
+
+    context 'when the glob raises an error' do
+      it 'returns an error hash' do
+        bad_resolver = double('PathResolver')
+        allow(bad_resolver).to receive(:glob_for).and_raise(StandardError, 'glob failure')
+        introspector = described_class.new(Rails.application)
+        introspector.instance_variable_set(:@path_resolver, bad_resolver)
+        result = introspector.call
+        expect(result[:error]).to eq('glob failure')
+      end
+    end
+
+    context 'with a TypeScript controller' do
+      let(:controllers_dir) { Rails.root.join('app/javascript/controllers').to_s }
+
+      before do
+        FileUtils.mkdir_p(controllers_dir)
+        File.write(File.join(controllers_dir, 'ts_controller.ts'), <<~TS)
+          import { Controller } from "@hotwired/stimulus"
+
+          export default class extends Controller {
+            static targets = ["input"]
+            static values = { name: String }
+
+            submit() {
+              this.inputTarget.value = ""
             }
           }
         TS
       end
 
-      it 'discovers controllers from the configured JavaScript controllers path' do
-        controllers = custom_context[:introspector].call[:controllers]
+      after do
+        FileUtils.rm_rf(Rails.root.join('app/javascript').to_s)
+      end
 
-        expect(controllers).to include(
-          a_hash_including(name: 'admin-filter', file: 'admin/filter_controller.ts', targets: ['query'], actions: ['apply'])
-        )
+      it 'discovers and parses TypeScript controllers' do
+        result = introspector.call
+        controller = result[:controllers].first
+        expect(controller[:name]).to eq('ts')
+        expect(controller[:file]).to eq('ts_controller.ts')
+        expect(controller[:targets]).to eq(['input'])
+        expect(controller[:values]).to eq('name' => 'String')
+        expect(controller[:actions]).to include('submit')
       end
     end
   end

--- a/spec/lib/rails_ai_bridge/introspectors/stimulus_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/stimulus_introspector_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe RailsAiBridge::Introspectors::StimulusIntrospector do
       end
 
       after do
-        FileUtils.rm_rf(Rails.root.join('app/javascript').to_s)
+        FileUtils.rm_f(File.join(controllers_dir, 'hello_controller.js'))
+        FileUtils.rmdir(controllers_dir) if File.directory?(controllers_dir) && Dir.empty?(controllers_dir)
       end
 
       it 'discovers controllers' do
@@ -101,7 +102,8 @@ RSpec.describe RailsAiBridge::Introspectors::StimulusIntrospector do
       end
 
       after do
-        FileUtils.rm_rf(Rails.root.join('app/javascript').to_s)
+        FileUtils.rm_f(File.join(controllers_dir, 'search_controller.js'))
+        FileUtils.rmdir(controllers_dir) if File.directory?(controllers_dir) && Dir.empty?(controllers_dir)
       end
 
       it 'extracts async methods as actions' do
@@ -129,7 +131,8 @@ RSpec.describe RailsAiBridge::Introspectors::StimulusIntrospector do
       end
 
       after do
-        FileUtils.rm_rf(Rails.root.join('app/javascript').to_s)
+        FileUtils.rm_f(bad_file)
+        FileUtils.rmdir(controllers_dir) if File.directory?(controllers_dir) && Dir.empty?(controllers_dir)
       end
 
       it 'returns an error entry for the broken controller' do
@@ -157,7 +160,8 @@ RSpec.describe RailsAiBridge::Introspectors::StimulusIntrospector do
       end
 
       after do
-        FileUtils.rm_rf(Rails.root.join('app/javascript').to_s)
+        FileUtils.rm_f(File.join(controllers_dir, 'minimal_controller.js'))
+        FileUtils.rmdir(controllers_dir) if File.directory?(controllers_dir) && Dir.empty?(controllers_dir)
       end
 
       it 'returns empty arrays and hashes for missing static declarations' do
@@ -206,7 +210,8 @@ RSpec.describe RailsAiBridge::Introspectors::StimulusIntrospector do
       end
 
       after do
-        FileUtils.rm_rf(Rails.root.join('app/javascript').to_s)
+        FileUtils.rm_f(File.join(controllers_dir, 'ts_controller.ts'))
+        FileUtils.rmdir(controllers_dir) if File.directory?(controllers_dir) && Dir.empty?(controllers_dir)
       end
 
       it 'discovers and parses TypeScript controllers' do

--- a/spec/lib/rails_ai_bridge/introspectors/test_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/test_introspector_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
         FileUtils.mkdir_p(circleci_dir)
         File.write(File.join(circleci_dir, 'config.yml'), 'version: 2')
         File.write(gitlab_file, "stages:\n  - test")
-        File.write(travis_file, "language: ruby")
+        File.write(travis_file, 'language: ruby')
       end
 
       after do

--- a/spec/lib/rails_ai_bridge/introspectors/test_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/test_introspector_spec.rb
@@ -85,5 +85,289 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
         expect(result[:factories][:count]).to eq(1)
       end
     end
+
+    context 'with test/factories (not spec/factories)' do
+      let(:factories_dir) { Rails.root.join('test/factories').to_s }
+
+      before do
+        FileUtils.mkdir_p(factories_dir)
+        File.write(File.join(factories_dir, 'users.rb'), 'FactoryBot.define {}')
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+
+      it 'detects factories in test/factories' do
+        expect(result[:factories]).to be_a(Hash)
+        expect(result[:factories][:location]).to eq('test/factories')
+        expect(result[:factories][:count]).to eq(1)
+      end
+    end
+
+    context 'with empty spec/factories (count zero)' do
+      let(:factories_dir) { Rails.root.join('spec/factories').to_s }
+
+      before { FileUtils.mkdir_p(factories_dir) }
+      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      it 'returns nil for factories when directory is empty' do
+        expect(result[:factories]).to be_nil
+      end
+    end
+
+    context 'with fixtures' do
+      let(:fixtures_dir) { Rails.root.join('spec/fixtures').to_s }
+
+      before do
+        FileUtils.mkdir_p(fixtures_dir)
+        File.write(File.join(fixtures_dir, 'users.yml'), "name: test\n")
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      it 'detects fixtures with location and count' do
+        expect(result[:fixtures]).to be_a(Hash)
+        expect(result[:fixtures][:location]).to eq('spec/fixtures')
+        expect(result[:fixtures][:count]).to eq(1)
+      end
+    end
+
+    context 'with test/fixtures (not spec/fixtures)' do
+      let(:fixtures_dir) { Rails.root.join('test/fixtures').to_s }
+
+      before do
+        FileUtils.mkdir_p(fixtures_dir)
+        File.write(File.join(fixtures_dir, 'users.yml'), "name: test\n")
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+
+      it 'detects fixtures in test/fixtures' do
+        expect(result[:fixtures]).to be_a(Hash)
+        expect(result[:fixtures][:location]).to eq('test/fixtures')
+      end
+    end
+
+    context 'with empty spec/fixtures (count zero)' do
+      let(:fixtures_dir) { Rails.root.join('spec/fixtures').to_s }
+
+      before { FileUtils.mkdir_p(fixtures_dir) }
+      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      it 'returns nil for fixtures when directory is empty' do
+        expect(result[:fixtures]).to be_nil
+      end
+    end
+
+    context 'with system tests' do
+      let(:system_dir) { Rails.root.join('spec/system').to_s }
+
+      before do
+        FileUtils.mkdir_p(system_dir)
+        File.write(File.join(system_dir, 'login_test.rb'), 'require "test_helper"')
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      it 'detects system tests with location and count' do
+        expect(result[:system_tests]).to be_a(Hash)
+        expect(result[:system_tests][:location]).to eq('spec/system')
+        expect(result[:system_tests][:count]).to eq(1)
+      end
+    end
+
+    context 'with test/system (not spec/system)' do
+      let(:system_dir) { Rails.root.join('test/system').to_s }
+
+      before do
+        FileUtils.mkdir_p(system_dir)
+        File.write(File.join(system_dir, 'login_test.rb'), 'require "test_helper"')
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+
+      it 'detects system tests in test/system' do
+        expect(result[:system_tests]).to be_a(Hash)
+        expect(result[:system_tests][:location]).to eq('test/system')
+      end
+    end
+
+    context 'with empty spec/system (count zero)' do
+      let(:system_dir) { Rails.root.join('spec/system').to_s }
+
+      before { FileUtils.mkdir_p(system_dir) }
+      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      it 'returns nil for system_tests when directory is empty' do
+        expect(result[:system_tests]).to be_nil
+      end
+    end
+
+    context 'with test helpers' do
+      let(:support_dir) { Rails.root.join('spec/support').to_s }
+
+      before do
+        FileUtils.mkdir_p(support_dir)
+        File.write(File.join(support_dir, 'auth_helper.rb'), 'module AuthHelper; end')
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      it 'detects test helpers from spec/support' do
+        expect(result[:test_helpers]).to include('spec/support/auth_helper.rb')
+      end
+    end
+
+    context 'with test/helpers (not spec/support)' do
+      let(:helpers_dir) { Rails.root.join('test/helpers').to_s }
+
+      before do
+        FileUtils.mkdir_p(helpers_dir)
+        File.write(File.join(helpers_dir, 'auth_helper.rb'), 'module AuthHelper; end')
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+
+      it 'detects test helpers from test/helpers' do
+        expect(result[:test_helpers]).to include('test/helpers/auth_helper.rb')
+      end
+    end
+
+    context 'with VCR cassettes in spec/cassettes' do
+      let(:cassettes_dir) { Rails.root.join('spec/cassettes').to_s }
+
+      before do
+        FileUtils.mkdir_p(cassettes_dir)
+        File.write(File.join(cassettes_dir, 'api.yml'), "name: test\n")
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      it 'detects VCR cassettes with location and count' do
+        expect(result[:vcr_cassettes]).to be_a(Hash)
+        expect(result[:vcr_cassettes][:location]).to eq('spec/cassettes')
+        expect(result[:vcr_cassettes][:count]).to eq(1)
+      end
+    end
+
+    context 'with VCR cassettes in spec/vcr_cassettes' do
+      let(:cassettes_dir) { Rails.root.join('spec/vcr_cassettes').to_s }
+
+      before do
+        FileUtils.mkdir_p(cassettes_dir)
+        File.write(File.join(cassettes_dir, 'api.yml'), "name: test\n")
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      it 'detects VCR cassettes in spec/vcr_cassettes' do
+        expect(result[:vcr_cassettes]).to be_a(Hash)
+        expect(result[:vcr_cassettes][:location]).to eq('spec/vcr_cassettes')
+      end
+    end
+
+    context 'with VCR cassettes in test/cassettes' do
+      let(:cassettes_dir) { Rails.root.join('test/cassettes').to_s }
+
+      before do
+        FileUtils.mkdir_p(cassettes_dir)
+        File.write(File.join(cassettes_dir, 'api.yml'), "name: test\n")
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+
+      it 'detects VCR cassettes in test/cassettes' do
+        expect(result[:vcr_cassettes]).to be_a(Hash)
+        expect(result[:vcr_cassettes][:location]).to eq('test/cassettes')
+      end
+    end
+
+    context 'with VCR cassettes in test/vcr_cassettes' do
+      let(:cassettes_dir) { Rails.root.join('test/vcr_cassettes').to_s }
+
+      before do
+        FileUtils.mkdir_p(cassettes_dir)
+        File.write(File.join(cassettes_dir, 'api.yml'), "name: test\n")
+      end
+
+      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+
+      it 'detects VCR cassettes in test/vcr_cassettes' do
+        expect(result[:vcr_cassettes]).to be_a(Hash)
+        expect(result[:vcr_cassettes][:location]).to eq('test/vcr_cassettes')
+      end
+    end
+
+    context 'with empty spec/cassettes (count zero)' do
+      let(:cassettes_dir) { Rails.root.join('spec/cassettes').to_s }
+
+      before { FileUtils.mkdir_p(cassettes_dir) }
+      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      it 'returns nil for vcr_cassettes when directory is empty' do
+        expect(result[:vcr_cassettes]).to be_nil
+      end
+    end
+
+    context 'with CI configs' do
+      let(:github_dir) { Rails.root.join('.github/workflows').to_s }
+      let(:circleci_dir) { Rails.root.join('.circleci').to_s }
+      let(:gitlab_file) { Rails.root.join('.gitlab-ci.yml').to_s }
+      let(:travis_file) { Rails.root.join('.travis.yml').to_s }
+
+      before do
+        FileUtils.mkdir_p(github_dir)
+        File.write(File.join(github_dir, 'ci.yml'), 'name: CI')
+        FileUtils.mkdir_p(circleci_dir)
+        File.write(File.join(circleci_dir, 'config.yml'), 'version: 2')
+        File.write(gitlab_file, "stages:\n  - test")
+        File.write(travis_file, "language: ruby")
+      end
+
+      after do
+        FileUtils.rm_rf(github_dir)
+        FileUtils.rm_rf(circleci_dir)
+        FileUtils.rm_f(gitlab_file)
+        FileUtils.rm_f(travis_file)
+      end
+
+      it 'detects all CI configurations' do
+        expect(result[:ci_config]).to include('github_actions')
+        expect(result[:ci_config]).to include('circleci')
+        expect(result[:ci_config]).to include('gitlab_ci')
+        expect(result[:ci_config]).to include('travis')
+      end
+    end
+
+    context 'with Gemfile.lock containing reek' do
+      let(:gemfile_lock) { Rails.root.join('Gemfile.lock').to_s }
+
+      before { File.write(gemfile_lock, "reek (6.3.0)\n") }
+      after { FileUtils.rm_f(gemfile_lock) }
+
+      it 'detects reek coverage tool' do
+        expect(result[:coverage]).to eq('reek')
+      end
+    end
+
+    context 'with Gemfile.lock without reek' do
+      let(:gemfile_lock) { Rails.root.join('Gemfile.lock').to_s }
+
+      before { File.write(gemfile_lock, "rails (7.1.0)\n") }
+      after { FileUtils.rm_f(gemfile_lock) }
+
+      it 'returns nil for coverage when reek is not present' do
+        expect(result[:coverage]).to be_nil
+      end
+    end
+
+    context 'when app.root raises an error' do
+      let(:bad_app) { double('Rails::Application') }
+
+      before { allow(bad_app).to receive(:root).and_raise(StandardError, 'root boom') }
+
+      it 'returns error hash' do
+        expect(described_class.new(bad_app).call[:error]).to eq('root boom')
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/test_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/test_introspector_spec.rb
@@ -46,9 +46,10 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with a spec directory' do
       let(:spec_dir) { Rails.root.join('spec').to_s }
+      let!(:spec_existed) { File.directory?(spec_dir) }
 
       before { FileUtils.mkdir_p(spec_dir) }
-      after { FileUtils.rm_rf(spec_dir) }
+      after { FileUtils.rmdir(spec_dir) if !spec_existed && File.directory?(spec_dir) && Dir.empty?(spec_dir) }
 
       it 'detects rspec framework' do
         expect(result[:framework]).to eq('rspec')
@@ -57,9 +58,10 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with a test directory' do
       let(:test_dir) { Rails.root.join('test').to_s }
+      let!(:test_existed) { File.directory?(test_dir) }
 
       before { FileUtils.mkdir_p(test_dir) }
-      after { FileUtils.rm_rf(test_dir) }
+      after { FileUtils.rmdir(test_dir) if !test_existed && File.directory?(test_dir) && Dir.empty?(test_dir) }
 
       it 'detects minitest framework' do
         # Ensure spec/ doesn't exist (rspec takes priority)
@@ -71,13 +73,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with factories' do
       let(:factories_dir) { Rails.root.join('spec/factories').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before do
         FileUtils.mkdir_p(factories_dir)
         File.write(File.join(factories_dir, 'users.rb'), 'FactoryBot.define {}')
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+      after do
+        FileUtils.rm_rf(factories_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'detects factories with location and count' do
         expect(result[:factories]).to be_a(Hash)
@@ -88,13 +94,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with test/factories (not spec/factories)' do
       let(:factories_dir) { Rails.root.join('test/factories').to_s }
+      let!(:test_existed) { Rails.root.join('test').directory? }
 
       before do
         FileUtils.mkdir_p(factories_dir)
         File.write(File.join(factories_dir, 'users.rb'), 'FactoryBot.define {}')
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+      after do
+        FileUtils.rm_rf(factories_dir)
+        FileUtils.rmdir(Rails.root.join('test').to_s) if !test_existed && Rails.root.join('test').directory? && Dir.empty?(Rails.root.join('test').to_s)
+      end
 
       it 'detects factories in test/factories' do
         expect(result[:factories]).to be_a(Hash)
@@ -105,9 +115,14 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with empty spec/factories (count zero)' do
       let(:factories_dir) { Rails.root.join('spec/factories').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before { FileUtils.mkdir_p(factories_dir) }
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      after do
+        FileUtils.rm_rf(factories_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'returns nil for factories when directory is empty' do
         expect(result[:factories]).to be_nil
@@ -116,13 +131,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with fixtures' do
       let(:fixtures_dir) { Rails.root.join('spec/fixtures').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before do
         FileUtils.mkdir_p(fixtures_dir)
         File.write(File.join(fixtures_dir, 'users.yml'), "name: test\n")
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+      after do
+        FileUtils.rm_rf(fixtures_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'detects fixtures with location and count' do
         expect(result[:fixtures]).to be_a(Hash)
@@ -133,13 +152,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with test/fixtures (not spec/fixtures)' do
       let(:fixtures_dir) { Rails.root.join('test/fixtures').to_s }
+      let!(:test_existed) { Rails.root.join('test').directory? }
 
       before do
         FileUtils.mkdir_p(fixtures_dir)
         File.write(File.join(fixtures_dir, 'users.yml'), "name: test\n")
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+      after do
+        FileUtils.rm_rf(fixtures_dir)
+        FileUtils.rmdir(Rails.root.join('test').to_s) if !test_existed && Rails.root.join('test').directory? && Dir.empty?(Rails.root.join('test').to_s)
+      end
 
       it 'detects fixtures in test/fixtures' do
         expect(result[:fixtures]).to be_a(Hash)
@@ -149,9 +172,14 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with empty spec/fixtures (count zero)' do
       let(:fixtures_dir) { Rails.root.join('spec/fixtures').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before { FileUtils.mkdir_p(fixtures_dir) }
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      after do
+        FileUtils.rm_rf(fixtures_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'returns nil for fixtures when directory is empty' do
         expect(result[:fixtures]).to be_nil
@@ -160,13 +188,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with system tests' do
       let(:system_dir) { Rails.root.join('spec/system').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before do
         FileUtils.mkdir_p(system_dir)
         File.write(File.join(system_dir, 'login_test.rb'), 'require "test_helper"')
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+      after do
+        FileUtils.rm_rf(system_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'detects system tests with location and count' do
         expect(result[:system_tests]).to be_a(Hash)
@@ -177,13 +209,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with test/system (not spec/system)' do
       let(:system_dir) { Rails.root.join('test/system').to_s }
+      let!(:test_existed) { Rails.root.join('test').directory? }
 
       before do
         FileUtils.mkdir_p(system_dir)
         File.write(File.join(system_dir, 'login_test.rb'), 'require "test_helper"')
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+      after do
+        FileUtils.rm_rf(system_dir)
+        FileUtils.rmdir(Rails.root.join('test').to_s) if !test_existed && Rails.root.join('test').directory? && Dir.empty?(Rails.root.join('test').to_s)
+      end
 
       it 'detects system tests in test/system' do
         expect(result[:system_tests]).to be_a(Hash)
@@ -193,9 +229,14 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with empty spec/system (count zero)' do
       let(:system_dir) { Rails.root.join('spec/system').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before { FileUtils.mkdir_p(system_dir) }
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      after do
+        FileUtils.rm_rf(system_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'returns nil for system_tests when directory is empty' do
         expect(result[:system_tests]).to be_nil
@@ -204,13 +245,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with test helpers' do
       let(:support_dir) { Rails.root.join('spec/support').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before do
         FileUtils.mkdir_p(support_dir)
         File.write(File.join(support_dir, 'auth_helper.rb'), 'module AuthHelper; end')
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+      after do
+        FileUtils.rm_rf(support_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'detects test helpers from spec/support' do
         expect(result[:test_helpers]).to include('spec/support/auth_helper.rb')
@@ -219,13 +264,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with test/helpers (not spec/support)' do
       let(:helpers_dir) { Rails.root.join('test/helpers').to_s }
+      let!(:test_existed) { Rails.root.join('test').directory? }
 
       before do
         FileUtils.mkdir_p(helpers_dir)
         File.write(File.join(helpers_dir, 'auth_helper.rb'), 'module AuthHelper; end')
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+      after do
+        FileUtils.rm_rf(helpers_dir)
+        FileUtils.rmdir(Rails.root.join('test').to_s) if !test_existed && Rails.root.join('test').directory? && Dir.empty?(Rails.root.join('test').to_s)
+      end
 
       it 'detects test helpers from test/helpers' do
         expect(result[:test_helpers]).to include('test/helpers/auth_helper.rb')
@@ -234,13 +283,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with VCR cassettes in spec/cassettes' do
       let(:cassettes_dir) { Rails.root.join('spec/cassettes').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before do
         FileUtils.mkdir_p(cassettes_dir)
         File.write(File.join(cassettes_dir, 'api.yml'), "name: test\n")
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+      after do
+        FileUtils.rm_rf(cassettes_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'detects VCR cassettes with location and count' do
         expect(result[:vcr_cassettes]).to be_a(Hash)
@@ -251,13 +304,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with VCR cassettes in spec/vcr_cassettes' do
       let(:cassettes_dir) { Rails.root.join('spec/vcr_cassettes').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before do
         FileUtils.mkdir_p(cassettes_dir)
         File.write(File.join(cassettes_dir, 'api.yml'), "name: test\n")
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+      after do
+        FileUtils.rm_rf(cassettes_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'detects VCR cassettes in spec/vcr_cassettes' do
         expect(result[:vcr_cassettes]).to be_a(Hash)
@@ -267,13 +324,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with VCR cassettes in test/cassettes' do
       let(:cassettes_dir) { Rails.root.join('test/cassettes').to_s }
+      let!(:test_existed) { Rails.root.join('test').directory? }
 
       before do
         FileUtils.mkdir_p(cassettes_dir)
         File.write(File.join(cassettes_dir, 'api.yml'), "name: test\n")
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+      after do
+        FileUtils.rm_rf(cassettes_dir)
+        FileUtils.rmdir(Rails.root.join('test').to_s) if !test_existed && Rails.root.join('test').directory? && Dir.empty?(Rails.root.join('test').to_s)
+      end
 
       it 'detects VCR cassettes in test/cassettes' do
         expect(result[:vcr_cassettes]).to be_a(Hash)
@@ -283,13 +344,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with VCR cassettes in test/vcr_cassettes' do
       let(:cassettes_dir) { Rails.root.join('test/vcr_cassettes').to_s }
+      let!(:test_existed) { Rails.root.join('test').directory? }
 
       before do
         FileUtils.mkdir_p(cassettes_dir)
         File.write(File.join(cassettes_dir, 'api.yml'), "name: test\n")
       end
 
-      after { FileUtils.rm_rf(Rails.root.join('test').to_s) }
+      after do
+        FileUtils.rm_rf(cassettes_dir)
+        FileUtils.rmdir(Rails.root.join('test').to_s) if !test_existed && Rails.root.join('test').directory? && Dir.empty?(Rails.root.join('test').to_s)
+      end
 
       it 'detects VCR cassettes in test/vcr_cassettes' do
         expect(result[:vcr_cassettes]).to be_a(Hash)
@@ -299,9 +364,14 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with empty spec/cassettes (count zero)' do
       let(:cassettes_dir) { Rails.root.join('spec/cassettes').to_s }
+      let!(:spec_existed) { Rails.root.join('spec').directory? }
 
       before { FileUtils.mkdir_p(cassettes_dir) }
-      after { FileUtils.rm_rf(Rails.root.join('spec').to_s) }
+
+      after do
+        FileUtils.rm_rf(cassettes_dir)
+        FileUtils.rmdir(Rails.root.join('spec').to_s) if !spec_existed && Rails.root.join('spec').directory? && Dir.empty?(Rails.root.join('spec').to_s)
+      end
 
       it 'returns nil for vcr_cassettes when directory is empty' do
         expect(result[:vcr_cassettes]).to be_nil
@@ -313,6 +383,9 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
       let(:circleci_dir) { Rails.root.join('.circleci').to_s }
       let(:gitlab_file) { Rails.root.join('.gitlab-ci.yml').to_s }
       let(:travis_file) { Rails.root.join('.travis.yml').to_s }
+      let!(:ci_existed) do
+        { github: Rails.root.join('.github').directory?, circleci: Rails.root.join('.circleci').directory? }
+      end
 
       before do
         FileUtils.mkdir_p(github_dir)
@@ -324,8 +397,10 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
       end
 
       after do
+        github_root = Rails.root.join('.github')
         FileUtils.rm_rf(github_dir)
-        FileUtils.rm_rf(circleci_dir)
+        FileUtils.rmdir(github_root.to_s) if !ci_existed[:github] && github_root.directory? && Dir.empty?(github_root.to_s)
+        FileUtils.rm_rf(circleci_dir) unless ci_existed[:circleci]
         FileUtils.rm_f(gitlab_file)
         FileUtils.rm_f(travis_file)
       end
@@ -340,9 +415,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with Gemfile.lock containing reek' do
       let(:gemfile_lock) { Rails.root.join('Gemfile.lock').to_s }
+      let!(:original_content) { File.exist?(gemfile_lock) ? File.read(gemfile_lock) : nil }
 
       before { File.write(gemfile_lock, "reek (6.3.0)\n") }
-      after { FileUtils.rm_f(gemfile_lock) }
+
+      after do
+        if original_content
+          File.write(gemfile_lock, original_content)
+        else
+          FileUtils.rm_f(gemfile_lock)
+        end
+      end
 
       it 'detects reek coverage tool' do
         expect(result[:coverage]).to eq('reek')
@@ -351,9 +434,17 @@ RSpec.describe RailsAiBridge::Introspectors::TestIntrospector do
 
     context 'with Gemfile.lock without reek' do
       let(:gemfile_lock) { Rails.root.join('Gemfile.lock').to_s }
+      let!(:original_content) { File.exist?(gemfile_lock) ? File.read(gemfile_lock) : nil }
 
       before { File.write(gemfile_lock, "rails (7.1.0)\n") }
-      after { FileUtils.rm_f(gemfile_lock) }
+
+      after do
+        if original_content
+          File.write(gemfile_lock, original_content)
+        else
+          FileUtils.rm_f(gemfile_lock)
+        end
+      end
 
       it 'returns nil for coverage when reek is not present' do
         expect(result[:coverage]).to be_nil

--- a/spec/lib/rails_ai_bridge/introspectors/view_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/view_introspector_spec.rb
@@ -149,5 +149,79 @@ RSpec.describe RailsAiBridge::Introspectors::ViewIntrospector do
         expect(custom_result[:view_components]).to eq(['summary_component'])
       end
     end
+
+    context 'with haml, slim, and jbuilder templates' do
+      let(:views_dir) { Rails.root.join('app/views') }
+      let(:extra_templates) do
+        {
+          'posts/show.html.haml' => '%h= @post.title',
+          'posts/index.json.jbuilder' => 'json.(@posts, :id, :title)',
+          'posts/edit.html.slim' => 'h1 Edit'
+        }
+      end
+
+      before do
+        FileUtils.mkdir_p(views_dir.join('posts'))
+        extra_templates.each do |path, content|
+          File.write(views_dir.join(path), content)
+        end
+      end
+
+      after do
+        extra_templates.each_key { |path| FileUtils.rm_f(views_dir.join(path)) }
+      end
+
+      it 'detects haml, slim, and jbuilder template engines' do
+        engines = result[:template_engines]
+        expect(engines).to include('erb', 'haml', 'slim', 'jbuilder')
+      end
+    end
+
+    context 'with application partials' do
+      let(:views_dir) { Rails.root.join('app/views') }
+      let(:app_partial) { views_dir.join('application/_nav.html.erb') }
+
+      before do
+        FileUtils.mkdir_p(views_dir.join('application'))
+        File.write(app_partial, '<nav>Menu</nav>')
+      end
+
+      after { FileUtils.rm_f(app_partial) }
+
+      it 'groups application partials as shared' do
+        expect(result[:partials][:shared]).to include('_nav.html.erb')
+      end
+    end
+
+    context 'with unreadable helper file' do
+      let(:helpers_dir) { Rails.root.join('app/helpers') }
+      let(:bad_helper) { helpers_dir.join('bad_helper.rb') }
+
+      before do
+        File.write(bad_helper, 'module BadHelper; end')
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(bad_helper.to_s).and_raise(StandardError, 'read error')
+      end
+
+      after do
+        allow(File).to receive(:read).and_call_original
+        FileUtils.rm_f(bad_helper)
+      end
+
+      it 'skips unreadable helper files' do
+        helper_files = result[:helpers].pluck(:file)
+        expect(helper_files).not_to include('bad_helper.rb')
+      end
+    end
+
+    context 'when an extract method raises' do
+      let(:result) { introspector.call }
+
+      before { allow(introspector).to receive(:extract_layouts).and_raise(StandardError, 'extract boom') }
+
+      it 'returns error hash' do
+        expect(result[:error]).to eq('extract boom')
+      end
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/rubydex_adapter/incremental_indexer_spec.rb
+++ b/spec/lib/rails_ai_bridge/rubydex_adapter/incremental_indexer_spec.rb
@@ -280,4 +280,107 @@ RSpec.describe RailsAiBridge::RubydexAdapter::IncrementalIndexer do
       expect(result.errors.first).to include('boom')
     end
   end
+
+  describe 'private methods' do
+    let(:indexer) { described_class.new }
+
+    describe '#reindex_file' do
+      let(:graph) { double('Graph') }
+      let(:path) { File.join(root, 'test.rb') }
+
+      before do
+        File.write(path, 'class Test; end')
+        allow(graph).to receive(:respond_to?).with(:delete_document).and_return(true)
+        allow(graph).to receive(:respond_to?).with(:index_source).and_return(true)
+        allow(graph).to receive(:document).with(path).and_return(nil)
+        allow(graph).to receive(:delete_document)
+        allow(graph).to receive(:index_source)
+      end
+
+      it 'skips delete_document when document is nil' do
+        indexer.send(:reindex_file, graph, path)
+        expect(graph).not_to have_received(:delete_document)
+        expect(graph).to have_received(:index_source)
+      end
+
+      it 'rescues Errno::ENOENT when file is deleted during reindex' do
+        allow(File).to receive(:read).and_raise(Errno::ENOENT)
+        expect { indexer.send(:reindex_file, graph, path) }.not_to raise_error
+      end
+
+      it 'rescues ArgumentError on bad encoding' do
+        allow(File).to receive(:read).and_raise(ArgumentError, 'invalid byte sequence')
+        expect { indexer.send(:reindex_file, graph, path) }.not_to raise_error
+      end
+    end
+
+    describe '#remove_file' do
+      it 'is a no-op when graph does not support delete_document' do
+        graph = double('Graph')
+        allow(graph).to receive(:respond_to?).with(:delete_document).and_return(false)
+        indexer.send(:remove_file, graph, '/path/to/file.rb')
+      end
+
+      it 'calls delete_document when supported' do
+        graph = double('Graph')
+        allow(graph).to receive(:respond_to?).with(:delete_document).and_return(true)
+        expect(graph).to receive(:delete_document).with('/path/to/file.rb')
+        indexer.send(:remove_file, graph, '/path/to/file.rb')
+      end
+    end
+
+    describe '#file_mtime' do
+      it 'returns nil for non-existent file' do
+        expect(indexer.send(:file_mtime, '/nonexistent/path.rb')).to be_nil
+      end
+    end
+
+    describe '#threshold_exceeded?' do
+      it 'returns true when total is zero and changed is positive' do
+        expect(indexer.send(:threshold_exceeded?, 1, 0, 0.3)).to be true
+      end
+
+      it 'returns false when total is zero and changed is zero' do
+        expect(indexer.send(:threshold_exceeded?, 0, 0, 0.3)).to be false
+      end
+    end
+
+    describe '#persist_mtimes error handling' do
+      it 'rescues errors during persist' do
+        allow(FileUtils).to receive(:mkdir_p).and_raise(StandardError, 'mkdir failed')
+        expect { indexer.send(:persist_mtimes, {}, '/some/path') }.not_to raise_error
+      end
+    end
+
+    describe '#load_mtimes' do
+      it 'returns empty hash when index_path is nil' do
+        expect(indexer.send(:load_mtimes, nil)).to eq({})
+      end
+
+      it 'returns empty hash when mtimes file does not exist' do
+        expect(indexer.send(:load_mtimes, root)).to eq({})
+      end
+
+      it 'rescues errors during load' do
+        path = File.join(root, 'mtimes.json')
+        File.write(path, 'invalid json')
+        expect(indexer.send(:load_mtimes, root)).to eq({})
+      end
+    end
+
+    describe '#deserialize_mtimes' do
+      it 'handles nil values in JSON' do
+        content = JSON.dump({ 'file.rb' => nil })
+        result = indexer.send(:deserialize_mtimes, content)
+        expect(result['file.rb']).to be_nil
+      end
+    end
+
+    describe '#serialize_mtimes' do
+      it 'handles nil mtime values' do
+        result = indexer.send(:serialize_mtimes, { 'file.rb' => nil })
+        expect(result['file.rb']).to be_nil
+      end
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/rubydex_adapter/serializer_spec.rb
+++ b/spec/lib/rails_ai_bridge/rubydex_adapter/serializer_spec.rb
@@ -202,4 +202,95 @@ RSpec.describe RailsAiBridge::RubydexAdapter::Serializer do
       expect(result).to eq('declaration')
     end
   end
+
+  describe '.relativize_path' do
+    it 'returns path unchanged when root is nil' do
+      expect(described_class.relativize_path('/some/path', nil)).to eq('/some/path')
+    end
+
+    it 'returns path unchanged when path does not start with root' do
+      expect(described_class.relativize_path('/other/path', '/tmp/test_root')).to eq('/other/path')
+    end
+
+    it 'strips root prefix when path starts with root' do
+      expect(described_class.relativize_path('/tmp/test_root/app/models/user.rb', '/tmp/test_root')).to eq('app/models/user.rb')
+    end
+  end
+
+  describe '.format_location edge cases' do
+    it 'returns to_s when location has no path' do
+      loc = double('loc', to_s: 'string-loc', respond_to?: false)
+      allow(loc).to receive(:respond_to?).with(:path).and_return(true)
+      allow(loc).to receive(:path).and_return(nil)
+
+      expect(described_class.format_location(loc, '/tmp/test_root')).to eq('string-loc')
+    end
+  end
+
+  describe '#detailed_declaration_to_hash with nil relations' do
+    let(:decl) do
+      double(
+        'decl',
+        name: 'Empty',
+        class: double(name: 'Rubydex::ClassDeclaration'),
+        respond_to?: false
+      )
+    end
+
+    before do
+      allow(decl).to receive(:respond_to?).with(:unqualified_name).and_return(false)
+      allow(decl).to receive(:respond_to?).with(:definitions).and_return(false)
+      allow(decl).to receive(:respond_to?).with(:ancestors).and_return(false)
+      allow(decl).to receive(:respond_to?).with(:descendants).and_return(false)
+      allow(decl).to receive(:respond_to?).with(:owner).and_return(true)
+      allow(decl).to receive(:owner).and_return(nil)
+    end
+
+    it 'compacts away nil definitions, ancestors, descendants, and owner' do
+      result = serializer.detailed_declaration_to_hash(decl)
+
+      expect(result).not_to have_key(:definitions)
+      expect(result).not_to have_key(:ancestors)
+      expect(result).not_to have_key(:descendants)
+      expect(result).not_to have_key(:owner)
+      expect(result[:name]).to eq('Empty')
+      expect(result[:type]).to eq('class')
+    end
+  end
+
+  describe '#definition_to_hash with deprecated false' do
+    let(:defn) do
+      double('defn', name: 'safe_method', respond_to?: false)
+    end
+
+    before do
+      allow(defn).to receive(:respond_to?).with(:location).and_return(false)
+      allow(defn).to receive(:respond_to?).with(:comments).and_return(false)
+      allow(defn).to receive(:respond_to?).with(:deprecated?).and_return(true)
+      allow(defn).to receive(:deprecated?).and_return(false)
+    end
+
+    it 'omits deprecated when false' do
+      result = serializer.definition_to_hash(defn)
+      expect(result).not_to have_key(:deprecated)
+    end
+  end
+
+  describe '#definition_to_hash with comments blank' do
+    let(:defn) do
+      double('defn', name: 'method', respond_to?: false)
+    end
+
+    before do
+      allow(defn).to receive(:respond_to?).with(:location).and_return(false)
+      allow(defn).to receive(:respond_to?).with(:comments).and_return(true)
+      allow(defn).to receive(:comments).and_return('')
+      allow(defn).to receive(:respond_to?).with(:deprecated?).and_return(false)
+    end
+
+    it 'omits comments when blank' do
+      result = serializer.definition_to_hash(defn)
+      expect(result).not_to have_key(:comments)
+    end
+  end
 end

--- a/spec/lib/rails_ai_bridge/tools/search_semantic_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/search_semantic_spec.rb
@@ -101,6 +101,72 @@ RSpec.describe RailsAiBridge::Tools::SearchSemantic do
 
         described_class.call(query: 'User', max_results: -5)
       end
+
+      it 'normalizes zero max_results to default' do
+        allow(mock_adapter).to receive(:search)
+          .with('User', max_results: 20)
+          .and_return([])
+
+        described_class.call(query: 'User', max_results: 0)
+      end
+
+      it 'includes path in no results message' do
+        allow(mock_adapter).to receive(:file_declarations)
+          .with('app/models')
+          .and_return([])
+
+        response = described_class.call(query: 'User', path: 'app/models')
+        text = response.content.first[:text]
+        expect(text).to include("No declarations found matching 'User' in app/models")
+      end
+
+      it 'formats results with owner, ancestors, descendants, and definitions' do
+        allow(mock_adapter).to receive(:search)
+          .with('User', max_results: 20)
+          .and_return([
+                        {
+                          name: 'User',
+                          type: 'class',
+                          location: 'app/models/user.rb',
+                          owner: 'ApplicationRecord',
+                          ancestors: %w[ActiveRecord::Base Comparable],
+                          descendants: %w[AdminUser GuestUser],
+                          definitions: [
+                            { name: 'save', location: 'app/models/user.rb:10' },
+                            { name: 'validate' }
+                          ]
+                        }
+                      ])
+
+        response = described_class.call(query: 'User')
+        text = response.content.first[:text]
+        expect(text).to include('**Owner:** `ApplicationRecord`')
+        expect(text).to include('**Ancestors:** ActiveRecord::Base, Comparable')
+        expect(text).to include('**Descendants:** AdminUser, GuestUser')
+        expect(text).to include('**Definitions:**')
+        expect(text).to include('`save` (`app/models/user.rb:10`)')
+        expect(text).to include('`validate`')
+      end
+
+      it 'handles results with nil type and nil name' do
+        allow(mock_adapter).to receive(:search)
+          .with('Unknown', max_results: 20)
+          .and_return([{ name: nil, type: nil, location: nil }])
+
+        response = described_class.call(query: 'Unknown')
+        text = response.content.first[:text]
+        expect(text).to include('unknown')
+      end
+
+      it 'includes path in results header' do
+        allow(mock_adapter).to receive(:file_declarations)
+          .with('app/models')
+          .and_return([{ name: 'User', type: 'class', location: 'app/models/user.rb' }])
+
+        response = described_class.call(query: 'user', path: 'app/models')
+        text = response.content.first[:text]
+        expect(text).to include("Semantic Search Results for 'user' in app/models")
+      end
     end
   end
 

--- a/spec/lib/rails_ai_bridge/tools/search_semantic_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/search_semantic_spec.rb
@@ -156,9 +156,9 @@ RSpec.describe RailsAiBridge::Tools::SearchSemantic do
         response = described_class.call(query: 'Unknown')
         text = response.content.first[:text]
         # name falls back to 'unknown'; type badge is omitted; location line is omitted
-        expect(text).to include('### unknown')
-        expect(text).not_to include('[null]')
-        expect(text).not_to include('**Location:**')
+        expect(text).to match(/^### unknown\s*$/)     # name+type fallback: header is '### unknown' with no [type] badge
+        expect(text).not_to include('[null]')         # no literal null badge leaks through
+        expect(text).not_to include('**Location:**')  # location fallback: line omitted
       end
 
       it 'includes path in results header' do

--- a/spec/lib/rails_ai_bridge/tools/search_semantic_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/search_semantic_spec.rb
@@ -155,7 +155,10 @@ RSpec.describe RailsAiBridge::Tools::SearchSemantic do
 
         response = described_class.call(query: 'Unknown')
         text = response.content.first[:text]
-        expect(text).to include('unknown')
+        # name falls back to 'unknown'; type badge is omitted; location line is omitted
+        expect(text).to include('### unknown')
+        expect(text).not_to include('[null]')
+        expect(text).not_to include('**Location:**')
       end
 
       it 'includes path in results header' do

--- a/spec/lib/rails_ai_bridge/tools/search_semantic_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/search_semantic_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe RailsAiBridge::Tools::SearchSemantic do
       end
 
       it 'normalizes negative max_results to default' do
-        allow(mock_adapter).to receive(:search)
+        expect(mock_adapter).to receive(:search)
           .with('User', max_results: 20)
           .and_return([])
 
@@ -103,7 +103,7 @@ RSpec.describe RailsAiBridge::Tools::SearchSemantic do
       end
 
       it 'normalizes zero max_results to default' do
-        allow(mock_adapter).to receive(:search)
+        expect(mock_adapter).to receive(:search)
           .with('User', max_results: 20)
           .and_return([])
 


### PR DESCRIPTION
## Summary
- Raise branch coverage to >=90% for 5 files in introspection and Rubydex paths
- `controller_introspector.rb`: 83.3% -> 100%
- `controller_introspector/filter_extractor.rb`: 87.0% -> 100%
- `active_storage_introspector.rb`: 83.3% -> 100%
- `stimulus_introspector.rb`: 87.5% -> 100%
- `rubydex_adapter.rb`: 90.2% (already met threshold)
- Fixed pre-existing RuboCop offenses in spec files (File.delete -> FileUtils.rm_f, pluck, semicolons, keys.each)
- Overall branch coverage: 76.02% -> 82.05%

#### Test plan
- [x] 2875 examples, 0 failures
- [x] RuboCop: 0 offenses on modified files
- [x] Reek: 0 warnings on modified files
- [x] All target files at >=90% branch coverage

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage across snapshot caching, application introspection, controllers, models, routes, databases, assets, views, jobs, DevOps, localization, schemas, and testing tools.
  - Added extensive validation for missing files, unreadable resources, unavailable framework components, parsing failures, application-root errors, and safe fallback behavior.
  - Improved coverage for semantic enrichment, search result formatting, serialization, and incremental indexing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->