### PR TITLE
test: raise branch coverage to 90/90 for tools, serializers, and generators

### DIFF
--- a/spec/lib/rails_ai_bridge/serializers/context_summary_spec.rb
+++ b/spec/lib/rails_ai_bridge/serializers/context_summary_spec.rb
@@ -107,6 +107,31 @@ RSpec.describe RailsAiBridge::Serializers::ContextSummary do
 
       expect(described_class.model_relevance_score(data, name: 'Order', context: context)).to be >= 9
     end
+
+    it 'returns 0 when data is not a Hash' do
+      expect(described_class.model_relevance_score(nil, name: 'User', context: {})).to eq(0)
+    end
+
+    it 'handles nil name with route density lookup' do
+      data = { table_name: 'posts', associations: [], validations: [] }
+      context = { routes: { by_controller: { 'posts' => [{}] } } }
+      # nil name skips name-based bonuses; table_name match + 1 route = base score
+      expect(described_class.model_relevance_score(data, name: nil, context: context)).to eq(21)
+    end
+
+    it 'adds bonus score for hot and large database size buckets' do
+      hot_context = { database_stats: { tables: [{ table: 'users', size_bucket: 'hot' }] } }
+      large_context = { database_stats: { tables: [{ table: 'posts', size_bucket: 'large' }] } }
+      hot_data = { table_name: 'users', associations: [], validations: [] }
+      large_data = { table_name: 'posts', associations: [], validations: [] }
+
+      hot_score = described_class.model_relevance_score(hot_data, name: 'User', context: hot_context)
+      large_score = described_class.model_relevance_score(large_data, name: 'Post', context: large_context)
+      base_score = described_class.model_relevance_score({ table_name: 'x', associations: [], validations: [] },
+                                                         name: 'X', context: {})
+      expect(hot_score - base_score).to eq(12)
+      expect(large_score - base_score).to eq(8)
+    end
   end
 
   describe '.models_by_relevance' do
@@ -118,6 +143,22 @@ RSpec.describe RailsAiBridge::Serializers::ContextSummary do
       }
 
       expect(described_class.models_by_relevance(models).map(&:first)).to eq(%w[Account Bee Zebra])
+    end
+
+    it 'returns empty array when models is not a Hash' do
+      expect(described_class.models_by_relevance(nil)).to eq([])
+      expect(described_class.models_by_relevance([])).to eq([])
+    end
+  end
+
+  describe '.route_target_controller_count' do
+    it 'returns nil when routes has an error' do
+      context = { routes: { error: 'DB unavailable' } }
+      expect(described_class.route_target_controller_count(context)).to be_nil
+    end
+
+    it 'returns nil when routes is not a Hash' do
+      expect(described_class.route_target_controller_count({})).to be_nil
     end
   end
 
@@ -285,6 +326,11 @@ RSpec.describe RailsAiBridge::Serializers::ContextSummary do
 
     it 'returns false when recent is empty' do
       expect(described_class.recently_migrated?('users', { recent: [] })).to be false
+    end
+
+    it 'returns false when version string is shorter than 8 characters' do
+      migrations = { recent: [{ version: '12345', filename: '12345_create_users.rb' }] }
+      expect(described_class.recently_migrated?('users', migrations)).to be false
     end
   end
 

--- a/spec/lib/rails_ai_bridge/serializers/formatters/sections/section_formatter_branches_spec.rb
+++ b/spec/lib/rails_ai_bridge/serializers/formatters/sections/section_formatter_branches_spec.rb
@@ -1,0 +1,491 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Branch-coverage specs for serializer section formatters. Each formatter is
+# exercised through its public +.call+ interface with both present and
+# missing/nil data to cover safe-navigation and early-return branches.
+RSpec.describe RailsAiBridge::Serializers::Formatters::Sections do
+  # :reek:UtilityFunction
+  def render(klass, ctx)
+    klass.new(ctx).call
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::MiddlewareFormatter do
+    it 'renders custom middleware with detected patterns' do
+      ctx = { middleware: { custom_middleware: [
+        { class_name: 'CorsMiddleware', file: 'app/middleware/cors.rb', detected_patterns: %w[CORS Rack] }
+      ] } }
+      result = render(described_class, ctx)
+      expect(result).to include('`CorsMiddleware`')
+      expect(result).to include('CORS, Rack')
+    end
+
+    it 'renders custom middleware without detected patterns' do
+      ctx = { middleware: { custom_middleware: [
+        { class_name: 'SimpleMiddleware', file: 'app/middleware/simple.rb' }
+      ] } }
+      result = render(described_class, ctx)
+      expect(result).to include('`SimpleMiddleware`')
+      expect(result).not_to include('—')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::SeedsFormatter do
+    it 'renders seeds file details with faker and environment conditional' do
+      ctx = { seeds: {
+        seeds_file: { exists: true, uses_faker: true, environment_conditional: true },
+        models_seeded: %w[User Post],
+        seed_files: [{ file: 'db/seeds.rb' }, { file: 'db/seeds/production.rb' }]
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('Seeds file: exists')
+      expect(result).to include('Uses Faker: yes')
+      expect(result).to include('Environment-conditional: yes')
+      expect(result).to include('Models seeded: User, Post')
+      expect(result).to include('Seed Files')
+      expect(result).to include('db/seeds/production.rb')
+    end
+
+    it 'renders seeds file as missing' do
+      ctx = { seeds: { seeds_file: { exists: false } } }
+      result = render(described_class, ctx)
+      expect(result).to include('Seeds file: missing')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::ActiveStorageFormatter do
+    it 'returns nil when no models or services' do
+      expect(render(described_class, { active_storage: { models: [], services: [] } })).to be_nil
+    end
+
+    it 'renders services only' do
+      ctx = { active_storage: { models: [], services: %w[local s3] } }
+      result = render(described_class, ctx)
+      expect(result).to include('Services:')
+      expect(result).to include('`local`')
+      expect(result).not_to include('Attached to')
+    end
+
+    it 'renders both models and services' do
+      ctx = { active_storage: { models: ['User'], services: ['s3'] } }
+      result = render(described_class, ctx)
+      expect(result).to include('Attached to:')
+      expect(result).to include('Services:')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::AuthFormatter do
+    it 'returns nil when no strategies or models' do
+      expect(render(described_class, { auth: { strategies: [], models: [] } })).to be_nil
+    end
+
+    it 'renders models only' do
+      ctx = { auth: { strategies: [], models: ['User'] } }
+      result = render(described_class, ctx)
+      expect(result).to include('AuthN models:')
+      expect(result).not_to include('Strategies:')
+    end
+
+    it 'renders both strategies and models' do
+      ctx = { auth: { strategies: ['devise'], models: ['User'] } }
+      result = render(described_class, ctx)
+      expect(result).to include('Strategies:')
+      expect(result).to include('AuthN models:')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::DevopsFormatter do
+    it 'returns nil when no devops data' do
+      expect(render(described_class, { devops: {} })).to be_nil
+    end
+
+    it 'renders docker, kamal, procfile, and health check' do
+      ctx = { devops: {
+        ci_cd: ['GitHub Actions'],
+        docker: 'Dockerfile',
+        kamal: true,
+        procfile_entries: [{ name: 'web', command: 'bundle exec puma' }],
+        health_check_route: '/health'
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('**Docker:**')
+      expect(result).to include('**Kamal:** yes')
+      expect(result).to include('Procfile')
+      expect(result).to include('web: bundle exec puma')
+      expect(result).to include('Health Check')
+      expect(result).to include('/health')
+    end
+
+    it 'renders with only docker' do
+      ctx = { devops: { docker: 'Dockerfile' } }
+      result = render(described_class, ctx)
+      expect(result).to include('**Docker:**')
+      expect(result).not_to include('**Kamal:**')
+      expect(result).not_to include('Health Check')
+    end
+
+    it 'renders with only kamal' do
+      ctx = { devops: { kamal: true } }
+      result = render(described_class, ctx)
+      expect(result).to include('**Kamal:** yes')
+      expect(result).not_to include('**Docker:**')
+      expect(result).not_to include('Health Check')
+    end
+
+    it 'renders with only health check route' do
+      ctx = { devops: { health_check_route: '/up' } }
+      result = render(described_class, ctx)
+      expect(result).to include('Health Check')
+      expect(result).not_to include('**Docker:**')
+      expect(result).not_to include('**Kamal:**')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::TurboFormatter do
+    it 'returns nil when all turbo data empty' do
+      ctx = { turbo: { turbo_frames: [], turbo_streams: [], model_broadcasts: [] } }
+      expect(render(described_class, ctx)).to be_nil
+    end
+
+    it 'renders turbo frames' do
+      ctx = { turbo: { turbo_frames: [{ id: 'modal', file: 'app/views/posts/_modal.html.erb' }],
+                       turbo_streams: [], model_broadcasts: [] } }
+      result = render(described_class, ctx)
+      expect(result).to include('Turbo Frames')
+      expect(result).to include('modal')
+    end
+
+    it 'renders model broadcasts' do
+      ctx = { turbo: { turbo_frames: [], turbo_streams: [], model_broadcasts: [
+        { model: 'Post', methods: ['broadcast_replace'] }
+      ] } }
+      result = render(described_class, ctx)
+      expect(result).to include('Model Broadcasts')
+      expect(result).to include('Post')
+      expect(result).to include('broadcast_replace')
+    end
+
+    it 'renders heading when all turbo keys are nil' do
+      ctx = { turbo: { turbo_frames: nil, turbo_streams: nil, model_broadcasts: nil } }
+      result = render(described_class, ctx)
+      expect(result).to include('Hotwire / Turbo')
+      expect(result).not_to include('Turbo Frames')
+      expect(result).not_to include('Turbo Stream')
+      expect(result).not_to include('Model Broadcasts')
+    end
+
+    it 'renders broadcasts when turbo_streams key is nil' do
+      ctx = { turbo: { turbo_frames: [], turbo_streams: nil, model_broadcasts: [
+        { model: 'Comment', methods: ['broadcast_append'] }
+      ] } }
+      result = render(described_class, ctx)
+      expect(result).to include('Model Broadcasts')
+      expect(result).not_to include('Turbo Stream Templates')
+    end
+
+    it 'renders streams when model_broadcasts key is nil' do
+      ctx = { turbo: { turbo_frames: [], turbo_streams: ['comments/create'], model_broadcasts: nil } }
+      result = render(described_class, ctx)
+      expect(result).to include('Turbo Stream Templates')
+      expect(result).not_to include('Model Broadcasts')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::ActionMailboxFormatter do
+    it 'returns nil when no mailboxes' do
+      expect(render(described_class, { action_mailbox: { mailboxes: [] } })).to be_nil
+    end
+
+    it 'returns nil when mailboxes key is nil' do
+      expect(render(described_class, { action_mailbox: { mailboxes: nil } })).to be_nil
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::ActionTextFormatter do
+    it 'returns nil when no models' do
+      expect(render(described_class, { action_text: { models: [] } })).to be_nil
+    end
+
+    it 'returns nil when models key is nil' do
+      expect(render(described_class, { action_text: { models: nil } })).to be_nil
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::ApiFormatter do
+    it 'returns nil when no endpoints' do
+      expect(render(described_class, { api: { endpoints: [] } })).to be_nil
+    end
+
+    it 'renders version, base path, and documentation url' do
+      ctx = { api: {
+        version: 'v1',
+        base_path: '/api/v1',
+        documentation_url: 'https://docs.example.com',
+        endpoints: [{ verb: 'GET', path: '/widgets', controller: 'Widgets', action: 'index' }]
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('Version: `v1`')
+      expect(result).to include('Base path: `/api/v1`')
+      expect(result).to include('Documentation: [https://docs.example.com]')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::AssetsFormatter do
+    it 'returns nil when no asset data' do
+      expect(render(described_class, { assets: {} })).to be_nil
+    end
+
+    it 'renders js bundler, importmap pins, css framework, and manifest files' do
+      ctx = { assets: {
+        precompiler: 'sprockets',
+        js_bundler: 'esbuild',
+        importmap_pins: %w[application controllers],
+        css_framework: 'tailwindcss',
+        manifest_files: ['app/assets/config/manifest.js']
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('JavaScript bundler:')
+      expect(result).to include('Importmap pins:')
+      expect(result).to include('`application`')
+      expect(result).to include('CSS framework:')
+      expect(result).to include('Manifest files:')
+    end
+
+    it 'renders with only js bundler' do
+      ctx = { assets: { js_bundler: 'esbuild' } }
+      result = render(described_class, ctx)
+      expect(result).to include('JavaScript bundler:')
+      expect(result).not_to include('CSS framework:')
+    end
+
+    it 'renders with only css framework' do
+      ctx = { assets: { css_framework: 'tailwindcss' } }
+      result = render(described_class, ctx)
+      expect(result).to include('CSS framework:')
+      expect(result).not_to include('JavaScript bundler:')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::EnginesFormatter do
+    it 'returns nil when no mounted engines' do
+      expect(render(described_class, { engines: { mounted: [] } })).to be_nil
+    end
+
+    it 'returns nil when mounted key is nil' do
+      expect(render(described_class, { engines: { mounted: nil } })).to be_nil
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::I18nFormatter do
+    it 'returns nil when no locales' do
+      expect(render(described_class, { i18n: { locales: [] } })).to be_nil
+    end
+
+    it 'returns nil when locales key is nil' do
+      expect(render(described_class, { i18n: { locales: nil } })).to be_nil
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::MultiDatabaseFormatter do
+    it 'returns nil when multi_db is false' do
+      expect(render(described_class, { multi_database: { multi_db: false } })).to be_nil
+    end
+
+    it 'renders databases with replica flag' do
+      ctx = { multi_database: {
+        multi_db: true,
+        databases: [
+          { name: 'primary', adapter: 'postgresql', replica: false },
+          { name: 'replica', adapter: 'postgresql', replica: true }
+        ]
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('`primary` — postgresql')
+      expect(result).to include('`replica` — postgresql (replica)')
+    end
+
+    it 'renders model connections with and without connects_to' do
+      ctx = { multi_database: {
+        multi_db: true,
+        databases: [],
+        model_connections: [
+          { model: 'User', connects_to: 'replica' },
+          { model: 'AuditLog', connects_to: nil }
+        ]
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('Model Connections')
+      expect(result).to include('`User` → replica')
+      expect(result).to include('`AuditLog` → custom connection')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::RakeTasksFormatter do
+    it 'returns nil when no tasks' do
+      expect(render(described_class, { rake_tasks: { tasks: [] } })).to be_nil
+    end
+
+    it 'renders tasks with and without descriptions' do
+      ctx = { rake_tasks: { tasks: [
+        { name: 'db:migrate', description: 'Migrate the database' },
+        { name: 'db:seed', description: nil }
+      ] } }
+      result = render(described_class, ctx)
+      expect(result).to include('`db:migrate` — Migrate the database')
+      expect(result).to include('`db:seed`')
+      expect(result).not_to include('`db:seed` —')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::RoutesFormatter do
+    it 'renders routes grouped by controller with actions' do
+      ctx = { routes: {
+        total_routes: 2,
+        by_controller: {
+          'UsersController' => [{ verb: 'GET', path: '/users', action: 'index' }],
+          'PostsController' => [{ verb: 'POST', path: '/posts', action: 'create' }]
+        }
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('### UsersController')
+      expect(result).to include('`GET /users` → index')
+      expect(result).to include('### PostsController')
+    end
+
+    it 'renders heading when by_controller is nil' do
+      ctx = { routes: { total_routes: 0 } }
+      result = render(described_class, ctx)
+      expect(result).to include('Routes (0 total)')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::SchemaFormatter do
+    it 'renders tables with nil columns gracefully' do
+      ctx = { schema: {
+        total_tables: 1,
+        tables: { 'users' => { columns: nil } }
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('### users')
+    end
+
+    it 'renders multiple tables with columns' do
+      ctx = { schema: {
+        total_tables: 2,
+        tables: {
+          'users' => { columns: [{ name: 'id', type: 'integer' }, { name: 'email', type: 'string' }] },
+          'posts' => { columns: [{ name: 'id', type: 'integer' }] }
+        }
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('### users')
+      expect(result).to include('`id` (integer)')
+      expect(result).to include('`email` (string)')
+      expect(result).to include('### posts')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::TestsFormatter do
+    it 'renders all test details' do
+      ctx = { tests: {
+        framework: 'RSpec',
+        factories: { location: 'spec/factories', count: 5 },
+        fixtures: { location: 'spec/fixtures', count: 3 },
+        system_tests: { location: 'spec/system' },
+        ci_config: ['GitHub Actions', 'CircleCI'],
+        coverage: 'SimpleCov 95%'
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('Framework: RSpec')
+      expect(result).to include('Factories: spec/factories (5 files)')
+      expect(result).to include('Fixtures: spec/fixtures (3 files)')
+      expect(result).to include('System tests: spec/system')
+      expect(result).to include('CI: GitHub Actions, CircleCI')
+      expect(result).to include('Coverage: SimpleCov 95%')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::JobsFormatter do
+    it 'returns nil when no adapter and no jobs' do
+      expect(render(described_class, { jobs: { total_jobs: 0 } })).to be_nil
+    end
+
+    it 'renders with adapter only' do
+      ctx = { jobs: { total_jobs: 0, adapter: 'sidekiq' } }
+      result = render(described_class, ctx)
+      expect(result).to include('Adapter: `sidekiq`')
+      expect(result).not_to include('Defined Jobs')
+    end
+
+    it 'renders with jobs only (no adapter)' do
+      ctx = { jobs: { total_jobs: 2, jobs: %w[FooJob BarJob] } }
+      result = render(described_class, ctx)
+      expect(result).to include('Defined Jobs')
+      expect(result).to include('`FooJob`')
+      expect(result).not_to include('Adapter')
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Formatters::Sections::ConfigFormatter do
+    it 'returns nil when no config data' do
+      expect(render(described_class, { config: {} })).to be_nil
+    end
+
+    it 'renders all config details' do
+      ctx = { config: {
+        cache_store: ':redis_cache_store',
+        session_store: ':cookie_store',
+        timezone: 'UTC',
+        middleware_stack: %w[Rack::Cors Rack::Attack],
+        initializers: %w[devise.rb sidekiq.rb],
+        current_attributes: ['Current.user']
+      } }
+      result = render(described_class, ctx)
+      expect(result).to include('Cache store:')
+      expect(result).to include('Session store:')
+      expect(result).to include('Timezone:')
+      expect(result).to include('Middleware Stack')
+      expect(result).to include('`Rack::Cors`')
+      expect(result).to include('Initializers')
+      expect(result).to include('`devise.rb`')
+      expect(result).to include('CurrentAttributes')
+      expect(result).to include('`Current.user`')
+    end
+
+    it 'renders with only session store' do
+      ctx = { config: { session_store: ':cookie_store' } }
+      result = render(described_class, ctx)
+      expect(result).to include('Session store:')
+      expect(result).not_to include('Cache store:')
+    end
+
+    it 'renders with only timezone' do
+      ctx = { config: { timezone: 'UTC' } }
+      result = render(described_class, ctx)
+      expect(result).to include('Timezone:')
+      expect(result).not_to include('Session store:')
+    end
+
+    it 'renders with only middleware stack' do
+      ctx = { config: { middleware_stack: ['Rack::Cors'] } }
+      result = render(described_class, ctx)
+      expect(result).to include('Middleware Stack')
+      expect(result).not_to include('Timezone:')
+    end
+
+    it 'renders with only initializers' do
+      ctx = { config: { initializers: ['devise.rb'] } }
+      result = render(described_class, ctx)
+      expect(result).to include('Initializers')
+      expect(result).not_to include('Middleware Stack')
+    end
+
+    it 'renders with only current attributes' do
+      ctx = { config: { current_attributes: ['Current.user'] } }
+      result = render(described_class, ctx)
+      expect(result).to include('CurrentAttributes')
+      expect(result).not_to include('Initializers')
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/tools/get_context_branches_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_context_branches_spec.rb
@@ -1,0 +1,646 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+
+# Branch-coverage specs for GetContext::Composer and GetContext::Resolver,
+# exercised through the public +.call+ interface.
+RSpec.describe RailsAiBridge::Tools::GetContext do
+  let(:app_root) { Pathname.new(Dir.mktmpdir('get-context-branches-')) }
+
+  before do
+    allow(described_class).to receive(:rails_app).and_return(instance_double(Rails::Application, root: app_root))
+  end
+
+  after do
+    FileUtils.remove_entry(app_root)
+  end
+
+  describe 'Composer branch coverage' do
+    let(:composer) do
+      RailsAiBridge::Tools::GetContext::Composer.new(resolution: resolution, snapshots: snapshots,
+                                                     detail: detail, test_paths: test_paths)
+    end
+
+    let(:snapshots) { {} }
+    let(:test_paths) { [] }
+
+    context 'with hard error (nothing resolved)' do
+      let(:resolution) do
+        { error: 'Nothing matched feature foo', model_name: nil, controller_name: nil, table_name: nil,
+          setup_messages: ['Schema introspection not available.'], requested_feature: 'foo' }
+      end
+      let(:detail) { 'summary' }
+
+      it 'returns error and setup messages' do
+        result = composer.call
+        expect(result).to include('Nothing matched feature foo')
+        expect(result).to include('Schema introspection not available.')
+      end
+    end
+
+    context 'with model data nil' do
+      let(:resolution) do
+        { model_name: 'Ghost', model_data: nil, table_name: nil, table_data: nil,
+          controller_name: nil, controller_data: nil, routes: {},
+          setup_messages: [], schema_source: :live, requested_model: 'Ghost' }
+      end
+      let(:detail) { 'summary' }
+
+      it 'renders model-not-found message' do
+        result = composer.call
+        expect(result).to include("Model 'Ghost' has no introspection payload")
+      end
+    end
+
+    context 'with model data error' do
+      let(:resolution) do
+        { model_name: 'Broken', model_data: { error: 'load failed' },
+          table_name: nil, table_data: nil, controller_name: nil, controller_data: nil,
+          routes: {}, setup_messages: [], schema_source: :live, requested_model: 'Broken' }
+      end
+      let(:detail) { 'summary' }
+
+      it 'renders model error message' do
+        result = composer.call
+        expect(result).to include('Error inspecting Broken: load failed')
+      end
+    end
+
+    context 'with table data nil in full detail' do
+      let(:resolution) do
+        { model_name: nil, model_data: nil, table_name: 'ghost_table', table_data: nil,
+          controller_name: nil, controller_data: nil, routes: {},
+          setup_messages: [], schema_source: :static, requested_feature: 'ghost' }
+      end
+      let(:detail) { 'full' }
+
+      it 'renders table name with confidence tag but no columns' do
+        result = composer.call
+        expect(result).to include('## Table')
+        expect(result).to include('ghost_table')
+      end
+    end
+
+    context 'with table data present in full detail' do
+      let(:resolution) do
+        { model_name: nil, model_data: nil,
+          table_name: 'users', table_data: { columns: [{ name: 'id', type: 'integer' }], indexes: [] },
+          controller_name: nil, controller_data: nil, routes: {},
+          setup_messages: [], schema_source: :live, requested_feature: 'users' }
+      end
+      let(:detail) { 'full' }
+
+      it 'renders full table with columns' do
+        result = composer.call
+        expect(result).to include('## Table')
+        expect(result).to include('| id | integer |')
+      end
+    end
+
+    context 'with table in standard detail' do
+      let(:resolution) do
+        { model_name: nil, model_data: nil,
+          table_name: 'users', table_data: { columns: [{ name: 'id', type: 'integer' }] },
+          controller_name: nil, controller_data: nil, routes: {},
+          setup_messages: [], schema_source: :live, requested_feature: 'users' }
+      end
+      let(:detail) { 'standard' }
+
+      it 'renders standard table with column signatures' do
+        result = composer.call
+        expect(result).to include('id:integer')
+      end
+    end
+
+    context 'with table in summary detail and no data' do
+      let(:resolution) do
+        { model_name: nil, model_data: nil,
+          table_name: 'users', table_data: nil,
+          controller_name: nil, controller_data: nil, routes: {},
+          setup_messages: [], schema_source: :live, requested_feature: 'users' }
+      end
+      let(:detail) { 'summary' }
+
+      it 'renders table with 0 columns and 0 indexes' do
+        result = composer.call
+        expect(result).to include('0 columns, 0 indexes')
+      end
+    end
+
+    context 'with model in full detail' do
+      let(:resolution) do
+        { model_name: 'User', model_data: { table_name: 'users', associations: [{ type: 'has_many', name: 'posts', source: :reflection }], validations: [] },
+          table_name: 'users', table_data: { columns: [{ name: 'id', type: 'integer' }] },
+          controller_name: nil, controller_data: nil, routes: {},
+          setup_messages: [], schema_source: :live, requested_model: 'User' }
+      end
+      let(:detail) { 'full' }
+
+      it 'renders full model detail via SingleModelFormatter' do
+        result = composer.call
+        expect(result).to include('# User')
+        expect(result).to include('has_many')
+      end
+    end
+
+    context 'with model in standard detail' do
+      let(:resolution) do
+        { model_name: 'User',
+          model_data: { table_name: 'users', semantic_tier: 'core', semantic_tier_reason: 'central',
+                        associations: [{ type: 'has_many', name: 'posts', source: :reflection }],
+                        validations: [{ kind: 'presence', attributes: ['name'] }] },
+          table_name: nil, table_data: nil, controller_name: nil, controller_data: nil, routes: {},
+          setup_messages: [], schema_source: :live, requested_model: 'User' }
+      end
+      let(:detail) { 'standard' }
+
+      it 'renders standard model with table, tier, associations, and validations' do
+        result = composer.call
+        expect(result).to include('# User')
+        expect(result).to include('**Table:** `users`')
+        expect(result).to include('**Semantic tier:** `core`')
+        expect(result).to include('**Tier reason:** central')
+        expect(result).to include('## Associations')
+        expect(result).to include('## Validations')
+      end
+    end
+
+    context 'with model in summary detail with semantic tier' do
+      let(:resolution) do
+        { model_name: 'User',
+          model_data: { associations: [{ type: 'has_many', name: 'posts', source: :reflection }],
+                        validations: [{ kind: 'presence', attributes: ['name'] }], semantic_tier: 'core' },
+          table_name: nil, table_data: nil, controller_name: nil, controller_data: nil, routes: {},
+          setup_messages: [], schema_source: :live, requested_model: 'User' }
+      end
+      let(:detail) { 'summary' }
+
+      it 'renders summary model with tier and limited associations/validations' do
+        result = composer.call
+        expect(result).to include('tier: `core`')
+        expect(result).to include('1 associations, 1 validations')
+        expect(result).to include('`has_many` **posts**')
+        expect(result).to include('`presence` on name')
+      end
+    end
+
+    context 'with routes in summary detail' do
+      let(:resolution) do
+        { model_name: nil, model_data: nil, table_name: nil, table_data: nil,
+          controller_name: nil, controller_data: nil,
+          routes: { 'users' => [{ path: '/users', verb: 'GET', action: 'index' }, { path: '/users/:id', verb: 'GET', action: 'show' }] },
+          setup_messages: [], schema_source: nil, requested_feature: 'users' }
+      end
+      let(:detail) { 'summary' }
+
+      it 'renders routes summary with sample paths' do
+        result = composer.call
+        expect(result).to include('## Routes')
+        expect(result).to include('**users** — 2 routes')
+        expect(result).to include('`/users`')
+      end
+    end
+
+    context 'with routes in standard detail' do
+      let(:resolution) do
+        { model_name: nil, model_data: nil, table_name: nil, table_data: nil,
+          controller_name: nil, controller_data: nil,
+          routes: { 'users' => [{ path: '/users', verb: 'GET', action: 'index', name: 'users' }] },
+          setup_messages: [], schema_source: nil, requested_feature: 'users' }
+      end
+      let(:detail) { 'standard' }
+
+      it 'renders routes with paths and actions' do
+        result = composer.call
+        expect(result).to include('## Routes')
+        expect(result).to include('### users')
+        expect(result).to include('`/users` → index')
+      end
+    end
+
+    context 'with controller data error' do
+      let(:resolution) do
+        { model_name: nil, model_data: nil, table_name: nil, table_data: nil,
+          controller_name: 'BrokenController', controller_data: { error: 'load failed' },
+          routes: {}, setup_messages: [], schema_source: nil, requested_controller: 'BrokenController' }
+      end
+      let(:detail) { 'summary' }
+
+      it 'renders controller error message' do
+        result = composer.call
+        expect(result).to include('Error inspecting BrokenController: load failed')
+      end
+    end
+
+    context 'with controller data nil' do
+      let(:resolution) do
+        { model_name: nil, model_data: nil, table_name: nil, table_data: nil,
+          controller_name: 'GhostController', controller_data: nil,
+          routes: {}, setup_messages: [], schema_source: nil, requested_controller: 'GhostController' }
+      end
+      let(:detail) { 'summary' }
+
+      it 'renders controller-not-found message' do
+        result = composer.call
+        expect(result).to include('_No payload for GhostController._')
+      end
+    end
+
+    context 'with controller in full detail' do
+      let(:resolution) do
+        { model_name: nil, model_data: nil, table_name: nil, table_data: nil,
+          controller_name: 'UsersController',
+          controller_data: { parent_class: 'ApplicationController', actions: %w[index show], filters: [{ kind: 'before', name: 'auth' }], strong_params: ['user_params'] },
+          routes: {}, setup_messages: [], schema_source: nil, requested_controller: 'UsersController' }
+      end
+      let(:detail) { 'full' }
+
+      it 'renders full controller detail' do
+        result = composer.call
+        expect(result).to include('# UsersController')
+        expect(result).to include('**Parent:** `ApplicationController`')
+        expect(result).to include('## Actions')
+        expect(result).to include('## Filters')
+        expect(result).to include('## Strong Params')
+      end
+    end
+
+    context 'with test paths in summary detail' do
+      let(:resolution) do
+        { model_name: 'User', model_data: { associations: [], validations: [] },
+          table_name: nil, table_data: nil, controller_name: nil, controller_data: nil,
+          routes: {}, setup_messages: [], schema_source: nil, requested_model: 'User' }
+      end
+      let(:test_paths) { %w[spec/models/user_spec.rb spec/requests/users_spec.rb] }
+      let(:detail) { 'summary' }
+
+      it 'renders test paths with limit' do
+        result = composer.call
+        expect(result).to include('## Related tests')
+        expect(result).to include('spec/models/user_spec.rb')
+      end
+    end
+
+    context 'with test paths in full detail' do
+      let(:resolution) do
+        { model_name: 'User', model_data: { associations: [], validations: [] },
+          table_name: nil, table_data: nil, controller_name: nil, controller_data: nil,
+          routes: {}, setup_messages: [], schema_source: nil, requested_model: 'User' }
+      end
+      let(:test_paths) { %w[spec/models/user_spec.rb spec/requests/users_spec.rb spec/system/users_spec.rb] }
+      let(:detail) { 'full' }
+
+      it 'renders all test paths' do
+        result = composer.call
+        expect(result).to include('## Related tests')
+        expect(result).to include('spec/system/users_spec.rb')
+      end
+    end
+
+    context 'with invalid detail level' do
+      let(:resolution) do
+        { model_name: 'User', model_data: { associations: [], validations: [] },
+          table_name: nil, table_data: nil, controller_name: nil, controller_data: nil,
+          routes: {}, setup_messages: [], schema_source: nil, requested_model: 'User' }
+      end
+      let(:detail) { 'bogus' }
+
+      it 'falls back to summary' do
+        result = composer.call
+        expect(result).to include('# Context: User')
+      end
+    end
+
+    context 'with setup messages and resolved model' do
+      let(:resolution) do
+        { model_name: 'User', model_data: { associations: [], validations: [] },
+          table_name: nil, table_data: nil, controller_name: nil, controller_data: nil,
+          routes: {}, setup_messages: ['Schema introspection not available.'], schema_source: nil,
+          requested_model: 'User' }
+      end
+      let(:detail) { 'summary' }
+
+      it 'includes setup messages in output' do
+        result = composer.call
+        expect(result).to include('Schema introspection not available.')
+      end
+    end
+  end
+
+  describe 'Resolver branch coverage' do
+    let(:config) { RailsAiBridge.configuration }
+
+    let(:snapshots) do
+      {
+        models: { 'User' => { table_name: 'users', associations: [], validations: [] }, 'Post' => { table_name: 'posts' } },
+        schema: { source: :live, tables: { 'users' => { columns: [] }, 'posts' => { columns: [] } } },
+        controllers: { controllers: { 'UsersController' => { actions: ['index'] }, 'PostsController' => { actions: ['index'] } } },
+        routes: { by_controller: { 'users' => [{ verb: 'GET', path: '/users', action: 'index' }] } }
+      }
+    end
+
+    let(:resolver) do
+      RailsAiBridge::Tools::GetContext::Resolver.new(model: model, controller: controller, feature: feature,
+                                                     snapshots: snapshots, config: config)
+    end
+
+    context 'when schema has adapter but no source key' do
+      let(:model) { 'User' }
+      let(:controller) { nil }
+      let(:feature) { nil }
+      let(:snapshots) do
+        {
+          models: { 'User' => { table_name: 'users' } },
+          schema: { adapter: 'PostgreSQL', tables: { 'users' => { columns: [] } } },
+          controllers: { controllers: {} },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'infers schema source as :live from adapter' do
+        result = resolver.call
+        expect(result[:schema_source]).to eq(:live)
+      end
+    end
+
+    context 'when schema has static_parse adapter' do
+      let(:model) { 'User' }
+      let(:controller) { nil }
+      let(:feature) { nil }
+      let(:snapshots) do
+        {
+          models: { 'User' => { table_name: 'users' } },
+          schema: { adapter: 'static_parse', tables: { 'users' => { columns: [] } } },
+          controllers: { controllers: {} },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'infers schema source as :static' do
+        result = resolver.call
+        expect(result[:schema_source]).to eq(:static)
+      end
+    end
+
+    context 'when schema has no adapter and no source' do
+      let(:model) { 'User' }
+      let(:controller) { nil }
+      let(:feature) { nil }
+      let(:snapshots) do
+        {
+          models: { 'User' => { table_name: 'users' } },
+          schema: { tables: { 'users' => { columns: [] } } },
+          controllers: { controllers: {} },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'returns nil schema source' do
+        result = resolver.call
+        expect(result[:schema_source]).to be_nil
+      end
+    end
+
+    context 'when models section has error' do
+      let(:model) { nil }
+      let(:controller) { 'UsersController' }
+      let(:feature) { nil }
+      let(:snapshots) do
+        {
+          models: { error: 'models failed' },
+          schema: { source: :live, tables: {} },
+          controllers: { controllers: { 'UsersController' => { actions: ['index'] } } },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'includes model error in setup messages' do
+        result = resolver.call
+        expect(result[:setup_messages]).to include('Model introspection failed: models failed')
+      end
+    end
+
+    context 'when schema section has error' do
+      let(:model) { 'User' }
+      let(:controller) { nil }
+      let(:feature) { nil }
+      let(:snapshots) do
+        {
+          models: { 'User' => { table_name: 'users' } },
+          schema: { error: 'schema failed' },
+          controllers: { controllers: {} },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'includes schema error in setup messages' do
+        result = resolver.call
+        expect(result[:setup_messages]).to include('Schema introspection not available: schema failed')
+      end
+    end
+
+    context 'when nothing resolves and only controller was given' do
+      let(:model) { nil }
+      let(:controller) { 'MissingController' }
+      let(:feature) { nil }
+      let(:snapshots) do
+        {
+          models: { 'User' => { table_name: 'users' } },
+          schema: { source: :live, tables: { 'users' => { columns: [] } } },
+          controllers: { controllers: { 'UsersController' => { actions: ['index'] } } },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'returns controller not found error' do
+        result = resolver.call
+        expect(result[:error]).to include("Controller 'MissingController' not found")
+        expect(result[:error]).to include('UsersController')
+      end
+    end
+
+    context 'when nothing resolves and only feature was given' do
+      let(:model) { nil }
+      let(:controller) { nil }
+      let(:feature) { 'nonexistent' }
+      let(:snapshots) do
+        {
+          models: { 'User' => { table_name: 'users' } },
+          schema: { source: :live, tables: { 'users' => { columns: [] } } },
+          controllers: { controllers: { 'UsersController' => { actions: ['index'] } } },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'returns nothing matched error with available models and controllers' do
+        result = resolver.call
+        expect(result[:error]).to include("Nothing matched feature 'nonexistent'")
+        expect(result[:error]).to include('User')
+        expect(result[:error]).to include('UsersController')
+      end
+    end
+
+    context 'when models section is missing' do
+      let(:model) { nil }
+      let(:controller) { 'UsersController' }
+      let(:feature) { nil }
+      let(:snapshots) do
+        {
+          models: nil,
+          schema: { source: :live, tables: {} },
+          controllers: { controllers: { 'UsersController' => { actions: ['index'] } } },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'includes model not available setup message' do
+        result = resolver.call
+        expect(result[:setup_messages]).to include('Model introspection not available. Add :models to introspectors.')
+      end
+    end
+
+    context 'when schema section is missing' do
+      let(:model) { 'User' }
+      let(:controller) { nil }
+      let(:feature) { nil }
+      let(:snapshots) do
+        {
+          models: { 'User' => { table_name: 'users' } },
+          schema: nil,
+          controllers: { controllers: {} },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'includes schema not available setup message' do
+        result = resolver.call
+        expect(result[:setup_messages]).to include('Schema introspection not available. Add :schema to introspectors.')
+      end
+    end
+
+    context 'when controller is inferred from model' do
+      let(:model) { 'User' }
+      let(:controller) { nil }
+      let(:feature) { nil }
+
+      it 'infers controller from model name' do
+        result = resolver.call
+        expect(result[:controller_name]).to eq('UsersController')
+      end
+    end
+
+    context 'when model is inferred from controller' do
+      let(:model) { nil }
+      let(:controller) { 'UsersController' }
+      let(:feature) { nil }
+
+      it 'infers model from controller name' do
+        result = resolver.call
+        expect(result[:model_name]).to eq('User')
+      end
+    end
+
+    context 'when feature resolves to controller only (no model)' do
+      let(:model) { nil }
+      let(:controller) { nil }
+      let(:feature) { 'users_controller' }
+      let(:snapshots) do
+        {
+          models: {},
+          schema: { source: :live, tables: {} },
+          controllers: { controllers: { 'UsersController' => { actions: ['index'] } } },
+          routes: { by_controller: { 'users' => [{ verb: 'GET', path: '/users', action: 'index' }] } }
+        }
+      end
+
+      it 'resolves controller from feature' do
+        result = resolver.call
+        expect(result[:controller_name]).to eq('UsersController')
+        expect(result[:routes]).not_to be_empty
+      end
+    end
+
+    context 'with invalid name containing path traversal' do
+      let(:model) { '../etc/passwd' }
+      let(:controller) { nil }
+      let(:feature) { nil }
+
+      it 'shows invalid name in error message' do
+        result = resolver.call
+        expect(result[:error]).to include('(invalid name)')
+      end
+    end
+
+    context 'with invalid name containing backslash' do
+      let(:model) { nil }
+      let(:controller) { 'foo\\bar' }
+      let(:feature) { nil }
+      let(:snapshots) do
+        {
+          models: {},
+          schema: {},
+          controllers: { controllers: {} },
+          routes: { by_controller: {} }
+        }
+      end
+
+      it 'shows invalid name in error message' do
+        result = resolver.call
+        expect(result[:error]).to include('(invalid name)')
+      end
+    end
+  end
+
+  describe 'RelatedTests branch coverage' do
+    let(:root) { Pathname.new(Dir.mktmpdir('related-tests-')) }
+
+    after do
+      FileUtils.remove_entry(root)
+    end
+
+    it 'returns empty when root is nil' do
+      finder = RailsAiBridge::Tools::GetContext::RelatedTests.new(root: nil, resolution: { model_name: 'User' })
+      expect(finder.paths).to eq([])
+    end
+
+    it 'finds conventional spec paths for a model' do
+      FileUtils.mkdir_p(root.join('spec/models'))
+      File.write(root.join('spec/models/user_spec.rb'), '# user spec')
+      finder = RailsAiBridge::Tools::GetContext::RelatedTests.new(root: root, resolution: { model_name: 'User' })
+      expect(finder.paths).to include('spec/models/user_spec.rb')
+    end
+
+    it 'finds conventional test paths for a controller' do
+      FileUtils.mkdir_p(root.join('test/controllers'))
+      File.write(root.join('test/controllers/users_controller_test.rb'), '# test')
+      finder = RailsAiBridge::Tools::GetContext::RelatedTests.new(root: root, resolution: { controller_name: 'UsersController' })
+      expect(finder.paths).to include('test/controllers/users_controller_test.rb')
+    end
+
+    it 'finds paths using table name' do
+      FileUtils.mkdir_p(root.join('spec/requests'))
+      File.write(root.join('spec/requests/users_spec.rb'), '# test')
+      finder = RailsAiBridge::Tools::GetContext::RelatedTests.new(root: root, resolution: { table_name: 'users' })
+      expect(finder.paths).to include('spec/requests/users_spec.rb')
+    end
+
+    it 'finds paths using feature name' do
+      FileUtils.mkdir_p(root.join('spec/system'))
+      File.write(root.join('spec/system/posts_spec.rb'), '# test')
+      finder = RailsAiBridge::Tools::GetContext::RelatedTests.new(root: root, resolution: { requested_feature: 'posts' })
+      expect(finder.paths).to include('spec/system/posts_spec.rb')
+    end
+
+    it 'ignores unsafe tokens' do
+      finder = RailsAiBridge::Tools::GetContext::RelatedTests.new(root: root, resolution: { requested_feature: '../etc/passwd' })
+      expect(finder.paths).to eq([])
+    end
+
+    it 'handles blank controller name' do
+      finder = RailsAiBridge::Tools::GetContext::RelatedTests.new(root: root, resolution: { controller_name: '' })
+      expect(finder.paths).to eq([])
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/rails_ai_bridge/tools/remaining_branches_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/remaining_branches_spec.rb
@@ -1,0 +1,589 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'generators/rails_ai_bridge/install/profile_resolver'
+
+# Branch-coverage specs for remaining tool, serializer, and generator branches.
+RSpec.describe 'Remaining branch coverage' do
+  # ------------------------------------------------------------------
+  # GetRoutes — pagination, unknown detail, API namespaces in full
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::GetRoutes do
+    before { described_class.reset_cache! }
+
+    context 'with pagination' do
+      let(:routes_data) do
+        {
+          total_routes: 6,
+          api_namespaces: [],
+          by_controller: {
+            'users' => Array.new(3) { |i| { verb: 'GET', path: "/users/#{i}", action: 'show', name: "user_#{i}" } },
+            'posts' => Array.new(3) { |i| { verb: 'GET', path: "/posts/#{i}", action: 'show', name: "post_#{i}" } }
+          }
+        }
+      end
+
+      before { allow(described_class).to receive(:cached_section).with(:routes).and_return(routes_data) }
+
+      it 'paginates standard detail with offset and limit' do
+        text = described_class.call(detail: 'standard', limit: 2, offset: 2).content.first[:text]
+        expect(text).to include('offset:4')
+      end
+
+      it 'shows hint when more routes exist in standard' do
+        text = described_class.call(detail: 'standard', limit: 2).content.first[:text]
+        expect(text).to include('Use `detail:"summary"`')
+      end
+
+      it 'paginates full detail with offset and limit' do
+        text = described_class.call(detail: 'full', limit: 2, offset: 2).content.first[:text]
+        expect(text).to include('offset:4')
+      end
+    end
+
+    context 'with unknown detail level' do
+      let(:routes_data) { { total_routes: 1, by_controller: { 'x' => [{ verb: 'GET', path: '/x', action: 'show' }] } } }
+
+      before { allow(described_class).to receive(:cached_section).with(:routes).and_return(routes_data) }
+
+      it 'returns an error message' do
+        text = described_class.call(detail: 'bogus').content.first[:text]
+        expect(text).to include('Unknown detail level: bogus')
+      end
+    end
+
+    context 'with API namespaces in full detail' do
+      let(:routes_data) do
+        { total_routes: 1, api_namespaces: ['api/v1'], by_controller: { 'x' => [{ verb: 'GET', path: '/x', action: 'show' }] } }
+      end
+
+      before { allow(described_class).to receive(:cached_section).with(:routes).and_return(routes_data) }
+
+      it 'includes API namespaces in full output' do
+        text = described_class.call(detail: 'full').content.first[:text]
+        expect(text).to include('## API namespaces: api/v1')
+      end
+    end
+
+    context 'with routes having no by_controller key' do
+      let(:routes_data) { { total_routes: 0 } }
+
+      before { allow(described_class).to receive(:cached_section).with(:routes).and_return(routes_data) }
+
+      it 'returns empty routes without error' do
+        text = described_class.call.content.first[:text]
+        expect(text).to include('# Routes (0 total)')
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # GetConfig — all fields
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::GetConfig do
+    before { described_class.reset_cache! }
+
+    it 'renders config with middleware, initializers, and current_attributes' do
+      allow(described_class).to receive(:cached_section).with(:config).and_return({
+                                                                                    cache_store: ':redis_cache',
+                                                                                    session_store: ':cookie_store',
+                                                                                    timezone: 'UTC',
+                                                                                    middleware_stack: %w[Rack::Cors Rack::Attack],
+                                                                                    initializers: %w[devise.rb sidekiq.rb],
+                                                                                    current_attributes: ['Current.user']
+                                                                                  })
+      text = described_class.call.content.first[:text]
+      expect(text).to include('## Middleware Stack')
+      expect(text).to include('Rack::Cors')
+      expect(text).to include('## Initializers')
+      expect(text).to include('`devise.rb`')
+      expect(text).to include('## CurrentAttributes')
+      expect(text).to include('`Current.user`')
+    end
+
+    it 'renders config with only cache store' do
+      allow(described_class).to receive(:cached_section).with(:config).and_return({ cache_store: ':memory' })
+      text = described_class.call.content.first[:text]
+      expect(text).to include('Cache store:')
+      expect(text).not_to include('Middleware')
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # ExplainSymbol::CliExplorer — error cases
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::ExplainSymbol::CliExplorer do
+    it 'raises ExploreError when codegraph CLI is not found' do
+      explorer = described_class.new(root: '/tmp')
+      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+      expect { explorer.explore('User') }.to raise_error(RailsAiBridge::Tools::ExplainSymbol::ExploreError, /not found on PATH/)
+    end
+
+    it 'raises ExploreError on timeout' do
+      explorer = described_class.new(root: '/tmp', timeout: 0.01)
+      allow(Open3).to receive(:capture3).and_raise(Timeout::Error)
+      expect { explorer.explore('User') }.to raise_error(RailsAiBridge::Tools::ExplainSymbol::ExploreError, /timed out/)
+    end
+
+    it 'raises ExploreError with stderr on non-zero exit' do
+      explorer = described_class.new(root: '/tmp')
+      status = double('status', success?: false, exitstatus: 1)
+      allow(Open3).to receive(:capture3).and_return(['', 'index corrupt', status])
+      expect { explorer.explore('User') }.to raise_error(RailsAiBridge::Tools::ExplainSymbol::ExploreError, /index corrupt/)
+    end
+
+    it 'raises ExploreError with exit status when stderr is empty' do
+      explorer = described_class.new(root: '/tmp')
+      status = double('status', success?: false, exitstatus: 42)
+      allow(Open3).to receive(:capture3).and_return(['', '', status])
+      expect { explorer.explore('User') }.to raise_error(RailsAiBridge::Tools::ExplainSymbol::ExploreError, /exit 42/)
+    end
+
+    it 'returns stdout on success' do
+      explorer = described_class.new(root: '/tmp')
+      status = double('status', success?: true)
+      allow(Open3).to receive(:capture3).and_return(['# User markdown', '', status])
+      expect(explorer.explore('User')).to eq('# User markdown')
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # ResolveSkill — pack mismatch, agent type
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::ResolveSkill do
+    def build_resolved(name:, pack:, path:, content:)
+      RailsAiBridge::Registry::ResolvedSkill.new(name: name, pack: pack, path: path, content: content)
+    end
+
+    def build_resolver(**stubs)
+      defaults = { resolve_skill: nil, resolve_agent: nil, list_skills: [], list_agents: [], active_packs: [] }
+      instance_double(RailsAiBridge::Registry::Resolver, **defaults, **stubs)
+    end
+
+    context 'when resolving an agent' do
+      let(:resolver) { build_resolver }
+      let(:agent) { build_resolved(name: 'tdd-workflow', pack: 'rails', path: '/cache/tdd.md', content: '# TDD Workflow') }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(resolver).to receive(:resolve_agent).with('tdd-workflow').and_return(agent)
+      end
+
+      it 'returns the agent content' do
+        text = described_class.call(name: 'tdd-workflow', type: 'agent').content.first[:text]
+        expect(text).to include('# tdd-workflow')
+        expect(text).to include('# TDD Workflow')
+      end
+    end
+
+    context 'when agent is not found' do
+      let(:resolver) { build_resolver }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        allow(resolver).to receive(:resolve_agent).with('missing').and_return(nil)
+      end
+
+      it 'returns agent not found message' do
+        text = described_class.call(name: 'missing', type: 'agent').content.first[:text]
+        expect(text).to include('Agent `missing` not found')
+        expect(text).to include('rails_list_registry')
+      end
+    end
+
+    context 'when pack-pinned resolution finds skill in different pack' do
+      let(:skill) { build_resolved(name: 'code-review', pack: 'core', path: '/cache/code-review.md', content: '# Code Review') }
+      let(:pack) { RailsAiBridge::Registry::LoadedPack.new(name: 'rails', tile: nil, base_path: '/tmp', priority: 1) }
+      let(:resolver) { build_resolver(active_packs: [pack], list_skills: [skill], resolve_skill: skill) }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        single_resolver = instance_double(RailsAiBridge::Registry::Resolver, resolve_skill: nil)
+        allow(RailsAiBridge::Registry::Resolver).to receive(:new).with([pack]).and_return(single_resolver)
+      end
+
+      it 'includes pack mismatch warning when requested pack differs' do
+        text = described_class.call(name: 'code-review', pack: 'rails').content.first[:text]
+        expect(text).to include('Skill `code-review` was found in pack `core`, not `rails`')
+      end
+    end
+
+    context 'when pack-pinned resolution falls back to priority-based' do
+      let(:skill) { build_resolved(name: 'code-review', pack: 'core', path: '/cache/code-review.md', content: '# Code Review') }
+      let(:pack) { RailsAiBridge::Registry::LoadedPack.new(name: 'other', tile: nil, base_path: '/tmp', priority: 1) }
+      let(:resolver) { build_resolver(active_packs: [pack], list_skills: [skill]) }
+
+      before do
+        allow(RailsAiBridge::Registry).to receive(:build_resolver).and_return(resolver)
+        single_resolver = instance_double(RailsAiBridge::Registry::Resolver, resolve_skill: nil)
+        allow(RailsAiBridge::Registry::Resolver).to receive(:new).with([pack]).and_return(single_resolver)
+        allow(resolver).to receive(:resolve_skill).with('code-review').and_return(skill)
+      end
+
+      it 'falls back to priority-based resolution' do
+        text = described_class.call(name: 'code-review', pack: 'other').content.first[:text]
+        expect(text).to include('# code-review')
+        expect(text).to include('# Code Review')
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # ProfileResolver — remaining branches
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Generators::ProfileResolver do
+    let(:shell) { double('shell', say: nil, ask: 'custom') }
+
+    context 'interactive mode with unknown answer' do
+      before { allow(shell).to receive(:say) }
+
+      it 'falls back to custom with yellow warning' do
+        allow(shell).to receive(:ask).and_return('bogus')
+        expect(described_class.new(nil, shell: shell).call).to eq('custom')
+        expect(shell).to have_received(:say).with(a_string_including("Unknown profile 'bogus'"), :yellow)
+      end
+    end
+
+    describe '.formats_for' do
+      it 'returns nil for unknown profile' do
+        expect(described_class.formats_for('bogus')).to be_nil
+      end
+
+      it 'returns nil for custom (interactive)' do
+        expect(described_class.formats_for('custom')).to be_nil
+      end
+
+      it 'returns all formats for full' do
+        formats = described_class.formats_for('full')
+        expect(formats).to include(:claude, :json)
+      end
+    end
+
+    describe '.split_rules_for' do
+      it 'returns nil for unknown profile' do
+        expect(described_class.split_rules_for('bogus')).to be_nil
+      end
+
+      it 'returns false for mcp' do
+        expect(described_class.split_rules_for('mcp')).to be false
+      end
+    end
+
+    describe '.description_for' do
+      it 'returns nil for unknown profile' do
+        expect(described_class.description_for('bogus')).to be_nil
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # SharedAssistantGuidance — remaining branches
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Serializers::SharedAssistantGuidance do
+    context 'when anti_hallucination_rules is disabled' do
+      around do |example|
+        original = RailsAiBridge.configuration.anti_hallucination_rules
+        RailsAiBridge.configuration.anti_hallucination_rules = false
+        example.run
+      ensure
+        RailsAiBridge.configuration.anti_hallucination_rules = original
+      end
+
+      it 'returns empty array for anti_hallucination_rules_lines' do
+        expect(described_class.anti_hallucination_rules_lines).to eq([])
+      end
+
+      it 'does not include anti-hallucination heading in compact_engineering_rules_lines' do
+        lines = described_class.compact_engineering_rules_lines
+        expect(lines).not_to include('## Anti-hallucination')
+      end
+    end
+
+    describe '.cursor_engineering_mdc_body_lines' do
+      it 'includes overrides pointer when show_overrides_pointer is true' do
+        lines = described_class.cursor_engineering_mdc_body_lines(show_overrides_pointer: true)
+        expect(lines).to include('Repo-specific performance/security: `config/rails_ai_bridge/overrides.md`.')
+      end
+
+      it 'omits overrides pointer when show_overrides_pointer is false' do
+        lines = described_class.cursor_engineering_mdc_body_lines(show_overrides_pointer: false)
+        expect(lines).not_to include('Repo-specific performance/security')
+      end
+    end
+
+    describe '.claude_full_footer_lines' do
+      it 'includes architecture summary when conventions present' do
+        lines = described_class.claude_full_footer_lines({ conventions: { architecture: %w[hotwire api] } })
+        expect(lines).to include('- Match the project\'s architecture style (hotwire, api)')
+      end
+
+      it 'omits architecture summary when conventions absent' do
+        lines = described_class.claude_full_footer_lines({})
+        expect(lines).not_to include('architecture style')
+      end
+    end
+
+    describe '.compact_engineering_rules_footer_lines' do
+      it 'includes architecture summary when conventions present' do
+        lines = described_class.compact_engineering_rules_footer_lines({ conventions: { architecture: ['rails'] } })
+        expect(lines.join("\n")).to include('**Match Architecture:**')
+        expect(lines.join("\n")).to include('rails')
+      end
+
+      it 'omits anti-hallucination when include_anti_hallucination is false' do
+        lines = described_class.compact_engineering_rules_footer_lines({}, include_anti_hallucination: false)
+        expect(lines).not_to include('## Anti-hallucination')
+      end
+    end
+
+    describe '.read_assistant_overrides' do
+      it 'returns nil when Rails application is not available' do
+        allow(described_class).to receive(:resolved_assistant_overrides_path).and_return(nil)
+        expect(described_class.read_assistant_overrides).to be_nil
+      end
+
+      it 'returns nil when file does not exist' do
+        allow(described_class).to receive(:resolved_assistant_overrides_path).and_return('/nonexistent/path.md')
+        expect(described_class.read_assistant_overrides).to be_nil
+      end
+
+      it 'returns nil when file is empty' do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, 'overrides.md')
+          File.write(path, '')
+          allow(described_class).to receive(:resolved_assistant_overrides_path).and_return(path)
+          expect(described_class.read_assistant_overrides).to be_nil
+        end
+      end
+
+      it 'returns nil when file has omit-merge marker' do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, 'overrides.md')
+          File.write(path, "<!-- rails-ai-bridge:omit-merge -->\n\nSome content")
+          allow(described_class).to receive(:resolved_assistant_overrides_path).and_return(path)
+          expect(described_class.read_assistant_overrides).to be_nil
+        end
+      end
+
+      it 'returns content when file is valid' do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, 'overrides.md')
+          File.write(path, "## Custom rules\n\n- Do things right")
+          allow(described_class).to receive(:resolved_assistant_overrides_path).and_return(path)
+          expect(described_class.read_assistant_overrides).to include('Custom rules')
+        end
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Provider serializers — error/nil cases
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Serializers::Providers::ClaudeRulesSerializer do
+    let(:base_context) do
+      { app_name: 'Test', rails_version: '7.1', ruby_version: '3.2', environment: 'test',
+        models: { 'User' => { table_name: 'users', associations: [], validations: [] } },
+        schema: { adapter: 'pg', tables: { 'users' => { columns: [{ name: 'id' }] } } },
+        routes: { total_routes: 1, by_controller: { 'users' => [{ verb: 'GET', path: '/users', action: 'index' }] } } }
+    end
+
+    it 'skips context reference when models has error' do
+      context = base_context.merge(models: { error: 'failed' })
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        context_file = File.join(dir, '.claude', 'rules', 'rails-context.md')
+        expect(File.exist?(context_file)).to be false
+      end
+    end
+
+    it 'handles nil models in context reference' do
+      context = base_context.merge(models: nil)
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        context_file = File.join(dir, '.claude', 'rules', 'rails-context.md')
+        expect(File.exist?(context_file)).to be true
+        body = File.read(context_file)
+        expect(body).to include('Rails semantic context')
+      end
+    end
+
+    it 'skips schema reference when schema has error' do
+      context = base_context.merge(schema: { error: 'failed' })
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        schema_file = File.join(dir, '.claude', 'rules', 'rails-schema.md')
+        expect(File.exist?(schema_file)).to be false
+      end
+    end
+
+    it 'skips schema reference when schema is nil' do
+      context = base_context.merge(schema: nil)
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        schema_file = File.join(dir, '.claude', 'rules', 'rails-schema.md')
+        expect(File.exist?(schema_file)).to be false
+      end
+    end
+
+    it 'skips models reference when models has error' do
+      context = base_context.merge(models: { error: 'failed' })
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        models_file = File.join(dir, '.claude', 'rules', 'rails-models.md')
+        expect(File.exist?(models_file)).to be false
+      end
+    end
+
+    it 'renders schema with nil columns gracefully' do
+      context = base_context.merge(schema: { adapter: 'pg', tables: { 'users' => { columns: nil } } })
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        body = File.read(File.join(dir, '.claude', 'rules', 'rails-schema.md'))
+        expect(body).to include('users (0 cols')
+      end
+    end
+
+    it 'renders schema with default primary key when missing' do
+      context = base_context.merge(schema: { adapter: 'pg', tables: { 'users' => { columns: [{ name: 'id' }] } } })
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        body = File.read(File.join(dir, '.claude', 'rules', 'rails-schema.md'))
+        expect(body).to include('pk: id')
+      end
+    end
+
+    it 'renders context without app metadata when missing' do
+      context = base_context.merge(app_name: nil, rails_version: nil, ruby_version: nil, environment: nil)
+      Dir.mktmpdir do |dir|
+        described_class.new(context).call(dir)
+        body = File.read(File.join(dir, '.claude', 'rules', 'rails-context.md'))
+        expect(body).not_to include('**Name:**')
+        expect(body).not_to include('**Rails:**')
+      end
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Providers::CopilotInstructionsSerializer do
+    let(:context) do
+      { models: { 'User' => { table_name: 'users', associations: [], validations: [] } },
+        controllers: { controllers: { 'UsersController' => { actions: ['index'] } } } }
+    end
+
+    it 'skips models instructions when models has error' do
+      ctx = context.merge(models: { error: 'failed' })
+      Dir.mktmpdir do |dir|
+        described_class.new(ctx).call(dir)
+        models_file = File.join(dir, '.github', 'instructions', 'rails-models.instructions.md')
+        expect(File.exist?(models_file)).to be false
+      end
+    end
+
+    it 'skips models instructions when models is empty' do
+      ctx = context.merge(models: {})
+      Dir.mktmpdir do |dir|
+        described_class.new(ctx).call(dir)
+        models_file = File.join(dir, '.github', 'instructions', 'rails-models.instructions.md')
+        expect(File.exist?(models_file)).to be false
+      end
+    end
+
+    it 'skips controllers instructions when controllers has error' do
+      ctx = context.merge(controllers: { error: 'failed' })
+      Dir.mktmpdir do |dir|
+        described_class.new(ctx).call(dir)
+        controllers_file = File.join(dir, '.github', 'instructions', 'rails-controllers.instructions.md')
+        expect(File.exist?(controllers_file)).to be false
+      end
+    end
+
+    it 'skips controllers instructions when no controllers' do
+      ctx = context.merge(controllers: { controllers: {} })
+      Dir.mktmpdir do |dir|
+        described_class.new(ctx).call(dir)
+        controllers_file = File.join(dir, '.github', 'instructions', 'rails-controllers.instructions.md')
+        expect(File.exist?(controllers_file)).to be false
+      end
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Providers::DevinRulesSerializer do
+    let(:context) do
+      { app_name: 'Test', models: { 'User' => { table_name: 'users' } },
+        schema: { adapter: 'pg', tables: { 'users' => { columns: [{ name: 'id' }] } } } }
+    end
+
+    it 'skips unchanged files on second call' do
+      Dir.mktmpdir do |dir|
+        first = described_class.new(context).call(dir)
+        expect(first[:written]).not_to be_empty
+        second = described_class.new(context).call(dir)
+        expect(second[:written]).to eq([])
+        expect(second[:skipped]).not_to be_empty
+      end
+    end
+  end
+
+  describe RailsAiBridge::Serializers::Providers::CursorRulesSerializer do
+    let(:context) do
+      { app_name: 'Test', models: { 'User' => { table_name: 'users' } },
+        schema: { adapter: 'pg', tables: { 'users' => { columns: [{ name: 'id' }] } } },
+        controllers: { controllers: { 'UsersController' => { actions: ['index'] } } },
+        routes: { total_routes: 1, by_controller: { 'users' => [{ verb: 'GET', path: '/users', action: 'index' }] } } }
+    end
+
+    it 'skips unchanged files on second call' do
+      Dir.mktmpdir do |dir|
+        first = described_class.new(context).call(dir)
+        expect(first[:written]).not_to be_empty
+        second = described_class.new(context).call(dir)
+        expect(second[:written]).to eq([])
+        expect(second[:skipped]).not_to be_empty
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # GeminiSerializer — full mode
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Serializers::Providers::GeminiSerializer do
+    let(:context) do
+      { app_name: 'Test', rails_version: '7.1', ruby_version: '3.2', generated_at: '2024-01-01',
+        models: { 'User' => { table_name: 'users', associations: [], validations: [] } },
+        schema: { adapter: 'pg', tables: { 'users' => { columns: [{ name: 'id' }] } } } }
+    end
+
+    around do |example|
+      original = RailsAiBridge.configuration.context_mode
+      RailsAiBridge.configuration.context_mode = :full
+      example.run
+    ensure
+      RailsAiBridge.configuration.context_mode = original
+    end
+
+    it 'delegates to MarkdownSerializer in full mode' do
+      result = described_class.new(context).call
+      expect(result).to be_a(String)
+      expect(result).not_to be_empty
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Factory — NullStrategy and NullSplitRulesStrategy
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Serializers::Providers::Factory do
+    it 'returns NullStrategy for unknown format' do
+      serializer = described_class.for(:unknown_format, { app_name: 'Test' })
+      expect(serializer).to be_a(RailsAiBridge::Serializers::Providers::Factory::NullStrategy)
+      expect(serializer.call).to be_a(String)
+    end
+
+    it 'returns NullSplitRulesStrategy for unknown format' do
+      serializer = described_class.split_rules_for(:unknown_format, { app_name: 'Test' })
+      expect(serializer).to be_a(RailsAiBridge::Serializers::Providers::Factory::NullSplitRulesStrategy)
+      Dir.mktmpdir do |dir|
+        result = serializer.call(dir)
+        expect(result).to eq({ written: [], skipped: [] })
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/tools/tool_formatter_branches_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/tool_formatter_branches_spec.rb
@@ -1,0 +1,640 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Branch-coverage specs for tool ResponseFormatter classes that are exercised
+# through the public +.call+ interface but have conditional branches not yet
+# reached by existing specs.
+RSpec.describe 'Tool formatter branch coverage' do
+  # ------------------------------------------------------------------
+  # GetControllers::ResponseFormatter
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::GetControllers do
+    before { described_class.reset_cache! }
+
+    describe 'uncovered branches' do
+      before do
+        allow(described_class).to receive(:cached_section).with(:controllers).and_return({
+                                                                                           controllers: {
+                                                                                             'PostsController' => {
+                                                                                               parent_class: 'ApplicationController',
+                                                                                               api_controller: true,
+                                                                                               actions: %w[index show],
+                                                                                               filters: [
+                                                                                                 { kind: 'before', name: 'auth', only: ['show'], except: ['index'],
+                                                                                                   source: 'ApplicationController' },
+                                                                                                 { kind: 'after', name: 'log', source: nil }
+                                                                                               ],
+                                                                                               strong_params: ['post_params']
+                                                                                             },
+                                                                                             'BlankController' => {
+                                                                                               actions: nil,
+                                                                                               filters: nil,
+                                                                                               strong_params: nil
+                                                                                             },
+                                                                                             'ErrorController' => { error: 'load failed' }
+                                                                                           }
+                                                                                         })
+      end
+
+      it 'falls back to name list for unknown detail level' do
+        text = described_class.call(detail: 'bogus').content.first[:text]
+        expect(text).to include('# Controllers (3)')
+        expect(text).to include('- BlankController')
+      end
+
+      it 'renders single controller with api_controller flag' do
+        text = described_class.call(controller: 'PostsController').content.first[:text]
+        expect(text).to include('**API controller:** yes')
+      end
+
+      it 'renders single controller with error' do
+        text = described_class.call(controller: 'ErrorController').content.first[:text]
+        expect(text).to include('Error inspecting ErrorController: load failed')
+      end
+
+      it 'renders filter lines with except clause in single controller mode' do
+        text = described_class.call(controller: 'PostsController').content.first[:text]
+        expect(text).to include('(except: index)')
+      end
+
+      it 'renders filter lines with source in full listing mode' do
+        text = described_class.call(detail: 'full').content.first[:text]
+        expect(text).to include('before auth (ApplicationController)')
+      end
+
+      it 'renders full listing with blank controller (no actions/filters/strong_params)' do
+        text = described_class.call(detail: 'full').content.first[:text]
+        expect(text).to include('## BlankController')
+      end
+
+      it 'renders summary with nil actions' do
+        text = described_class.call(detail: 'summary').content.first[:text]
+        expect(text).to include('**BlankController** — 0 actions')
+      end
+
+      it 'renders standard with nil actions as none' do
+        text = described_class.call(detail: 'standard').content.first[:text]
+        expect(text).to include('**BlankController** — none')
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # GetStimulus::ResponseFormatter
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::GetStimulus do
+    before { described_class.reset_cache! }
+
+    describe 'uncovered branches' do
+      before do
+        allow(described_class).to receive(:cached_section).with(:stimulus).and_return({
+                                                                                        controllers: [
+                                                                                          {
+                                                                                            name: 'full',
+                                                                                            file: 'app/javascript/controllers/full_controller.js',
+                                                                                            targets: %w[input output],
+                                                                                            values: { 'open' => 'Boolean' },
+                                                                                            actions: %w[toggle reset],
+                                                                                            outlets: ['modal'],
+                                                                                            classes: ['active']
+                                                                                          },
+                                                                                          {
+                                                                                            name: 'bare',
+                                                                                            file: nil,
+                                                                                            targets: [],
+                                                                                            values: nil,
+                                                                                            actions: [],
+                                                                                            outlets: [],
+                                                                                            classes: []
+                                                                                          }
+                                                                                        ]
+                                                                                      })
+      end
+
+      it 'renders single controller with outlets and classes' do
+        text = described_class.call(controller: 'full').content.first[:text]
+        expect(text).to include('## Outlets')
+        expect(text).to include('- `modal`')
+        expect(text).to include('## Classes')
+        expect(text).to include('- `active`')
+      end
+
+      it 'renders single controller with no file, targets, actions, values, outlets, or classes' do
+        text = described_class.call(controller: 'bare').content.first[:text]
+        expect(text).to include('# bare')
+        expect(text).not_to include('## Targets')
+        expect(text).not_to include('## Actions')
+        expect(text).not_to include('## Values')
+      end
+
+      it 'renders standard listing with controller that has no values' do
+        text = described_class.call(detail: 'standard').content.first[:text]
+        bare_section = text.split('## bare').last.split('## full').first
+        expect(bare_section).not_to include('Values:')
+      end
+
+      it 'renders full listing with controller that has no file' do
+        text = described_class.call(detail: 'full').content.first[:text]
+        bare_section = text.split('## bare').last.split('## full').first
+        expect(bare_section).not_to include('File:')
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # GetView formatters
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::GetView do
+    let(:view_data) do
+      {
+        layouts: %w[application admin],
+        template_engines: %w[erb slim],
+        templates: {
+          'posts' => %w[index show],
+          'users' => %w[index]
+        },
+        partials: {
+          shared: %w[_form _nav],
+          per_controller: { 'posts' => %w[_body] }
+        },
+        helpers: [
+          { file: 'app/helpers/posts_helper.rb', methods: %w[format_title] }
+        ],
+        view_components: ['PostComponent']
+      }
+    end
+
+    describe 'FullFormatter' do
+      it 'renders helpers and view components' do
+        formatter = RailsAiBridge::Tools::GetView::FullFormatter.new(context: view_data)
+        result = formatter.call
+        expect(result).to include('## Helpers')
+        expect(result).to include('format_title')
+        expect(result).to include('## View Components')
+        expect(result).to include('PostComponent')
+      end
+
+      it 'returns error when controller filter fails' do
+        formatter = RailsAiBridge::Tools::GetView::FullFormatter.new(context: view_data, controller: 'missing')
+        result = formatter.call
+        expect(result).to include('View introspection failed')
+      end
+    end
+
+    describe 'SummaryFormatter' do
+      it 'renders summary with template and partial counts' do
+        formatter = RailsAiBridge::Tools::GetView::SummaryFormatter.new(context: view_data)
+        result = formatter.call
+        expect(result).to include('# View Summary')
+        expect(result).to include('- Layouts: 2')
+        expect(result).to include('- Template engines: erb, slim')
+        expect(result).to include('- Shared partials: 2')
+        expect(result).to include('**posts/** — 2 templates, 1 partials')
+        expect(result).to include('**users/** — 1 templates, 0 partials')
+      end
+
+      it 'skips templates when partial filter is set without controller' do
+        formatter = RailsAiBridge::Tools::GetView::SummaryFormatter.new(context: view_data, partial: 'form')
+        result = formatter.call
+        expect(result).to include('# Partials matching form')
+        expect(result).not_to include('**posts/**')
+      end
+
+      it 'returns error when partial filter fails' do
+        formatter = RailsAiBridge::Tools::GetView::SummaryFormatter.new(context: view_data, partial: 'nonexistent')
+        result = formatter.call
+        expect(result).to include('View introspection failed')
+      end
+    end
+
+    describe 'StandardFormatter' do
+      it 'renders layouts, template engines, templates, and partials' do
+        formatter = RailsAiBridge::Tools::GetView::StandardFormatter.new(context: view_data)
+        result = formatter.call
+        expect(result).to include('- Layouts: application, admin')
+        expect(result).to include('- Template engines: erb, slim')
+        expect(result).to include('## Templates by controller')
+        expect(result).to include('`posts/`: index, show')
+        expect(result).to include('## Shared Partials')
+        expect(result).to include('- `_form`')
+        expect(result).to include('## Controller Partials')
+        expect(result).to include('`posts/`: _body')
+      end
+
+      it 'skips templates when partial filter is set without controller' do
+        formatter = RailsAiBridge::Tools::GetView::StandardFormatter.new(context: view_data, partial: 'form')
+        result = formatter.call
+        expect(result).to include('## Shared Partials')
+        expect(result).not_to include('## Templates by controller')
+      end
+
+      it 'filters by controller name' do
+        formatter = RailsAiBridge::Tools::GetView::StandardFormatter.new(context: view_data, controller: 'posts')
+        result = formatter.call
+        expect(result).to include('# Views for posts')
+        expect(result).to include('`posts/`: index, show')
+        expect(result).not_to include('users')
+      end
+
+      it 'returns error when controller not found' do
+        formatter = RailsAiBridge::Tools::GetView::StandardFormatter.new(context: view_data, controller: 'missing')
+        result = formatter.call
+        expect(result).to include("Controller views 'missing' not found.")
+      end
+    end
+
+    describe 'SpecificViewFormatter' do
+      it 'renders all optional fields when present' do
+        analysis = {
+          path: 'app/views/posts/show.html.erb',
+          template_engine: 'erb',
+          partial: true,
+          renders: %w[_form _nav],
+          turbo_frames: ['modal'],
+          stimulus_controllers: ['clipboard'],
+          stimulus_actions: ['copy'],
+          content: "<h1>Hello</h1>\n"
+        }
+        formatter = RailsAiBridge::Tools::GetView::SpecificViewFormatter.new
+        result = formatter.call(analysis)
+        expect(result).to include('# View: app/views/posts/show.html.erb')
+        expect(result).to include('- Template engine: erb')
+        expect(result).to include('- Partial: yes')
+        expect(result).to include('- Renders: _form, _nav')
+        expect(result).to include('- Turbo frames: modal')
+        expect(result).to include('- Stimulus controllers: clipboard')
+        expect(result).to include('- Stimulus actions: copy')
+        expect(result).to include('## Source')
+        expect(result).to include('<h1>Hello</h1>')
+      end
+
+      it 'renders minimal fields when optional data is absent' do
+        analysis = {
+          path: 'app/views/posts/index.html.erb',
+          template_engine: nil,
+          partial: false,
+          renders: [],
+          turbo_frames: [],
+          stimulus_controllers: [],
+          stimulus_actions: [],
+          content: '<p>Index</p>'
+        }
+        formatter = RailsAiBridge::Tools::GetView::SpecificViewFormatter.new
+        result = formatter.call(analysis)
+        expect(result).to include('- Partial: no')
+        expect(result).not_to include('Template engine')
+        expect(result).not_to include('Renders:')
+        expect(result).not_to include('Turbo frames:')
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # GetGems::ResponseFormatter
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::GetGems do
+    before { described_class.reset_cache! }
+
+    it 'filters by category' do
+      allow(described_class).to receive(:cached_section).with(:gems).and_return({
+                                                                                  total_gems: 10,
+                                                                                  notable_gems: [
+                                                                                    { name: 'devise', version: '4.9', category: 'auth', note: 'Authentication' },
+                                                                                    { name: 'sidekiq', version: '7.0', category: 'jobs', note: 'Background jobs' }
+                                                                                  ]
+                                                                                })
+      text = described_class.call(category: 'auth').content.first[:text]
+      expect(text).to include('**devise**')
+      expect(text).not_to include('**sidekiq**')
+    end
+
+    it 'shows no notable gems message for all' do
+      allow(described_class).to receive(:cached_section).with(:gems).and_return({
+                                                                                  total_gems: 5,
+                                                                                  notable_gems: []
+                                                                                })
+      text = described_class.call.content.first[:text]
+      expect(text).to include('_No notable gems found._')
+    end
+
+    it 'shows no notable gems message for specific category' do
+      allow(described_class).to receive(:cached_section).with(:gems).and_return({
+                                                                                  total_gems: 5,
+                                                                                  notable_gems: [
+                                                                                    { name: 'devise', version: '4.9', category: 'auth', note: 'Authentication' }
+                                                                                  ]
+                                                                                })
+      text = described_class.call(category: 'jobs').content.first[:text]
+      expect(text).to include("_No notable gems found in category 'jobs'._")
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # SearchCode::Formatter
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::SearchCode::Formatter do
+    it 'formats results with path' do
+      formatter = described_class.new
+      result = formatter.call([{ file: 'app.rb', line_number: 10, content: '  hello  ' }], 'hello', 'app/')
+      expect(result).to include('# Search: `hello`')
+      expect(result).to include('**1 results** in app/')
+      expect(result).to include('app.rb:10: hello')
+    end
+
+    it 'formats no results with path' do
+      formatter = described_class.new
+      result = formatter.call([], 'missing', 'lib/')
+      expect(result).to include("No results found for 'missing' in lib/")
+    end
+
+    it 'formats no results without path' do
+      formatter = described_class.new
+      result = formatter.call([], 'missing', nil)
+      expect(result).to include("No results found for 'missing'.")
+      expect(result).not_to include('in ')
+    end
+
+    it 'formats results without path' do
+      formatter = described_class.new
+      result = formatter.call([{ file: 'app.rb', line_number: 1, content: 'test' }], 'test', nil)
+      expect(result).to include('**1 results**')
+      expect(result).not_to include(' in ')
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Schema formatters
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::Schema::SummaryFormatter do
+    it 'shows pagination hint when more tables exist' do
+      tables = {
+        'a' => { columns: [{ name: 'id', type: 'integer' }], indexes: [{ name: 'idx', columns: ['id'], unique: true }] },
+        'b' => { columns: [], indexes: [] },
+        'c' => { columns: nil, indexes: nil }
+      }
+      formatter = described_class.new(tables: tables, total: 3, limit: 1, offset: 0, source: :live)
+      result = formatter.call
+      expect(result).to include('# Schema Summary (3 tables)')
+      expect(result).to include('- **a**')
+      expect(result).to include('1 columns, 1 indexes')
+      expect(result).to include('Use `offset:1` for more')
+    end
+
+    it 'omits pagination hint when all tables shown' do
+      tables = { 'a' => { columns: [], indexes: [] } }
+      formatter = described_class.new(tables: tables, total: 1, limit: 10, offset: 0)
+      result = formatter.call
+      expect(result).not_to include('Use `offset:')
+    end
+  end
+
+  describe RailsAiBridge::Tools::Schema::StandardFormatter do
+    it 'renders columns and partition note' do
+      tables = {
+        'users' => { columns: [{ name: 'id', type: 'integer' }], partition_of: 'parent_table', partition_bound: 'FOR VALUES FROM (1) TO (100)' }
+      }
+      formatter = described_class.new(tables: tables, total: 1, limit: 10, offset: 0, source: :static)
+      result = formatter.call
+      expect(result).to include('# Schema (1 tables, showing 1)')
+      expect(result).to include('### users')
+      expect(result).to include('id:integer')
+      expect(result).to include('partition of parent_table (FOR VALUES FROM (1) TO (100))')
+    end
+
+    it 'renders partitioned note without partition_by' do
+      tables = { 'events' => { columns: [], partitioned: true } }
+      formatter = described_class.new(tables: tables, total: 1, limit: 10, offset: 0)
+      result = formatter.call
+      expect(result).to include('partitioned')
+    end
+
+    it 'renders partitioned by note' do
+      tables = { 'events' => { columns: [], partitioned: true, partition_by: 'RANGE (created_at)' } }
+      formatter = described_class.new(tables: tables, total: 1, limit: 10, offset: 0)
+      result = formatter.call
+      expect(result).to include('partitioned by RANGE (created_at)')
+    end
+
+    it 'shows pagination hint' do
+      tables = { 'a' => { columns: [] } }
+      formatter = described_class.new(tables: tables, total: 5, limit: 1, offset: 0)
+      result = formatter.call
+      expect(result).to include('Use `detail:"summary"`')
+    end
+  end
+
+  describe RailsAiBridge::Tools::Schema::TableFormatter do
+    it 'renders columns, indexes, and foreign keys' do
+      data = {
+        columns: [
+          { name: 'id', type: 'integer', null: false, default: nil },
+          { name: 'email', type: 'string', null: true, default: "'a@b.c'" }
+        ],
+        indexes: [{ name: 'idx_email', columns: ['email'], unique: true }],
+        foreign_keys: [{ column: 'user_id', to_table: 'users', primary_key: 'id' }]
+      }
+      formatter = described_class.new(name: 'posts', data: data, source: :live)
+      result = formatter.call
+      expect(result).to include('## Table: posts')
+      expect(result).to include('| id | integer | no | - |')
+      expect(result).to include('| email | string | yes | \'a@b.c\' |')
+      expect(result).to include('### Indexes')
+      expect(result).to include('`idx_email` on (email) (unique)')
+      expect(result).to include('### Foreign keys')
+      expect(result).to include('`user_id` → `users.id`')
+    end
+
+    it 'renders partition_of heading' do
+      data = { columns: [], partition_of: 'parent', partition_bound: 'BOUND' }
+      formatter = described_class.new(name: 'child', data: data)
+      result = formatter.call
+      expect(result).to include('_Partition of `parent` — BOUND_')
+    end
+
+    it 'renders partitioned heading with partition_by' do
+      data = { columns: [], partitioned: true, partition_by: 'RANGE (id)' }
+      formatter = described_class.new(name: 'events', data: data)
+      result = formatter.call
+      expect(result).to include('_Partitioned by RANGE (id)_')
+    end
+
+    it 'renders partitioned heading without partition_by' do
+      data = { columns: [], partitioned: true }
+      formatter = described_class.new(name: 'events', data: data)
+      result = formatter.call
+      expect(result).to include('_Partitioned_')
+    end
+
+    it 'handles nil columns and indexes' do
+      data = { columns: nil, indexes: nil, foreign_keys: nil }
+      formatter = described_class.new(name: 'empty', data: data)
+      result = formatter.call
+      expect(result).to include('## Table: empty')
+      expect(result).to include('| Column | Type | Nullable | Default |')
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # ModelDetails formatters
+  # ------------------------------------------------------------------
+  describe RailsAiBridge::Tools::ModelDetails::SummaryFormatter do
+    it 'renders model list with semantic tier' do
+      models = { 'User' => { semantic_tier: 'core' }, 'Post' => { semantic_tier: nil } }
+      formatter = described_class.new(models: models)
+      result = formatter.call
+      expect(result).to include('# Available models (2)')
+      expect(result).to include('- Post')
+      expect(result).to include('- User (core)')
+    end
+
+    it 'handles non-hash model data' do
+      models = { 'Foo' => nil }
+      formatter = described_class.new(models: models)
+      result = formatter.call
+      expect(result).to include('- Foo')
+    end
+
+    it 'appends non-AR models' do
+      models = { 'User' => {} }
+      non_ar = { non_ar_models: [{ name: 'PaymentGateway', relative_path: 'app/models/payment_gateway.rb', tag: 'PORO' }] }
+      formatter = described_class.new(models: models, non_ar_models: non_ar)
+      result = formatter.call
+      expect(result).to include('PaymentGateway')
+      expect(result).to include('Non-ActiveRecord classes')
+    end
+  end
+
+  describe RailsAiBridge::Tools::ModelDetails::StandardFormatter do
+    it 'renders models with tier and association/validation counts' do
+      models = {
+        'User' => { associations: [{ type: 'has_many', name: 'posts' }], validations: [{ kind: 'presence', attributes: ['name'] }], semantic_tier: 'core',
+                    semantic_tier_reason: 'central entity' },
+        'Post' => { associations: [], validations: [], semantic_tier: nil },
+        'Error' => { error: 'boom' }
+      }
+      formatter = described_class.new(models: models)
+      result = formatter.call
+      expect(result).to include('# Models (3)')
+      expect(result).to include('- **Post**')
+      expect(result).to include('- **User** — tier: core — 1 associations, 1 validations')
+      expect(result).not_to include('Error')
+    end
+
+    it 'renders model with zero counts' do
+      models = { 'Empty' => { associations: nil, validations: nil } }
+      formatter = described_class.new(models: models)
+      result = formatter.call
+      expect(result).to include('- **Empty**')
+      expect(result).not_to include('associations')
+    end
+  end
+
+  describe RailsAiBridge::Tools::ModelDetails::FullFormatter do
+    it 'renders models with table, tier, and associations' do
+      models = {
+        'User' => {
+          table_name: 'users',
+          semantic_tier: 'core',
+          associations: [{ type: 'has_many', name: 'posts', source: :reflection }]
+        },
+        'Post' => { table_name: nil, associations: [], semantic_tier: nil },
+        'Error' => { error: 'boom' }
+      }
+      formatter = described_class.new(models: models)
+      result = formatter.call
+      expect(result).to include('# Models (3)')
+      expect(result).to include('- **User** (table: users) — tier: core')
+      expect(result).to include('has_many :posts')
+      expect(result).to include('- **Post**')
+      expect(result).not_to include('Error')
+    end
+  end
+
+  describe RailsAiBridge::Tools::ModelDetails::SingleModelFormatter do
+    it 'renders full model detail with all sections' do
+      data = {
+        table_name: 'users',
+        semantic_tier: 'core',
+        semantic_tier_reason: 'central',
+        associations: [
+          { type: 'has_many', name: 'posts', source: :reflection },
+          { type: 'belongs_to', name: 'account', class_name: 'BillingAccount', through: nil, polymorphic: true, dependent: nil },
+          { type: 'has_many', name: 'comments', through: 'post_comments', dependent: :destroy }
+        ],
+        validations: [
+          { kind: 'presence', attributes: ['name'], options: {} },
+          { kind: 'uniqueness', attributes: ['email'], options: { scope: 'account_id' } }
+        ],
+        enums: { status: %w[active inactive] },
+        scopes: %w[recent published],
+        callbacks: { before_save: %w[normalize_email], after_create: %w[send_welcome] },
+        concerns: %w[Trackable Validatable],
+        instance_methods: %w[full_name admin? active? reset_password update_last_login generate_token validate_email send_notification archive unarchive restore lock unlock ban
+                             unban]
+      }
+      formatter = described_class.new(name: 'User', data: data)
+      result = formatter.call
+      expect(result).to include('# User')
+      expect(result).to include('**Table:** `users`')
+      expect(result).to include('**Semantic tier:** `core`')
+      expect(result).to include('**Tier reason:** central')
+      expect(result).to include('## Associations')
+      expect(result).to include('`belongs_to` **account** (class: BillingAccount) [polymorphic]')
+      expect(result).to include('`has_many` **comments** through: post_comments dependent: destroy')
+      expect(result).to include('## Validations')
+      expect(result).to include('`uniqueness` on email (scope: account_id)')
+      expect(result).to include('## Enums')
+      expect(result).to include('`status`: active, inactive')
+      expect(result).to include('## Scopes')
+      expect(result).to include('`recent`')
+      expect(result).to include('## Callbacks')
+      expect(result).to include('`before_save`: normalize_email')
+      expect(result).to include('## Concerns')
+      expect(result).to include('Trackable')
+      expect(result).to include('## Key instance methods')
+    end
+
+    it 'renders source macros with boolean, array, and hash values' do
+      data = {
+        has_secure_password: true,
+        has_many_attached: %w[avatar document],
+        normalizes: [{ methods: %w[trim], to: 'email' }]
+      }
+      formatter = described_class.new(name: 'User', data: data)
+      result = formatter.call
+      expect(result).to include('## Source macros')
+      expect(result).to include('`has_secure_password`')
+      expect(result).to include('`has_many_attached`: avatar, document')
+      expect(result).to include('`normalizes`: trim → email')
+    end
+
+    it 'renders association with class_name matching name (no class annotation)' do
+      data = {
+        associations: [{ type: 'belongs_to', name: 'post', class_name: 'Post', source: :reflection }]
+      }
+      formatter = described_class.new(name: 'Comment', data: data)
+      result = formatter.call
+      expect(result).to include('`belongs_to` **post**')
+      expect(result).not_to include('(class: Post)')
+    end
+
+    it 'limits instance methods to 15' do
+      data = { instance_methods: ('a'..'z').to_a }
+      formatter = described_class.new(name: 'Big', data: data)
+      result = formatter.call
+      expect(result).to include('## Key instance methods')
+      method_lines = result.lines.select { |l| l.start_with?('- `') }
+      expect(method_lines.size).to eq(15)
+    end
+
+    it 'renders minimal model with no optional data' do
+      data = {}
+      formatter = described_class.new(name: 'Bare', data: data)
+      result = formatter.call
+      expect(result).to include('# Bare')
+      expect(result).not_to include('## Associations')
+      expect(result).not_to include('## Source macros')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'simplecov'
 SimpleCov.start do
   enable_coverage :branch
-  minimum_coverage line: 90, branch: 75 if (ENV['CI'] || ENV.fetch('COVERAGE', nil)) && !ENV['PERF']
+  minimum_coverage line: 90, branch: 90 if (ENV['CI'] || ENV.fetch('COVERAGE', nil)) && !ENV['PERF']
   skip 'spec'
 end
 


### PR DESCRIPTION
## Summary
- Add focused specs for uncovered branches in MCP tools (pagination, detail levels, formatters), serializer section formatters (nil-value handling, missing-data paths), context summary scoring (non-Hash inputs, database size buckets, short version strings), and generator profiles
- Raise SimpleCov branch minimum from 75 to 90 — the 90/90 gate is now permanent
- Global coverage: 96.29% line / 90.10% branch across 3170 examples

This is the critical Task 5 gate from the v5 plan. It must merge before any v5 feature PR can be released.

#### Test plan
- [x] `bundle exec rspec` — 3170 examples, 0 failures
- [x] `bundle exec rubocop --parallel` — 466 files, 0 offenses
- [x] SimpleCov gate passes at line:90, branch:90
- [x] No production code changed (spec-only + spec_helper threshold)

Generated with [Devin](https://devin.ai)