### PR TITLE
test: characterization specs for Rubydex 0.4 and MCP 1.3 upgrades

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,165 @@
 # Upgrading rails-ai-bridge
 
+## Upgrading Rubydex to 0.4.0 (age-gated: mergeable Aug 28)
+
+**Current:** `rubydex ~> 0.3.0` (installed: 0.3.0)
+**Target:** `rubydex ~> 0.4.0`
+
+### What changed in Rubydex 0.4.0
+
+Source: [v0.3.0...v0.4.0](https://github.com/Shopify/rubydex/compare/v0.3.0...v0.4.0)
+
+**Breaking changes:**
+- **`Config` is now a proper object** (#965) — `Rubydex::Graph.new` may accept
+  or require a `Config` instance instead of being constructed with no args.
+  The adapter currently calls `Rubydex::Graph.new` with no arguments in
+  `Indexer.build_index`; this may need updating.
+- **Cypher query results return graph objects** (#873) — query return types
+  may have changed from plain arrays/hashes to graph object wrappers.
+- **Declaration core extracted** (#944) — declaration object shape may have
+  changed; the serializer relies on `decl.name`, `decl.unqualified_name`,
+  `decl.definitions`, `decl.ancestors`, `decl.descendants`, `decl.owner`,
+  and `decl.class.name`.
+- **`NamespaceStore` extracted** (#945) — namespace resolution internals
+  changed; may affect `graph[name]` lookups.
+
+**Enhancements:**
+- Eagerly compute name depths into `Name` (#948)
+- Remove Mixin vec clones from ancestor linearization (#949)
+- Add linter configuration and configurable Rubydex linter (#972, #974)
+- Add severity and related information to diagnostics (#973)
+- Index RBS attribute methods (#970)
+
+**Bug fixes:**
+- Enqueue retry if `Object` ancestors are incomplete (#950)
+- Visit `module_function` bodies once in `OperationBuilder` (#994)
+- Fix `extend self` in anonymous modules (#1001)
+- Linearize ancestors for implicitly created namespaces (#1005)
+
+### Migration steps
+
+1. **Update the gemspec constraint** from `~> 0.3.0` to `~> 0.4.0` (after Aug 28).
+2. **Run `bundle update rubydex`** and verify the installed version is 0.4.x.
+3. **Check `Rubydex::Graph.new`** — if `Config` is now required, update
+   `Indexer.build_index` to construct and pass a `Config` object.
+4. **Run characterization specs** under
+   `spec/lib/rails_ai_bridge/rubydex_adapter/characterization_spec.rb` —
+   these pin the graph API surface (method names, return shapes) and will
+   fail if any breaking changes affect the adapter.
+5. **Verify declaration/definition shapes** — the serializer's
+   `declaration_type` method uses `decl.class.name` pattern matching
+   (`/class/`, `/module/`, `/method/`, `/constant/`). If class names change
+   in 0.4.0, update `TYPE_PATTERNS` in `serializer.rb`.
+6. **Test incremental reindex** — the `IncrementalIndexer` calls
+   `graph.delete_document`, `graph.index_source`, `graph.document`, and
+   `graph.resolve`. Verify these methods still exist with the same signatures.
+7. **Smoke-test `rails_search_semantic` tool** — this is the primary
+   user-facing consumer of the Rubydex adapter.
+
+### Characterization specs
+
+The following spec files pin current behavior to catch regressions:
+- `spec/lib/rails_ai_bridge/rubydex_adapter/characterization_spec.rb` —
+  full graph API contract (indexing, search, declarations, definitions,
+  references, locations, ancestors/descendants, graceful failure)
+- `spec/lib/rails_ai_bridge/rubydex_adapter_spec.rb` — adapter unit tests
+- `spec/lib/rails_ai_bridge/rubydex_adapter/incremental_indexer_spec.rb` —
+  incremental rebuild and persistence behavior
+- `spec/lib/rails_ai_bridge/rubydex_adapter/serializer_spec.rb` —
+  declaration/definition serialization shapes
+- `spec/lib/rails_ai_bridge/rubydex_adapter/indexer_spec.rb` —
+  file discovery and graph construction
+- `spec/lib/rails_ai_bridge/rubydex_adapter/method_counter_spec.rb` —
+  method counting logic
+
+---
+
+## Upgrading MCP SDK to 1.3.0 (age-gated: mergeable Aug 29)
+
+**Current:** `mcp >= 1.0, < 2.0` (installed: 1.3.0)
+**Target:** `mcp >= 1.3, < 2.0`
+
+The installed version is already 1.3.0; the gemspec lower bound needs
+tightening from `>= 1.0` to `>= 1.3` to ensure all hosts pick up the
+1.2.0+ stateless lifecycle and 1.3.0 resource list handler features.
+
+### What changed in MCP 1.1.0 → 1.2.0 → 1.3.0
+
+Source: [CHANGELOG.md](https://github.com/modelcontextprotocol/ruby-sdk/blob/main/CHANGELOG.md)
+
+**1.3.0 (Aug 22, 2026):**
+- **Added:** `resources_list_handler` for context-dependent resource lists (#509)
+- **Added:** Handler-returned `_meta` passed through subscribe result (#510)
+- **Changed:** Bound OAuth response bodies in the client (#520)
+- **Changed:** Reject duplicate in-flight JSON-RPC request ids (#521)
+- **Changed:** Documentation moved from README.md to documentation site (#523)
+
+**1.2.0 (Aug 15, 2026) — 2026-07-28 stateless lifecycle:**
+- **Added:** SEP-2575 modern request envelope handling (#475)
+- **Added:** Both lifecycle eras over stdio with era lock (#478)
+- **Added:** Sessionless modern path over Streamable HTTP (#479)
+- **Added:** `server/discover` and client modern lifecycle (#480)
+- **Added:** Multi round-trip `input_required` results (#481, #500, #501)
+- **Added:** `MCP::Elicitation::EnumSchema` builders (#482)
+- **Added:** Modern lifecycle admission rules (#489)
+- **Added:** `subscriptions/listen` notification stream (#495)
+- **Added:** Opt-in `requestState` sealing via `MCP::Server::RequestStateSecurity` (#496)
+- **Added:** `x-mcp-header` tool parameters mirrored to `Mcp-Param-*` headers (#498)
+- **Added:** Cache hints on modern cacheable results (#499)
+- **Changed:** `Mcp-Method` header required on modern path (#492)
+- **Changed:** Server-to-client requests refused in modern lifecycle (#503)
+- **Changed:** SSE reconnection wait bounded (#504)
+- **Changed:** Automatic pagination bounded in client (#505)
+- **Deprecated:** Roots and Sampling capabilities deprecated per SEP-2577 (#516)
+- **Fixed:** Exception messages no longer leaked to clients (#486)
+- **Fixed:** Invalid Params for unknown prompts and missing prompt arguments (#517)
+
+**1.1.0 (Aug 1, 2026):**
+- **Added:** 2026-07-28 as Latest Protocol Version (#476)
+- **Added:** Server tool annotations exposed on `MCP::Client::Tool` (#445)
+- **Fixed:** Explicit tool response content preserved (#469)
+
+### Migration steps
+
+1. **Update the gemspec constraint** from `>= 1.0, < 2.0` to `>= 1.3, < 2.0`
+   (after Aug 29).
+2. **Run `bundle update mcp`** — most hosts already resolve 1.3.0; this
+   tightens the floor.
+3. **Run characterization specs** under `spec/lib/rails_ai_bridge/mcp/`:
+   - `protocol_characterization_spec.rb` — SDK version, server constructor,
+     transport classes, 2026-07-28 lifecycle method surface
+   - `tool_annotations_spec.rb` — all 19 tool annotation hints
+   - `resource_lists_spec.rb` — resource/template construction and read handler
+   - `error_responses_spec.rb` — 404/401/403/429 error shapes, response bounds
+4. **Verify `resources_list_handler`** — new in 1.3.0. If the bridge wants
+   context-dependent resource lists, register a handler via
+   `server.resources_list_handler { |params| ... }`.
+5. **Check for duplicate request id rejection** — 1.3.0 rejects duplicate
+   in-flight JSON-RPC request ids (#521). This is a server-side change that
+   should be transparent to the bridge, but verify no test relies on
+   duplicate ids being accepted.
+6. **Verify exception message masking** — 1.2.0 stopped leaking exception
+   messages to clients via JSON-RPC error data (#486). Ensure error
+   responses still contain useful information for debugging.
+7. **Smoke-test stdio and HTTP transports** — start `rails ai:serve` and
+   verify tool calls and resource reads work end-to-end.
+
+### Characterization specs
+
+The following spec files pin current protocol behavior:
+- `spec/lib/rails_ai_bridge/mcp/protocol_characterization_spec.rb` —
+  SDK version, server construction, transport routing, lifecycle methods
+- `spec/lib/rails_ai_bridge/mcp/tool_annotations_spec.rb` —
+  all 19 tool annotations, response construction, truncation bounds
+- `spec/lib/rails_ai_bridge/mcp/resource_lists_spec.rb` —
+  resource/template construction, read handler, URI resolution
+- `spec/lib/rails_ai_bridge/mcp/error_responses_spec.rb` —
+  HTTP error responses (404/401/403/429), CORS preflight, response bounds
+- `spec/lib/rails_ai_bridge/mcp/sdk_compatibility_spec.rb` —
+  basic SDK surface compatibility (pre-existing)
+
+---
+
 ## Upgrading from 3.7.x to 4.0.0 (`mcp` 1.x) (#104/#118)
 
 **Action required:**

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,7 +36,7 @@ Source: [v0.3.0...v0.4.0](https://github.com/Shopify/rubydex/compare/v0.3.0...v0
 - Fix `extend self` in anonymous modules (#1001)
 - Linearize ancestors for implicitly created namespaces (#1005)
 
-### Migration steps
+### Rubydex migration steps
 
 1. **Update the gemspec constraint** from `~> 0.3.0` to `~> 0.4.0` (after Aug 28).
 2. **Run `bundle update rubydex`** and verify the installed version is 0.4.x.
@@ -56,7 +56,7 @@ Source: [v0.3.0...v0.4.0](https://github.com/Shopify/rubydex/compare/v0.3.0...v0
 7. **Smoke-test `rails_search_semantic` tool** — this is the primary
    user-facing consumer of the Rubydex adapter.
 
-### Characterization specs
+### Rubydex characterization specs
 
 The following spec files pin current behavior to catch regressions:
 - `spec/lib/rails_ai_bridge/rubydex_adapter/characterization_spec.rb` —
@@ -119,7 +119,7 @@ Source: [CHANGELOG.md](https://github.com/modelcontextprotocol/ruby-sdk/blob/mai
 - **Added:** Server tool annotations exposed on `MCP::Client::Tool` (#445)
 - **Fixed:** Explicit tool response content preserved (#469)
 
-### Migration steps
+### MCP migration steps
 
 1. **Update the gemspec constraint** from `>= 1.0, < 2.0` to `>= 1.3, < 2.0`
    (after Aug 29).
@@ -144,7 +144,7 @@ Source: [CHANGELOG.md](https://github.com/modelcontextprotocol/ruby-sdk/blob/mai
 7. **Smoke-test stdio and HTTP transports** — start `rails ai:serve` and
    verify tool calls and resource reads work end-to-end.
 
-### Characterization specs
+### MCP characterization specs
 
 The following spec files pin current protocol behavior:
 - `spec/lib/rails_ai_bridge/mcp/protocol_characterization_spec.rb` —

--- a/lib/rails_ai_bridge/tools/list_registry.rb
+++ b/lib/rails_ai_bridge/tools/list_registry.rb
@@ -120,8 +120,8 @@ module RailsAiBridge
         # @return [String] markdown string
         def format
           case @type
-          when 'skills'  then format_catalog(@resolver.list_skills,   noun: 'Skill')
-          when 'agents'  then format_catalog(@resolver.list_agents,   noun: 'Agent')
+          when 'skills'  then format_catalog(@resolver.list_skills, noun: 'Skill')
+          when 'agents'  then format_catalog(@resolver.list_agents, noun: 'Agent')
           when 'packs'   then format_packs(@resolver.active_packs)
           end
         end

--- a/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
@@ -76,9 +76,8 @@ RSpec.describe RailsAiBridge::Introspectors::NonArModelsIntrospector do
       end
 
       after do
-        # rubocop:disable RSpec/RemoveConst
+        # rubocop:disable-next RSpec/RemoveConst
         Object.send(:remove_const, custom_context[:constant_name]) if Object.const_defined?(custom_context[:constant_name], false)
-        # rubocop:enable RSpec/RemoveConst
         FileUtils.rm_rf(custom_context[:root_path])
       end
 

--- a/spec/lib/rails_ai_bridge/mcp/error_responses_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/error_responses_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe 'MCP error responses and bounds (SDK 1.3.0)' do
     saved_authorize = RailsAiBridge.configuration.mcp.authorize
     saved_rate_limiter = RailsAiBridge.configuration.mcp.rate_limiter
     saved_max_reqs = RailsAiBridge.configuration.mcp.rate_limit_max_requests
+    saved_token_resolver = RailsAiBridge.configuration.mcp_token_resolver
+    saved_jwt_decoder = RailsAiBridge.configuration.mcp_jwt_decoder
+    saved_rate_limit_window = RailsAiBridge.configuration.mcp.rate_limit_window_seconds
+    saved_cors_origins = RailsAiBridge.configuration.mcp.cors_origins
     example.run
   ensure
     RailsAiBridge.configuration.http_mcp_token = saved_token
@@ -25,6 +29,10 @@ RSpec.describe 'MCP error responses and bounds (SDK 1.3.0)' do
     RailsAiBridge.configuration.mcp.authorize = saved_authorize
     RailsAiBridge.configuration.mcp.rate_limiter = saved_rate_limiter
     RailsAiBridge.configuration.mcp.rate_limit_max_requests = saved_max_reqs
+    RailsAiBridge.configuration.mcp_token_resolver = saved_token_resolver
+    RailsAiBridge.configuration.mcp_jwt_decoder = saved_jwt_decoder
+    RailsAiBridge.configuration.mcp.rate_limit_window_seconds = saved_rate_limit_window
+    RailsAiBridge.configuration.mcp.cors_origins = saved_cors_origins
   end
 
   before do

--- a/spec/lib/rails_ai_bridge/mcp/error_responses_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/error_responses_spec.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mcp'
+
+# Characterization specs that pin MCP error response behavior and response
+# bounds. These cover the HTTP transport's error handling (404, 401, 403,
+# 429), the resource read error path, and tool response truncation limits.
+#
+# These specs pin the current error response shapes so the MCP 1.3.0
+# upgrade doesn't silently change status codes, headers, or body formats.
+RSpec.describe 'MCP error responses and bounds (SDK 1.3.0)' do
+  let(:transport) { instance_double(MCP::Server::Transports::StreamableHTTPTransport) }
+
+  around do |example|
+    saved_token = RailsAiBridge.configuration.http_mcp_token
+    saved_require_http_auth = RailsAiBridge.configuration.mcp.require_http_auth
+    saved_authorize = RailsAiBridge.configuration.mcp.authorize
+    saved_rate_limiter = RailsAiBridge.configuration.mcp.rate_limiter
+    saved_max_reqs = RailsAiBridge.configuration.mcp.rate_limit_max_requests
+    example.run
+  ensure
+    RailsAiBridge.configuration.http_mcp_token = saved_token
+    RailsAiBridge.configuration.mcp.require_http_auth = saved_require_http_auth
+    RailsAiBridge.configuration.mcp.authorize = saved_authorize
+    RailsAiBridge.configuration.mcp.rate_limiter = saved_rate_limiter
+    RailsAiBridge.configuration.mcp.rate_limit_max_requests = saved_max_reqs
+  end
+
+  before do
+    RailsAiBridge.configuration.http_mcp_token = nil
+    RailsAiBridge.configuration.mcp.require_http_auth = false
+    RailsAiBridge.configuration.mcp.authorize = nil
+    RailsAiBridge.configuration.mcp.rate_limiter = nil
+    RailsAiBridge.configuration.mcp.rate_limit_max_requests = 0
+  end
+
+  # ---- 404 Not Found ----
+
+  describe '404 for non-MCP paths' do
+    it 'returns 404 with JSON error body' do
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+
+      status, headers, body = app.call(Rack::MockRequest.env_for('/users'))
+
+      expect(status).to eq(404)
+      expect(headers['Content-Type']).to eq('application/json')
+      expect(body.first).to include('Not found')
+    end
+
+    it 'returns 404 for paths that do not match the MCP endpoint' do
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+
+      status, = app.call(Rack::MockRequest.env_for('/api/v1/data'))
+
+      expect(status).to eq(404)
+    end
+
+    it 'does not delegate to transport for non-MCP paths' do
+      allow(transport).to receive(:handle_request).and_return([200, {}, ['OK']])
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+
+      app.call(Rack::MockRequest.env_for('/users'))
+
+      expect(transport).not_to have_received(:handle_request)
+    end
+  end
+
+  # ---- 401 Unauthorized ----
+
+  describe '401 when authentication is required but missing' do
+    it 'returns 401 when require_http_auth is true and no auth is configured' do
+      token_key = RailsAiBridge::Mcp::Authenticator::TOKEN_ENV_KEY
+      saved_env_token = ENV.fetch(token_key, nil)
+      ENV.delete(token_key)
+
+      begin
+        RailsAiBridge.configuration.mcp.require_http_auth = true
+        RailsAiBridge.configuration.http_mcp_token = nil
+        RailsAiBridge.configuration.mcp_token_resolver = nil
+        RailsAiBridge.configuration.mcp_jwt_decoder = nil
+
+        app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+
+        status, headers, = app.call(Rack::MockRequest.env_for('/mcp', method: 'POST'))
+
+        expect(status).to eq(401)
+        expect(headers['WWW-Authenticate']).to include('Bearer')
+      ensure
+        if saved_env_token
+          ENV[token_key] = saved_env_token
+        else
+          ENV.delete(token_key)
+        end
+      end
+    end
+
+    it 'returns 401 when a token is configured but Authorization header is missing' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+
+      status, headers, = app.call(Rack::MockRequest.env_for('/mcp', method: 'POST'))
+
+      expect(status).to eq(401)
+      expect(headers['WWW-Authenticate']).to include('Bearer')
+    end
+  end
+
+  # ---- 403 Forbidden ----
+
+  describe '403 when authorize lambda denies access' do
+    it 'returns 403 when authorize returns false' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.authorize = ->(_ctx, _req) { false }
+
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for('/mcp', method: 'POST', 'HTTP_AUTHORIZATION' => 'Bearer secret')
+      allow(Rails.logger).to receive(:warn)
+      status, _headers, body = app.call(env)
+
+      expect(status).to eq(403)
+      expect(body.first).to include('Forbidden')
+    end
+
+    it 'returns 403 when authorize lambda raises' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.authorize = ->(_ctx, _req) { raise 'boom' }
+
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+
+      env = Rack::MockRequest.env_for('/mcp', method: 'POST', 'HTTP_AUTHORIZATION' => 'Bearer secret')
+      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
+      status, _headers, body = app.call(env)
+
+      expect(status).to eq(403)
+      expect(body.first).to include('Forbidden')
+    end
+  end
+
+  # ---- 429 Too Many Requests ----
+
+  describe '429 when rate limit is exceeded' do
+    it 'returns 429 with Retry-After header' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.rate_limit_max_requests = 1
+      RailsAiBridge.configuration.mcp.rate_limit_window_seconds = 60
+
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+      allow(transport).to receive(:handle_request).and_return([200, {}, ['OK']])
+
+      env = Rack::MockRequest.env_for('/mcp', method: 'POST',
+                                              'HTTP_AUTHORIZATION' => 'Bearer secret', 'REMOTE_ADDR' => '1.2.3.4')
+      app.call(env)
+      status, headers, body = app.call(env)
+
+      expect(status).to eq(429)
+      expect(headers['Retry-After']).to eq('60')
+      expect(body.first).to include('Too many requests')
+    end
+
+    it 'emits a rate_limit.hit instrumentation event' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      RailsAiBridge.configuration.mcp.rate_limiter = ->(_ip) { false }
+      RailsAiBridge.configuration.mcp.rate_limit_max_requests = 0
+
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+      env = Rack::MockRequest.env_for('/mcp', method: 'POST',
+                                              'HTTP_AUTHORIZATION' => 'Bearer secret', 'REMOTE_ADDR' => '1.2.3.4')
+
+      events = []
+      callback = ->(name, _started, _finished, _unique_id, payload) { events << [name, payload] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'rails_ai_bridge.rate_limit.hit') do
+        app.call(env)
+      end
+
+      expect(events.size).to eq(1)
+      expect(events.first.last[:ip]).to eq('1.2.3.4')
+    end
+  end
+
+  # ---- Resource read error ----
+
+  describe 'resource read error for unknown URIs' do
+    it 'raises when resource URI is not found' do
+      expect do
+        RailsAiBridge::Resources.send(:handle_read, uri: 'rails://nonexistent')
+      end.to raise_error(RuntimeError, /Unknown resource/)
+    end
+  end
+
+  # ---- Response bounds: tool truncation ----
+
+  describe 'tool response truncation bounds' do
+    context 'when max_tool_response_chars is set' do
+      before do
+        allow(RailsAiBridge.configuration).to receive(:max_tool_response_chars).and_return(50)
+      end
+
+      it 'truncates responses exceeding the limit' do
+        long_text = 'x' * 200
+        response = RailsAiBridge::Tools::BaseTool.text_response(long_text)
+
+        expect(response.content.first[:text].length).to be <= 50
+      end
+
+      it 'includes a truncation notice' do
+        response = RailsAiBridge::Tools::BaseTool.text_response('x' * 200)
+
+        expect(response.content.first[:text]).to include('Response truncated')
+      end
+
+      it 'does not truncate responses under the limit' do
+        response = RailsAiBridge::Tools::BaseTool.text_response('short')
+
+        expect(response.content.first[:text]).to eq('short')
+      end
+    end
+
+    context 'when max_tool_response_chars is nil' do
+      before do
+        allow(RailsAiBridge.configuration).to receive(:max_tool_response_chars).and_return(nil)
+      end
+
+      it 'returns full text without truncation' do
+        text = 'x' * 50_000
+        response = RailsAiBridge::Tools::BaseTool.text_response(text)
+
+        expect(response.content.first[:text]).to eq(text)
+      end
+    end
+  end
+
+  # ---- CORS preflight (204) ----
+
+  describe '204 for CORS preflight requests' do
+    it 'returns 204 with CORS headers for allowed origins' do
+      RailsAiBridge.configuration.mcp.cors_origins = ['https://example.com']
+      allow(transport).to receive(:handle_request)
+
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+      env = Rack::MockRequest.env_for('/mcp', method: 'OPTIONS', 'HTTP_ORIGIN' => 'https://example.com')
+
+      status, headers, body = app.call(env)
+
+      expect(status).to eq(204)
+      expect(headers['Access-Control-Allow-Origin']).to eq('https://example.com')
+      expect(body.first).to be_empty
+    end
+
+    it 'does not delegate to transport for preflight' do
+      RailsAiBridge.configuration.mcp.cors_origins = ['https://example.com']
+      allow(transport).to receive(:handle_request)
+
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+      app.call(Rack::MockRequest.env_for('/mcp', method: 'OPTIONS', 'HTTP_ORIGIN' => 'https://example.com'))
+
+      expect(transport).not_to have_received(:handle_request)
+    end
+  end
+
+  # ---- Authorized request delegation ----
+
+  describe 'authorized request delegation to transport' do
+    it 'delegates to transport.handle_request for authorized requests' do
+      RailsAiBridge.configuration.http_mcp_token = 'secret'
+      allow(transport).to receive(:handle_request).and_return([200, {}, ['OK']])
+
+      app = RailsAiBridge::HttpTransportApp.build(transport: transport, path: '/mcp')
+      env = Rack::MockRequest.env_for('/mcp', method: 'POST', 'HTTP_AUTHORIZATION' => 'Bearer secret')
+
+      status, = app.call(env)
+
+      expect(status).to eq(200)
+      expect(transport).to have_received(:handle_request)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/protocol_characterization_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/protocol_characterization_spec.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mcp'
+
+# Characterization specs that pin the MCP protocol behavior as exposed
+# through the rails-ai-bridge Server class with the official Ruby MCP SDK.
+#
+# Current SDK: mcp 1.3.0 (gemspec constraint: >= 1.0, < 2.0)
+# Target: tighten to >= 1.3, < 2.0 (age-gated until Aug 29)
+#
+# These specs pin:
+#   - MCP::Server constructor signature and kwargs
+#   - Transport class availability and construction
+#   - Protocol version advertised by the SDK
+#   - The 2026-07-28 stateless lifecycle support
+RSpec.describe 'MCP protocol characterization (SDK 1.3.0)' do
+  let(:app) { 'TestApp' }
+  let(:server) { RailsAiBridge::Server.new(app, transport: RailsAiBridge::Server::STDIO_TRANSPORT) }
+
+  before do
+    allow(RailsAiBridge).to receive(:configuration).and_return(
+      double(
+        server_name: 'Test Server',
+        server_version: '1.0.0',
+        additional_tools: [],
+        http_bind: 'localhost',
+        http_port: 3000,
+        http_path: '/mcp',
+        mcp: double(tool_result_cache_ttl: 0)
+      )
+    )
+    allow(RailsAiBridge::Resources).to receive_messages(build_resources: [], build_templates: [])
+    allow(RailsAiBridge::Resources).to receive(:register)
+  end
+
+  # ---- SDK version ----
+
+  describe 'SDK version' do
+    it 'is 1.3.0' do
+      expect(MCP::VERSION).to eq('1.3.0')
+    end
+
+    it 'is within the 1.x stable range' do
+      version = Gem.loaded_specs['mcp']&.version || Gem::Version.new(MCP::VERSION)
+      expect(version).to be >= Gem::Version.new('1.0.0')
+      expect(version).to be < Gem::Version.new('2.0.0')
+    end
+  end
+
+  # ---- Server construction ----
+
+  describe 'MCP::Server constructor kwargs' do
+    it 'accepts name, version, tools, resources, and resource_templates' do
+      mcp_server = nil
+      allow(MCP::Server).to receive(:new) do |**kwargs|
+        mcp_server = double('MCP::Server', kwargs: kwargs)
+        mcp_server
+      end
+
+      server.build
+
+      expect(MCP::Server).to have_received(:new) do |**kwargs|
+        expect(kwargs[:name]).to eq('Test Server')
+        expect(kwargs[:version]).to eq('1.0.0')
+        expect(kwargs[:tools]).to be_an(Array)
+        expect(kwargs[:resources]).to eq([])
+        expect(kwargs[:resource_templates]).to eq([])
+      end
+    end
+
+    it 'passes tool classes wrapped with Instrumentation::InstrumentedTool' do
+      allow(MCP::Server).to receive(:new).and_return(double(register: nil))
+
+      server.build
+
+      expect(MCP::Server).to have_received(:new) do |**kwargs|
+        kwargs[:tools].each do |tool|
+          expect(tool).to be_a(RailsAiBridge::Instrumentation::InstrumentedTool)
+        end
+      end
+    end
+  end
+
+  # ---- Transport classes ----
+
+  describe 'transport class availability' do
+    it 'exposes StdioTransport' do
+      expect(defined?(MCP::Server::Transports::StdioTransport)).to eq('constant')
+    end
+
+    it 'exposes StreamableHTTPTransport' do
+      expect(defined?(MCP::Server::Transports::StreamableHTTPTransport)).to eq('constant')
+    end
+
+    it 'constructs StdioTransport with a server argument' do
+      mcp_server = double('MCP::Server')
+      transport = double('transport', open: true)
+      allow(MCP::Server::Transports::StdioTransport).to receive(:new).with(mcp_server).and_return(transport)
+
+      server.send(:start_stdio, mcp_server)
+
+      expect(MCP::Server::Transports::StdioTransport).to have_received(:new).with(mcp_server)
+    end
+
+    it 'constructs StreamableHTTPTransport with a server argument' do
+      http_server = RailsAiBridge::Server.new(app, transport: RailsAiBridge::Server::HTTP_TRANSPORT)
+      mcp_server = double('MCP::Server')
+      transport = double('transport')
+      allow(MCP::Server::Transports::StreamableHTTPTransport).to receive(:new).with(mcp_server).and_return(transport)
+      allow(http_server).to receive_messages(validate_http_server_in_production: nil, build_rack_app: double,
+                                             log_http_startup: nil, run_rack_server: nil)
+      allow(RailsAiBridge::Mcp::Authenticator).to receive(:any_configured?).and_return(true)
+
+      http_server.send(:start_http, mcp_server)
+
+      expect(MCP::Server::Transports::StreamableHTTPTransport).to have_received(:new).with(mcp_server)
+    end
+  end
+
+  # ---- Transport type routing ----
+
+  describe 'transport type routing' do
+    it 'routes :stdio to start_stdio' do
+      allow(server).to receive(:build).and_return(double('server'))
+      allow(server).to receive(:start_stdio)
+
+      server.start
+
+      expect(server).to have_received(:start_stdio)
+    end
+
+    it 'routes :http to start_http' do
+      http_server = RailsAiBridge::Server.new(app, transport: RailsAiBridge::Server::HTTP_TRANSPORT)
+      allow(http_server).to receive(:build).and_return(double('server'))
+      allow(http_server).to receive(:start_http)
+
+      http_server.start
+
+      expect(http_server).to have_received(:start_http)
+    end
+
+    it 'routes :streamable_http to start_http' do
+      streamable = RailsAiBridge::Server.new(app, transport: RailsAiBridge::Server::STREAMABLE_HTTP_TRANSPORT)
+      allow(streamable).to receive(:build).and_return(double('server'))
+      allow(streamable).to receive(:start_http)
+
+      streamable.start
+
+      expect(streamable).to have_received(:start_http)
+    end
+
+    it 'raises ConfigurationError for unknown transport' do
+      invalid = RailsAiBridge::Server.new(app, transport: :invalid)
+
+      expect { invalid.start }.to raise_error(RailsAiBridge::ConfigurationError, /Unknown transport: invalid/)
+    end
+  end
+
+  # ---- 2026-07-28 stateless lifecycle ----
+
+  describe '2026-07-28 stateless lifecycle support' do
+    it 'MCP::Server supports resources_read_handler for resource reads' do
+      expect(MCP::Server.instance_methods).to include(:resources_read_handler)
+    end
+
+    it 'MCP::Server supports resources_list_handler (added in 1.3.0)' do
+      expect(MCP::Server.instance_methods).to include(:resources_list_handler)
+    end
+
+    it 'MCP::Server supports resources_subscribe_handler' do
+      expect(MCP::Server.instance_methods).to include(:resources_subscribe_handler)
+    end
+
+    it 'MCP::Server supports resources_unsubscribe_handler' do
+      expect(MCP::Server.instance_methods).to include(:resources_unsubscribe_handler)
+    end
+
+    it 'MCP::Server supports server_context for handler state' do
+      expect(MCP::Server.instance_methods).to include(:server_context)
+    end
+
+    it 'MCP::Server supports request_state_security (SEP-2575)' do
+      expect(MCP::Server.instance_methods).to include(:request_state_security)
+    end
+
+    it 'StreamableHTTPTransport supports handle_request for stateless HTTP' do
+      expect(MCP::Server::Transports::StreamableHTTPTransport.instance_methods).to include(:handle_request)
+    end
+
+    it 'StreamableHTTPTransport supports serves_subscriptions_listen? (SEP-2575)' do
+      expect(MCP::Server::Transports::StreamableHTTPTransport.instance_methods)
+        .to include(:serves_subscriptions_listen?)
+    end
+  end
+
+  # ---- Stdio startup logging ----
+
+  describe 'stdio transport startup' do
+    it 'logs startup message to stderr' do
+      mcp_server = double('MCP::Server')
+      transport = double('transport', open: true)
+      allow(MCP::Server::Transports::StdioTransport).to receive(:new).and_return(transport)
+
+      expect { server.send(:start_stdio, mcp_server) }.to output(/MCP server started \(stdio transport\)/).to_stderr
+    end
+
+    it 'logs tool names to stderr' do
+      mcp_server = double('MCP::Server')
+      transport = double('transport', open: true)
+      allow(MCP::Server::Transports::StdioTransport).to receive(:new).and_return(transport)
+
+      expect { server.send(:start_stdio, mcp_server) }.to output(/Tools: rails_get_schema/).to_stderr
+    end
+
+    it 'opens the transport' do
+      mcp_server = double('MCP::Server')
+      transport = double('transport', open: true)
+      allow(MCP::Server::Transports::StdioTransport).to receive(:new).and_return(transport)
+
+      server.send(:start_stdio, mcp_server)
+
+      expect(transport).to have_received(:open)
+    end
+  end
+
+  # ---- HTTP transport auth warning ----
+
+  describe 'HTTP transport auth warning' do
+    let(:http_server) { RailsAiBridge::Server.new(app, transport: RailsAiBridge::Server::HTTP_TRANSPORT) }
+
+    before do
+      allow(http_server).to receive_messages(validate_http_server_in_production: nil,
+                                             create_http_transport: double, build_rack_app: double,
+                                             log_http_startup: nil, run_rack_server: nil)
+    end
+
+    it 'warns when HTTP MCP starts without authentication in non-production' do
+      allow(Rails.env).to receive(:production?).and_return(false)
+      allow(RailsAiBridge::Mcp::Authenticator).to receive(:any_configured?).and_return(false)
+
+      expect { http_server.send(:start_http, double) }
+        .to output(/WARNING: HTTP MCP is running without authentication/).to_stderr
+    end
+
+    it 'does not warn when auth is configured' do
+      allow(Rails.env).to receive(:production?).and_return(false)
+      allow(RailsAiBridge::Mcp::Authenticator).to receive(:any_configured?).and_return(true)
+
+      expect { http_server.send(:start_http, double) }.not_to output(/WARNING/).to_stderr
+    end
+
+    it 'does not warn in production' do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      allow(RailsAiBridge::Mcp::Authenticator).to receive(:any_configured?).and_return(false)
+
+      expect { http_server.send(:start_http, double) }.not_to output(/WARNING/).to_stderr
+    end
+  end
+
+  # ---- Tool count ----
+
+  describe 'built-in tool registration' do
+    it 'registers exactly 19 built-in tools' do
+      expect(RailsAiBridge::Server::TOOLS.length).to eq(19)
+    end
+
+    it 'all tool names are prefixed with rails_' do
+      allow(RailsAiBridge.configuration).to receive(:additional_tools).and_return([])
+
+      server.tool_classes.each do |tool|
+        expect(tool.tool_name).to start_with('rails_')
+      end
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/resource_lists_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/resource_lists_spec.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mcp'
+
+# Characterization specs that pin the MCP resource list and template
+# behavior. Resources are static data that AI clients read directly via
+# the resources/read and resources/list JSON-RPC methods.
+#
+# These specs pin:
+#   - MCP::Resource construction (uri, name, description, mime_type)
+#   - MCP::ResourceTemplate construction (uri_template, name, description, mime_type)
+#   - The full set of static resource URIs
+#   - Resource read handler registration
+#   - Resource read response format (JSON pretty-printed text)
+RSpec.describe 'MCP resource lists (SDK 1.3.0)' do
+  before do
+    allow(RailsAiBridge::ContextProvider).to receive(:fetch).and_return(
+      app_name: 'TestApp',
+      generated_at: Time.now.iso8601,
+      models: { 'User' => { name: 'User' } },
+      stimulus: { controllers: [{ name: 'hello' }] }
+    )
+    allow(RailsAiBridge::ContextProvider).to receive(:fetch_section).with(:models).and_return({ 'User' => { name: 'User' } })
+    allow(RailsAiBridge::ContextProvider).to receive(:fetch_section).with(:stimulus)
+                                                                    .and_return({ controllers: [{ name: 'hello' }] })
+    allow(RailsAiBridge.configuration).to receive(:additional_resources).and_return({})
+    stub_const('RailsAiBridge::ViewFileAnalyzer', Module.new do
+      def self.call(*_args)
+        { test: 'data' }
+      end
+    end)
+  end
+
+  # ---- Resource construction ----
+
+  describe 'MCP::Resource objects' do
+    it 'builds an array of MCP::Resource instances' do
+      resources = RailsAiBridge::Resources.build_resources
+
+      expect(resources).to be_an(Array)
+      expect(resources).to all(be_a(MCP::Resource))
+    end
+
+    it 'includes 13 static resources' do
+      resources = RailsAiBridge::Resources.build_resources
+
+      expect(resources.size).to eq(13)
+    end
+
+    it 'all resources have application/json mime type' do
+      resources = RailsAiBridge::Resources.build_resources
+
+      resources.each do |resource|
+        expect(resource.mime_type).to eq('application/json')
+      end
+    end
+
+    it 'all resources have a uri, name, and description' do
+      resources = RailsAiBridge::Resources.build_resources
+
+      resources.each do |resource|
+        expect(resource.uri).to be_present
+        expect(resource.name).to be_present
+        expect(resource.description).to be_present
+      end
+    end
+
+    it 'includes the bridge meta resource' do
+      resources = RailsAiBridge::Resources.build_resources
+      meta = resources.find { |r| r.uri == 'rails://bridge/meta' }
+
+      expect(meta).not_to be_nil
+      expect(meta.name).to eq('Bridge Metadata')
+    end
+
+    it 'includes the schema resource' do
+      resources = RailsAiBridge::Resources.build_resources
+
+      expect(resources.map(&:uri)).to include('rails://schema')
+    end
+
+    it 'includes the semantic analysis resource' do
+      resources = RailsAiBridge::Resources.build_resources
+
+      expect(resources.map(&:uri)).to include('rails://semantic/analysis')
+    end
+  end
+
+  # ---- Resource template construction ----
+
+  describe 'MCP::ResourceTemplate objects' do
+    it 'builds an array of MCP::ResourceTemplate instances' do
+      templates = RailsAiBridge::Resources.build_templates
+
+      expect(templates).to be_an(Array)
+      expect(templates).to all(be_a(MCP::ResourceTemplate))
+    end
+
+    it 'includes 4 resource templates' do
+      templates = RailsAiBridge::Resources.build_templates
+
+      expect(templates.size).to eq(4)
+    end
+
+    it 'includes model, view, stimulus, and context-provider templates' do
+      templates = RailsAiBridge::Resources.build_templates
+      uris = templates.map(&:uri_template)
+
+      expect(uris).to include('rails://models/{name}')
+      expect(uris).to include('rails://views/{path}')
+      expect(uris).to include('rails://stimulus/{name}')
+      expect(uris).to include('rails://context-providers/{name}')
+    end
+
+    it 'all templates have application/json mime type' do
+      templates = RailsAiBridge::Resources.build_templates
+
+      templates.each do |template|
+        expect(template.mime_type).to eq('application/json')
+      end
+    end
+  end
+
+  # ---- Resource read handler ----
+
+  describe 'resource read handler registration' do
+    it 'registers a resources_read_handler on the MCP server' do
+      mcp_server = double('MCP::Server')
+      allow(mcp_server).to receive(:resources_read_handler).and_yield(uri: 'rails://bridge/meta')
+
+      RailsAiBridge::Resources.register(mcp_server)
+
+      expect(mcp_server).to have_received(:resources_read_handler)
+    end
+  end
+
+  # ---- Resource read response format ----
+
+  describe 'resource read response format' do
+    it 'returns a JSON pretty-printed text payload' do
+      result = RailsAiBridge::Resources.send(:json_resource, 'rails://test', { key: 'value' })
+
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(1)
+      expect(result.first[:uri]).to eq('rails://test')
+      expect(result.first[:mime_type]).to eq('application/json')
+      expect(result.first[:text]).to include('"key": "value"')
+    end
+
+    it 'handles nil payload as null' do
+      result = RailsAiBridge::Resources.send(:json_resource, 'rails://test', nil)
+
+      expect(result.first[:text]).to eq('null')
+    end
+  end
+
+  # ---- Static resource URIs ----
+
+  describe 'static resource URI set' do
+    it 'includes all expected URIs' do
+      definitions = RailsAiBridge::Resources.resource_definitions
+      uris = definitions.keys
+
+      expected_uris = %w[
+        rails://bridge/meta
+        rails://schema
+        rails://routes
+        rails://conventions
+        rails://gems
+        rails://controllers
+        rails://config
+        rails://tests
+        rails://migrations
+        rails://engines
+        rails://views
+        rails://stimulus
+        rails://semantic/analysis
+      ]
+
+      expect(uris).to include(*expected_uris)
+    end
+  end
+
+  # ---- Templated resource resolution ----
+
+  describe 'templated resource resolution' do
+    it 'resolves model resources by name' do
+      payload = RailsAiBridge::Resources.send(:resolve_resource_payload, 'rails://models/User')
+
+      expect(payload).to eq({ name: 'User' })
+    end
+
+    it 'resolves URL-encoded model names' do
+      allow(RailsAiBridge::ContextProvider).to receive(:fetch_section).with(:models)
+                                                                      .and_return({ 'User::Profile' => { name: 'User::Profile' } })
+
+      payload = RailsAiBridge::Resources.send(:resolve_resource_payload, 'rails://models/User%3A%3AProfile')
+
+      expect(payload).to eq({ name: 'User::Profile' })
+    end
+
+    it 'returns an error hash for missing models' do
+      payload = RailsAiBridge::Resources.send(:resolve_resource_payload, 'rails://models/NonExistent')
+
+      expect(payload).to eq({ error: "Model 'NonExistent' not found" })
+    end
+
+    it 'resolves stimulus controllers case-insensitively' do
+      payload = RailsAiBridge::Resources.send(:resolve_resource_payload, 'rails://stimulus/HELLO')
+
+      expect(payload).to eq({ name: 'hello' })
+    end
+
+    it 'returns nil for unknown URIs' do
+      payload = RailsAiBridge::Resources.send(:resolve_resource_payload, 'rails://unknown')
+
+      expect(payload).to be_nil
+    end
+  end
+
+  # ---- Bridge metadata resource ----
+
+  describe 'bridge metadata resource' do
+    it 'includes bridge version and configuration' do
+      metadata = RailsAiBridge::Resources.send(:bridge_metadata)
+
+      expect(metadata[:bridge_version]).to eq(RailsAiBridge::VERSION)
+      expect(metadata[:server_name]).to eq(RailsAiBridge.configuration.server_name)
+      expect(metadata[:app_name]).to eq('TestApp')
+      expect(metadata[:available_resources]).to include('rails://bridge/meta')
+    end
+
+    it 'lists available tools sorted by name' do
+      metadata = RailsAiBridge::Resources.send(:bridge_metadata)
+
+      expect(metadata[:available_tools]).to be_an(Array)
+      expect(metadata[:available_tools]).to eq(metadata[:available_tools].sort)
+    end
+
+    it 'lists available resources sorted by URI' do
+      metadata = RailsAiBridge::Resources.send(:bridge_metadata)
+
+      expect(metadata[:available_resources]).to eq(metadata[:available_resources].sort)
+    end
+  end
+
+  # ---- Additional resources merge ----
+
+  describe 'additional resources merge' do
+    it 'merges user-defined resources with static resources' do
+      additional = { 'custom://test' => { name: 'Test', description: 'Custom', mime_type: 'application/json' } }
+      allow(RailsAiBridge.configuration).to receive(:additional_resources).and_return(additional)
+
+      definitions = RailsAiBridge::Resources.resource_definitions
+
+      expect(definitions).to include('custom://test')
+      expect(definitions).to include('rails://bridge/meta')
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/mcp/tool_annotations_spec.rb
+++ b/spec/lib/rails_ai_bridge/mcp/tool_annotations_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'mcp'
+
+# Characterization specs that pin the MCP tool annotation structure across
+# all 19 built-in tools. The MCP SDK's `annotations` DSL exposes hints that
+# clients use to understand tool safety characteristics.
+#
+# All rails-ai-bridge tools are read-only, non-destructive, idempotent, and
+# operate within the host app's world (open_world_hint: false). These specs
+# pin that contract so the MCP 1.3.0 upgrade doesn't silently change it.
+#
+# In MCP SDK 1.3.0, `annotations` returns an `MCP::Tool::Annotations` object
+# with accessor methods (not a Hash), and `input_schema` returns an
+# `MCP::Tool::InputSchema` object.
+RSpec.describe 'MCP tool annotations (SDK 1.3.0)' do
+  RailsAiBridge::Server::TOOLS.each do |tool_class|
+    describe "#{tool_class} annotations" do
+      it 'is a subclass of MCP::Tool' do
+        expect(tool_class.ancestors).to include(MCP::Tool)
+      end
+
+      it 'has a tool_name prefixed with rails_' do
+        expect(tool_class.tool_name).to start_with('rails_')
+      end
+
+      it 'has a non-empty description' do
+        expect(tool_class.description).to be_present
+      end
+
+      it 'has an input_schema object' do
+        expect(tool_class.input_schema).to respond_to(:to_h)
+      end
+
+      it 'declares read_only_hint: true' do
+        expect(tool_class.annotations.read_only_hint).to be(true)
+      end
+
+      it 'declares destructive_hint: false' do
+        expect(tool_class.annotations.destructive_hint).to be(false)
+      end
+
+      it 'declares idempotent_hint: true' do
+        expect(tool_class.annotations.idempotent_hint).to be(true)
+      end
+
+      it 'declares open_world_hint: false' do
+        expect(tool_class.annotations.open_world_hint).to be(false)
+      end
+    end
+  end
+
+  describe 'annotation keys present on every tool' do
+    it 'includes all four hint keys in to_h (camelCase per MCP spec)' do
+      RailsAiBridge::Server::TOOLS.each do |tool_class|
+        hash = tool_class.annotations.to_h
+        expect(hash).to include(:readOnlyHint, :destructiveHint, :idempotentHint, :openWorldHint)
+      end
+    end
+  end
+
+  describe 'MCP::Tool::Response construction' do
+    it 'builds a response from a text content array' do
+      response = MCP::Tool::Response.new([{ type: 'text', text: 'hello' }])
+
+      expect(response).to respond_to(:to_h)
+      expect(response).to respond_to(:content)
+      expect(response.content).to be_an(Array)
+    end
+
+    it 'serializes to a hash' do
+      response = MCP::Tool::Response.new([{ type: 'text', text: 'data' }])
+      hash = response.to_h
+
+      expect(hash).to be_a(Hash)
+    end
+
+    it 'is not an error response by default' do
+      response = MCP::Tool::Response.new([{ type: 'text', text: 'ok' }])
+
+      expect(response.error?).to be(false)
+    end
+  end
+
+  describe 'BaseTool.text_response truncation bounds' do
+    before do
+      allow(RailsAiBridge.configuration).to receive(:max_tool_response_chars).and_return(100)
+    end
+
+    it 'returns text as-is when under the limit' do
+      response = RailsAiBridge::Tools::BaseTool.text_response('short text')
+
+      expect(response.content.first[:text]).to eq('short text')
+    end
+
+    it 'truncates text and appends a suffix when over the limit' do
+      long_text = 'x' * 200
+      response = RailsAiBridge::Tools::BaseTool.text_response(long_text)
+
+      text = response.content.first[:text]
+      expect(text.length).to be <= 100
+      expect(text).to include('Response truncated')
+    end
+
+    it 'returns an MCP::Tool::Response instance' do
+      response = RailsAiBridge::Tools::BaseTool.text_response('text')
+
+      expect(response).to be_a(MCP::Tool::Response)
+    end
+  end
+
+  describe 'BaseTool.text_response without truncation limit' do
+    before do
+      allow(RailsAiBridge.configuration).to receive(:max_tool_response_chars).and_return(nil)
+    end
+
+    it 'returns full text without truncation' do
+      long_text = 'x' * 10_000
+      response = RailsAiBridge::Tools::BaseTool.text_response(long_text)
+
+      expect(response.content.first[:text]).to eq(long_text)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/rubydex_adapter/characterization_spec.rb
+++ b/spec/lib/rails_ai_bridge/rubydex_adapter/characterization_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Rubydex 0.3 graph API contract' do
   after do
     RailsAiBridge::RubydexAdapter.reset!
     RailsAiBridge::RubydexAdapter.reset_availability!
+    remove_stub_rubydex_module
   end
 
   # ---- Graph construction ----
@@ -447,6 +448,13 @@ RSpec.describe 'Rubydex 0.3 graph API contract' do
 
     Object.const_set(:Rubydex, Module.new)
     Rubydex.const_set(:Graph, Class.new)
+  end
+
+  def remove_stub_rubydex_module
+    return unless defined?(Rubydex)
+
+    Rubydex.send(:remove_const, :Graph) if Rubydex.const_defined?(:Graph, false)
+    Object.send(:remove_const, :Rubydex)
   end
 
   def stub_rubydex_graph(mock_graph)

--- a/spec/lib/rails_ai_bridge/rubydex_adapter/characterization_spec.rb
+++ b/spec/lib/rails_ai_bridge/rubydex_adapter/characterization_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'Rubydex 0.3 graph API contract' do
   after do
     RailsAiBridge::RubydexAdapter.reset!
     RailsAiBridge::RubydexAdapter.reset_availability!
-    remove_stub_rubydex_module
   end
 
   # ---- Graph construction ----
@@ -446,15 +445,9 @@ RSpec.describe 'Rubydex 0.3 graph API contract' do
   def stub_rubydex_module
     return if defined?(Rubydex)
 
-    Object.const_set(:Rubydex, Module.new)
-    Rubydex.const_set(:Graph, Class.new)
-  end
-
-  def remove_stub_rubydex_module
-    return unless defined?(Rubydex)
-
-    Rubydex.send(:remove_const, :Graph) if Rubydex.const_defined?(:Graph, false)
-    Object.send(:remove_const, :Rubydex)
+    rubydex_mod = Module.new
+    rubydex_mod.const_set(:Graph, Class.new)
+    stub_const('Rubydex', rubydex_mod)
   end
 
   def stub_rubydex_graph(mock_graph)

--- a/spec/lib/rails_ai_bridge/rubydex_adapter/characterization_spec.rb
+++ b/spec/lib/rails_ai_bridge/rubydex_adapter/characterization_spec.rb
@@ -1,0 +1,467 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Characterization specs that pin the contract between RubydexAdapter and
+# the Rubydex 0.3.0 graph API. When upgrading to Rubydex 0.4.0, these specs
+# will surface any breaking changes in the graph, declaration, definition,
+# location, or document object shapes.
+#
+# The 0.4.0 changelog notes these breaking changes:
+#   - "Make Config a proper object" (#965) — may change Graph initialization
+#   - "Return Cypher query results as graph objects" (#873) — may change
+#     query return types
+#   - "Extract declaration core" (#944) — may change declaration shape
+#   - "Extract NamespaceStore" (#945) — may change namespace resolution
+#
+# These specs use mock doubles to isolate the adapter from the real Rubydex
+# engine, pinning the *method names* and *return shapes* the adapter relies on.
+RSpec.describe 'Rubydex 0.3 graph API contract' do
+  let(:root) { '/tmp/test_root' }
+  let(:adapter) { RailsAiBridge::RubydexAdapter.new(root) }
+
+  before do
+    stub_rubydex_module
+  end
+
+  after do
+    RailsAiBridge::RubydexAdapter.reset!
+    RailsAiBridge::RubydexAdapter.reset_availability!
+  end
+
+  # ---- Graph construction ----
+
+  describe 'Rubydex::Graph initialization' do
+    it 'constructs Graph with no arguments' do
+      mock_graph = double('Graph')
+      stub_rubydex_graph(mock_graph)
+
+      adapter.index!
+
+      expect(Rubydex::Graph).to have_received(:new).with(no_args)
+    end
+  end
+
+  # ---- Indexing ----
+
+  describe 'graph indexing methods' do
+    it 'calls index_all with an array of file paths' do
+      mock_graph = double('Graph')
+      allow(mock_graph).to receive(:resolve)
+      allow(mock_graph).to receive(:index_all)
+      stub_rubydex_graph(mock_graph)
+
+      adapter.index!
+
+      expect(mock_graph).to have_received(:index_all).with(kind_of(Array))
+    end
+
+    it 'calls resolve with no arguments after indexing' do
+      mock_graph = double('Graph')
+      allow(mock_graph).to receive(:index_all)
+      allow(mock_graph).to receive(:resolve)
+      stub_rubydex_graph(mock_graph)
+
+      adapter.index!
+
+      expect(mock_graph).to have_received(:resolve).with(no_args)
+    end
+  end
+
+  # ---- Search ----
+
+  describe 'graph#search' do
+    it 'calls search with a string query and maps results via serializer' do
+      mock_graph = double('Graph')
+      decl = double('Decl', name: 'User', class: double(name: 'Rubydex::ClassDeclaration'))
+      allow(decl).to receive(:respond_to?).with(:unqualified_name).and_return(false)
+      allow(mock_graph).to receive(:search).with('User').and_return([decl])
+      index_adapter(adapter, mock_graph)
+
+      results = adapter.search('User')
+
+      expect(mock_graph).to have_received(:search).with('User')
+      expect(results).to eq([{ name: 'User', type: 'class' }])
+    end
+
+    it 'limits results to max_results' do
+      mock_graph = double('Graph')
+      decls = Array.new(30) do |i|
+        d = double("Decl#{i}", name: "Cls#{i}", class: double(name: 'Rubydex::ClassDeclaration'))
+        allow(d).to receive(:respond_to?).with(:unqualified_name).and_return(false)
+        d
+      end
+      allow(mock_graph).to receive(:search).with('Cls').and_return(decls)
+      index_adapter(adapter, mock_graph)
+
+      results = adapter.search('Cls', max_results: 5)
+
+      expect(results.length).to eq(5)
+    end
+  end
+
+  # ---- Declarations ----
+
+  describe 'graph#[] for declaration lookup' do
+    it 'retrieves a declaration by fully qualified name' do
+      mock_graph = double('Graph')
+      decl = double('Decl', name: 'Foo::Bar', class: double(name: 'Rubydex::ClassDeclaration'))
+      allow(decl).to receive(:respond_to?).with(:unqualified_name).and_return(false)
+      allow(decl).to receive(:respond_to?).with(:definitions).and_return(false)
+      allow(decl).to receive(:respond_to?).with(:ancestors).and_return(false)
+      allow(decl).to receive(:respond_to?).with(:descendants).and_return(false)
+      allow(decl).to receive(:respond_to?).with(:owner).and_return(false)
+      allow(mock_graph).to receive(:[]).with('Foo::Bar').and_return(decl)
+      index_adapter(adapter, mock_graph)
+
+      result = adapter.get_declaration('Foo::Bar')
+
+      expect(mock_graph).to have_received(:[]).with('Foo::Bar')
+      expect(result[:name]).to eq('Foo::Bar')
+    end
+
+    it 'returns nil when graph[] returns nil' do
+      mock_graph = double('Graph')
+      allow(mock_graph).to receive(:[]).with('Missing').and_return(nil)
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.get_declaration('Missing')).to be_nil
+    end
+  end
+
+  describe 'graph#declarations' do
+    it 'returns all declarations mapped through the serializer' do
+      mock_graph = double('Graph')
+      decl = double('Decl', name: 'User', class: double(name: 'Rubydex::ClassDeclaration'))
+      allow(decl).to receive(:respond_to?).with(:unqualified_name).and_return(false)
+      allow(mock_graph).to receive(:declarations).and_return([decl])
+      index_adapter(adapter, mock_graph)
+
+      results = adapter.all_declarations
+
+      expect(mock_graph).to have_received(:declarations)
+      expect(results).to eq([{ name: 'User', type: 'class' }])
+    end
+  end
+
+  # ---- Definitions / file declarations ----
+
+  describe 'graph#documents for file-scoped definitions' do
+    it 'finds a document by uri suffix and maps its definitions' do
+      mock_graph = double('Graph')
+      defn = double('Defn', name: 'save', class: double(name: 'Rubydex::MethodDeclaration'))
+      allow(defn).to receive(:respond_to?).with(:location).and_return(false)
+      allow(defn).to receive(:respond_to?).with(:comments).and_return(false)
+      allow(defn).to receive(:respond_to?).with(:deprecated?).and_return(false)
+      doc = double('Doc', uri: '/tmp/test_root/app/models/user.rb', definitions: [defn])
+      allow(mock_graph).to receive(:documents).and_return([doc])
+      index_adapter(adapter, mock_graph)
+
+      results = adapter.file_declarations('app/models/user.rb')
+
+      expect(results).to eq([{ name: 'save' }])
+    end
+
+    it 'matches document by exact uri' do
+      mock_graph = double('Graph')
+      doc = double('Doc', uri: '/exact/path.rb', definitions: [])
+      allow(mock_graph).to receive(:documents).and_return([doc])
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.file_declarations('/exact/path.rb')).to eq([])
+      expect(mock_graph).to have_received(:documents)
+    end
+  end
+
+  # ---- References ----
+
+  describe 'graph#constant_references' do
+    it 'maps constant references with name and location' do
+      mock_graph = double('Graph')
+      loc = double('Loc')
+      allow(loc).to receive(:respond_to?).with(:path).and_return(false)
+      allow(loc).to receive(:to_s).and_return('loc-string')
+      ref = double('Ref', name: 'API_KEY', location: loc)
+      allow(mock_graph).to receive(:constant_references).and_return([ref])
+      index_adapter(adapter, mock_graph)
+
+      results = adapter.constant_references
+
+      expect(results).to eq([{ name: 'API_KEY', location: 'loc-string' }])
+    end
+
+    it 'handles references without a name method by falling back to to_s' do
+      mock_graph = double('Graph')
+      ref = double('Ref')
+      allow(ref).to receive(:respond_to?).with(:name).and_return(false)
+      allow(ref).to receive(:to_s).and_return('CONSTANT_REF')
+      allow(ref).to receive(:respond_to?).with(:location).and_return(false)
+      allow(mock_graph).to receive(:constant_references).and_return([ref])
+      index_adapter(adapter, mock_graph)
+
+      results = adapter.constant_references
+
+      expect(results.first[:name]).to eq('CONSTANT_REF')
+    end
+  end
+
+  # ---- Locations ----
+
+  describe 'location object contract' do
+    it 'relativizes a location path against root' do
+      loc = double('Loc')
+      allow(loc).to receive(:respond_to?).with(:path).and_return(true)
+      allow(loc).to receive(:path).and_return('/tmp/test_root/app/models/user.rb')
+
+      result = RailsAiBridge::RubydexAdapter::Serializer.format_location(loc, root)
+
+      expect(result).to eq('app/models/user.rb')
+    end
+
+    it 'returns to_s when location has no path method' do
+      loc = double('Loc', to_s: 'raw-location')
+      allow(loc).to receive(:respond_to?).with(:path).and_return(false)
+
+      result = RailsAiBridge::RubydexAdapter::Serializer.format_location(loc, root)
+
+      expect(result).to eq('raw-location')
+    end
+
+    it 'returns to_s when location path is nil' do
+      loc = double('Loc', to_s: 'fallback-string')
+      allow(loc).to receive(:respond_to?).with(:path).and_return(true)
+      allow(loc).to receive(:path).and_return(nil)
+
+      result = RailsAiBridge::RubydexAdapter::Serializer.format_location(loc, root)
+
+      expect(result).to eq('fallback-string')
+    end
+  end
+
+  # ---- Ancestors / Descendants ----
+
+  describe 'declaration#ancestors' do
+    it 'maps ancestor names from declaration objects' do
+      mock_graph = double('Graph')
+      parent = double('Parent', name: 'ApplicationRecord')
+      decl = double('Decl', ancestors: [parent])
+      allow(decl).to receive(:respond_to?).with(:ancestors).and_return(true)
+      allow(mock_graph).to receive(:[]).with('User').and_return(decl)
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.ancestors('User')).to eq(['ApplicationRecord'])
+    end
+
+    it 'returns empty array when declaration does not respond to ancestors' do
+      mock_graph = double('Graph')
+      decl = double('Decl')
+      allow(decl).to receive(:respond_to?).with(:ancestors).and_return(false)
+      allow(mock_graph).to receive(:[]).with('User').and_return(decl)
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.ancestors('User')).to eq([])
+    end
+  end
+
+  describe 'declaration#descendants' do
+    it 'maps descendant names from declaration objects' do
+      mock_graph = double('Graph')
+      child = double('Child', name: 'Admin')
+      decl = double('Decl', descendants: [child])
+      allow(decl).to receive(:respond_to?).with(:descendants).and_return(true)
+      allow(mock_graph).to receive(:[]).with('User').and_return(decl)
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.descendants('User')).to eq(['Admin'])
+    end
+
+    it 'returns empty array when declaration does not respond to descendants' do
+      mock_graph = double('Graph')
+      decl = double('Decl')
+      allow(decl).to receive(:respond_to?).with(:descendants).and_return(false)
+      allow(mock_graph).to receive(:[]).with('User').and_return(decl)
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.descendants('User')).to eq([])
+    end
+  end
+
+  # ---- Declaration type detection ----
+
+  describe 'declaration type detection via class name' do
+    it 'detects class from Rubydex::ClassDeclaration' do
+      decl = double('Decl', class: double(name: 'Rubydex::ClassDeclaration'))
+      expect(RailsAiBridge::RubydexAdapter::Serializer.declaration_type(decl)).to eq('class')
+    end
+
+    it 'detects module from Rubydex::ModuleDeclaration' do
+      decl = double('Decl', class: double(name: 'Rubydex::ModuleDeclaration'))
+      expect(RailsAiBridge::RubydexAdapter::Serializer.declaration_type(decl)).to eq('module')
+    end
+
+    it 'detects method from Rubydex::MethodDeclaration' do
+      decl = double('Decl', class: double(name: 'Rubydex::MethodDeclaration'))
+      expect(RailsAiBridge::RubydexAdapter::Serializer.declaration_type(decl)).to eq('method')
+    end
+
+    it 'detects constant from Rubydex::ConstantDeclaration' do
+      decl = double('Decl', class: double(name: 'Rubydex::ConstantDeclaration'))
+      expect(RailsAiBridge::RubydexAdapter::Serializer.declaration_type(decl)).to eq('constant')
+    end
+
+    it 'falls back to declaration for unknown types' do
+      decl = double('Decl', class: double(name: 'Rubydex::UnknownType'))
+      expect(RailsAiBridge::RubydexAdapter::Serializer.declaration_type(decl)).to eq('declaration')
+    end
+  end
+
+  # ---- Codebase stats ----
+
+  describe 'codebase_stats graph method surface' do
+    it 'calls declarations, documents, constant_references, and method_references' do
+      mock_graph = double('Graph')
+      mock_counter = instance_double(RailsAiBridge::RubydexAdapter::MethodCounter)
+      allow(mock_counter).to receive(:count).and_return(10)
+      allow(mock_graph).to receive_messages(
+        declarations: [],
+        documents: [],
+        constant_references: [],
+        method_references: []
+      )
+      index_adapter(adapter, mock_graph)
+      adapter.instance_variable_set(:@method_counter, mock_counter)
+
+      stats = adapter.codebase_stats
+
+      expect(mock_graph).to have_received(:declarations)
+      expect(mock_graph).to have_received(:documents)
+      expect(mock_graph).to have_received(:constant_references)
+      expect(mock_graph).to have_received(:method_references)
+      expect(stats).to include(
+        total_files: 0,
+        total_declarations: 0,
+        total_classes: 0,
+        total_modules: 0,
+        total_methods: 10,
+        total_constant_references: 0,
+        total_method_references: 0
+      )
+    end
+
+    it 'returns 0 for method_references when graph does not respond to it' do
+      mock_graph = double('Graph')
+      mock_counter = instance_double(RailsAiBridge::RubydexAdapter::MethodCounter)
+      allow(mock_counter).to receive(:count).and_return(0)
+      allow(mock_graph).to receive_messages(declarations: [], documents: [])
+      allow(mock_graph).to receive_messages(constant_references: [], respond_to?: true)
+      allow(mock_graph).to receive(:respond_to?).with(:method_references).and_return(false)
+      index_adapter(adapter, mock_graph)
+      adapter.instance_variable_set(:@method_counter, mock_counter)
+
+      stats = adapter.codebase_stats
+
+      expect(stats[:total_method_references]).to eq(0)
+    end
+  end
+
+  # ---- Graceful failure ----
+
+  describe 'graceful failure when not indexed' do
+    before do
+      allow(RailsAiBridge::RubydexAdapter).to receive(:available?).and_return(false)
+    end
+
+    it 'returns empty array for search' do
+      expect(adapter.search('User')).to eq([])
+    end
+
+    it 'returns nil for get_declaration' do
+      expect(adapter.get_declaration('User')).to be_nil
+    end
+
+    it 'returns empty array for all_declarations' do
+      expect(adapter.all_declarations).to eq([])
+    end
+
+    it 'returns empty array for file_declarations' do
+      expect(adapter.file_declarations('app/models/user.rb')).to eq([])
+    end
+
+    it 'returns empty array for descendants' do
+      expect(adapter.descendants('User')).to eq([])
+    end
+
+    it 'returns empty array for ancestors' do
+      expect(adapter.ancestors('User')).to eq([])
+    end
+
+    it 'returns empty array for constant_references' do
+      expect(adapter.constant_references).to eq([])
+    end
+
+    it 'returns empty hash for codebase_stats' do
+      expect(adapter.codebase_stats).to eq({})
+    end
+  end
+
+  describe 'graceful failure when graph raises' do
+    it 'returns empty array when search raises' do
+      mock_graph = double('Graph')
+      allow(mock_graph).to receive(:search).and_raise(StandardError, 'boom')
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.search('User')).to eq([])
+    end
+
+    it 'returns nil when get_declaration raises' do
+      mock_graph = double('Graph')
+      allow(mock_graph).to receive(:[]).and_raise(StandardError, 'boom')
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.get_declaration('User')).to be_nil
+    end
+
+    it 'returns empty array when all_declarations raises' do
+      mock_graph = double('Graph')
+      allow(mock_graph).to receive(:declarations).and_raise(StandardError, 'boom')
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.all_declarations).to eq([])
+    end
+
+    it 'returns empty hash when codebase_stats raises' do
+      mock_graph = double('Graph')
+      allow(mock_graph).to receive(:declarations).and_raise(StandardError, 'boom')
+      index_adapter(adapter, mock_graph)
+
+      expect(adapter.codebase_stats).to eq({})
+    end
+  end
+
+  # ---- Helpers ----
+
+  private
+
+  def stub_rubydex_module
+    return if defined?(Rubydex)
+
+    Object.const_set(:Rubydex, Module.new)
+    Rubydex.const_set(:Graph, Class.new)
+  end
+
+  def stub_rubydex_graph(mock_graph)
+    allow(RailsAiBridge::RubydexAdapter).to receive(:available?).and_return(true)
+    allow(mock_graph).to receive(:empty?).and_return(false)
+    allow(mock_graph).to receive(:index_all)
+    allow(mock_graph).to receive(:resolve)
+    allow(Rubydex::Graph).to receive(:new).and_return(mock_graph)
+    allow(RailsAiBridge::RubydexAdapter::Indexer).to receive(:source_files).and_return([])
+    allow(adapter).to receive(:sanitize_index_path).and_return(nil)
+  end
+
+  def index_adapter(adapter, mock_graph)
+    allow(mock_graph).to receive(:empty?).and_return(false)
+    adapter.instance_variable_set(:@indexed, true)
+    adapter.instance_variable_set(:@graph, mock_graph)
+  end
+end

--- a/spec/lib/rails_ai_bridge/tools/get_context_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_context_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 # Composite tool fixtures need model/schema/controller/route/test snapshots.
-# rubocop:disable RSpec/MultipleMemoizedHelpers
+# rubocop:disable-next RSpec/MultipleMemoizedHelpers
 RSpec.describe RailsAiBridge::Tools::GetContext do
   let(:response) { described_class.call(**params) }
   let(:content) { response.content.first[:text] }
@@ -494,4 +494,3 @@ RSpec.describe RailsAiBridge::Tools::GetContext do
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
## Summary
- Add 383 characterization specs pinning current Rubydex adapter and MCP server behavior before upgrading dependencies
- Rubydex specs (467 lines): indexing, search, declarations, definitions, references, locations, ancestors/descendants, incremental rebuilds, persistence, graceful failure
- MCP specs (943 lines): error responses, protocol characterization, resource lists, tool annotations
- UPGRADING.md (160 lines): detailed migration notes for Rubydex 0.4 and MCP 1.3

**Age gate:** Rubydex 0.4.0 published Aug 20, MCP 1.3 published Aug 21. Both mergeable Aug 28-29 after 7-day age gate.

These specs are the safety net — they pin current behavior so the actual dependency upgrade PRs can verify no regressions.

#### Test plan
- [x] `bundle exec rspec` — 3451 examples, 0 failures
- [x] `bundle exec rubocop --parallel` — 474 files, 0 offenses
- [x] No production code changed (spec-only + UPGRADING.md)

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guidance for Rubydex 0.4.0 and MCP SDK 1.3.0, including breaking changes, migration steps, enhancements, and troubleshooting checks.

* **Tests**
  * Added coverage for MCP protocol behavior, authentication, authorization, rate limiting, error handling, transports, resource handling, tool metadata, and response limits.
  * Added compatibility coverage for Rubydex graph analysis, search, references, declarations, and codebase statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->