### PR TITLE
feat: introduce AppScope runtime seam for scoped app resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **AppScope runtime seam** — `RailsAiBridge::AppScope` provides a thread-local application scope (`with_app(app) { ... }` / `current_app`) so that CLI, tests, and standalone processes can scope a different app without hardcoding `Rails.application`. Defaults to `Rails.application` for backward compatibility. All MCP tools, `ContextProvider`, `Resources`, `CacheWarmer`, `Doctor`, `Watcher`, serializers, and the public API (`introspect`, `generate_context`, `start_mcp_server`) now resolve the app through `AppScope.current_app`.
+- **Watcher nil-app guard** — `Watcher#initialize` now raises `ArgumentError` when no application is available instead of storing `nil` and failing later with `NoMethodError` on `app.root`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **AppScope runtime seam** — `RailsAiBridge::AppScope` provides a thread-local application scope (`with_app(app) { ... }` / `current_app`) so that CLI, tests, and standalone processes can scope a different app without hardcoding `Rails.application`. Defaults to `Rails.application` for backward compatibility. All MCP tools, `ContextProvider`, `Resources`, `CacheWarmer`, `Doctor`, `Watcher`, serializers, and the public API (`introspect`, `generate_context`, `start_mcp_server`) now resolve the app through `AppScope.current_app`.
+
 ### Changed
 
 - **RuboCop Performance plugin enabled** — `rubocop-performance` (~> 1.27) added as an explicit development dependency and loaded as a RuboCop plugin. 77 offenses autocorrected (TimesMap, StringInclude, MapCompact, DeleteSuffix/DeletePrefix, StringReplacement, RedundantBlockCall). 4 CollectionLiteralInLoop offenses fixed by extracting immutable literals to constants. `rubocop-rails` constraint tightened to `~> 2.37`.

--- a/lib/rails_ai_bridge.rb
+++ b/lib/rails_ai_bridge.rb
@@ -42,7 +42,7 @@ module RailsAiBridge
     # @param only [Array<Symbol>, nil] optional subset of introspector keys to run
     # @return [Hash] introspection payload with enabled sections
     def introspect(app = nil, only: nil)
-      app ||= Rails.application
+      app ||= AppScope.current_app
       Introspector.new(app).call(only: only)
     end
 
@@ -62,7 +62,7 @@ module RailsAiBridge
     def generate_context(app = nil, **options)
       validate_generate_context_options!(options)
 
-      app ||= Rails.application
+      app ||= AppScope.current_app
       build_context_serializer(introspect(app), options).call
     end
 
@@ -73,7 +73,7 @@ module RailsAiBridge
     # @return [void]
     # @raise [RailsAiBridge::ConfigurationError] when HTTP transport is unsafe in production
     def start_mcp_server(app = nil, transport: :stdio)
-      app ||= Rails.application
+      app ||= AppScope.current_app
       Server.new(app, transport: transport).start
     end
 

--- a/lib/rails_ai_bridge.rb
+++ b/lib/rails_ai_bridge.rb
@@ -63,18 +63,22 @@ module RailsAiBridge
       validate_generate_context_options!(options)
 
       app ||= AppScope.current_app
-      build_context_serializer(introspect(app), options).call
+      AppScope.with_app(app) do
+        build_context_serializer(introspect(app), options).call
+      end
     end
 
     # Start the MCP server programmatically
     #
-    # @param app [Rails::Application, nil] app to serve, defaults to Rails.application
+    # @param app [Rails::Application, nil] app to serve, defaults to {AppScope.current_app}
     # @param transport [Symbol] transport type (:stdio or :http)
     # @return [void]
     # @raise [RailsAiBridge::ConfigurationError] when HTTP transport is unsafe in production
     def start_mcp_server(app = nil, transport: :stdio)
       app ||= AppScope.current_app
-      Server.new(app, transport: transport).start
+      AppScope.with_app(app) do
+        Server.new(app, transport: transport).start
+      end
     end
 
     # Raises {ConfigurationError} if +auto_mount+ is enabled in production without explicit opt-in and token.

--- a/lib/rails_ai_bridge/app_scope.rb
+++ b/lib/rails_ai_bridge/app_scope.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module RailsAiBridge
+  # Thread-local application scope for the runtime seam.
+  #
+  # Provides a scoped +with_app(app)+ block so that server tool calls, CLI
+  # commands, resources, and tests can share a single app reference without
+  # hardcoding +Rails.application+ everywhere. The default falls back to
+  # +Rails.application+ for backward compatibility with Rails-hosted usage.
+  #
+  # @example Scoped execution
+  #   RailsAiBridge::AppScope.with_app(my_app) do
+  #     RailsAiBridge::AppScope.current_app # => my_app
+  #   end
+  #   RailsAiBridge::AppScope.current_app   # => Rails.application
+  #
+  module AppScope
+    APP_KEY = :rails_ai_bridge_current_app
+
+    class << self
+      # Executes a block with +app+ as the current application for the calling
+      # thread. Nested scopes restore the prior app on exit, including when the
+      # block raises.
+      #
+      # @param app [Object] the application to scope
+      # @yield block to execute within the app scope
+      # @return [Object] the block result
+      # :reek:DuplicateMethodCall -- Thread.current access is the established pattern (see Registry.with_request_resolver)
+      def with_app(app)
+        previous = Thread.current[APP_KEY]
+        Thread.current[APP_KEY] = app
+        yield
+      ensure
+        Thread.current[APP_KEY] = previous
+      end
+
+      # Returns the current application for the calling thread, defaulting to
+      # +Rails.application+ when no scope is active.
+      #
+      # @return [Object, nil] the current Rails application or scoped app
+      def current_app
+        Thread.current[APP_KEY] || (defined?(Rails) ? Rails.application : nil)
+      end
+
+      # Clears the app scope for the calling thread. Primarily for test cleanup.
+      #
+      # @return [void]
+      def clear_app
+        Thread.current[APP_KEY] = nil
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/assistant_formats_preference.rb
+++ b/lib/rails_ai_bridge/assistant_formats_preference.rb
@@ -27,9 +27,10 @@ module RailsAiBridge
       #
       # @return [Pathname, nil] +nil+ when +Rails.application+ is unavailable
       def config_path
-        return nil unless defined?(Rails) && Rails.application
+        app = AppScope.current_app
+        return nil unless app
 
-        Rails.root.join(RELATIVE_PATH)
+        app.root.join(RELATIVE_PATH)
       end
 
       # Returns the subset of formats requested for the default +rails ai:bridge+ task.

--- a/lib/rails_ai_bridge/cache_warmer.rb
+++ b/lib/rails_ai_bridge/cache_warmer.rb
@@ -13,7 +13,8 @@ module RailsAiBridge
       #
       # @param app [Rails::Application]
       # @return [void]
-      def warm(app = Rails.application)
+      def warm(app = nil)
+        app ||= AppScope.current_app
         ContextProvider.fetch(app)
       rescue StandardError => error
         log_warning("cache warming failed: #{error.message}")
@@ -24,7 +25,8 @@ module RailsAiBridge
       # @param sections [Array<Symbol>] introspector keys to warm
       # @param app [Rails::Application]
       # @return [void]
-      def warm_sections(sections, app = Rails.application)
+      def warm_sections(sections, app = nil)
+        app ||= AppScope.current_app
         sections.each do |section|
           ContextProvider.fetch_section(section, app)
         rescue StandardError => error

--- a/lib/rails_ai_bridge/context_provider.rb
+++ b/lib/rails_ai_bridge/context_provider.rb
@@ -13,7 +13,8 @@ module RailsAiBridge
       #
       # @param app [Rails::Application] application to introspect
       # @return [Hash] introspection payload
-      def fetch(app = Rails.application)
+      def fetch(app = nil)
+        app ||= AppScope.current_app
         mutex.synchronize do
           cached = cache[cache_key(app)]
           return rebuild(app) unless cached[:full]
@@ -31,7 +32,8 @@ module RailsAiBridge
       # @param section [Symbol] introspector key to retrieve
       # @param app [Rails::Application] application to introspect
       # @return [Object, nil] requested section payload
-      def fetch_section(section, app = Rails.application)
+      def fetch_section(section, app = nil)
+        app ||= AppScope.current_app
         mutex.synchronize do
           key = cache_key(app)
           cached = cache[key]

--- a/lib/rails_ai_bridge/context_provider.rb
+++ b/lib/rails_ai_bridge/context_provider.rb
@@ -111,7 +111,8 @@ module RailsAiBridge
       end
 
       def cache_key(app)
-        "#{app.class.name}:#{defined?(Rails) && Rails.respond_to?(:env) ? Rails.env : 'development'}"
+        root = app.respond_to?(:root) ? app.root.to_s : ''
+        "#{app.class.name}:#{root}:#{defined?(Rails) && Rails.respond_to?(:env) ? Rails.env : 'development'}"
       end
 
       def metadata_key?(section_name)

--- a/lib/rails_ai_bridge/doctor.rb
+++ b/lib/rails_ai_bridge/doctor.rb
@@ -31,7 +31,7 @@ module RailsAiBridge
     # @param app [Rails::Application, nil] application to inspect
     # @return [void]
     def initialize(app = nil)
-      @app = app || Rails.application
+      @app = app || AppScope.current_app
     end
 
     # Runs all diagnostic checks and computes a readiness score.

--- a/lib/rails_ai_bridge/introspectors/controller_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/controller_introspector.rb
@@ -36,7 +36,7 @@ module RailsAiBridge
       private
 
       def eager_load_controllers!
-        Rails.application.eager_load! unless Rails.application.config.eager_load
+        @app.eager_load! unless @app.config.eager_load
       rescue StandardError
         nil
       end

--- a/lib/rails_ai_bridge/introspectors/model_introspector.rb
+++ b/lib/rails_ai_bridge/introspectors/model_introspector.rb
@@ -50,7 +50,7 @@ module RailsAiBridge
       private
 
       def eager_load_models!
-        Rails.application.eager_load! unless Rails.application.config.eager_load
+        @app.eager_load! unless @app.config.eager_load
       rescue StandardError
         # In some environments (CI, Claude Code) eager_load may partially fail
         nil

--- a/lib/rails_ai_bridge/middleware.rb
+++ b/lib/rails_ai_bridge/middleware.rb
@@ -26,6 +26,11 @@ module RailsAiBridge
 
     private
 
+    # The transport is memoized because it is expensive to create and bound to
+    # the process-wide application. In Rails-hosted mode, AppScope.current_app
+    # always resolves to Rails.application. In standalone mode, the CLI sets
+    # the scope before starting the server, so the first resolution is correct
+    # for the process lifetime.
     def transport
       @mutex.synchronize do
         @transport ||= begin

--- a/lib/rails_ai_bridge/middleware.rb
+++ b/lib/rails_ai_bridge/middleware.rb
@@ -29,7 +29,7 @@ module RailsAiBridge
     def transport
       @mutex.synchronize do
         @transport ||= begin
-          server = Server.new(Rails.application, transport: :http).build
+          server = Server.new(AppScope.current_app, transport: :http).build
           MCP::Server::Transports::StreamableHTTPTransport.new(server)
         end
       end

--- a/lib/rails_ai_bridge/middleware.rb
+++ b/lib/rails_ai_bridge/middleware.rb
@@ -9,7 +9,7 @@ module RailsAiBridge
   class Middleware
     def initialize(app)
       @app = app
-      @mcp_transport = nil
+      @transport = nil
       @mutex = Mutex.new
     end
 

--- a/lib/rails_ai_bridge/resources.rb
+++ b/lib/rails_ai_bridge/resources.rb
@@ -318,8 +318,12 @@ module RailsAiBridge
       # Handles security errors and missing files gracefully.
       # @param path [String] relative path to view file
       # @return [Hash] view analysis or error hash
+      # :reek:TooManyStatements -- nil guard adds one statement over threshold
       def read_view_resource(path)
-        ViewFileAnalyzer.call(root: Rails.root, app: Rails.application, relative_path: path)
+        app = AppScope.current_app
+        return { error: 'No Rails application available' } unless app
+
+        ViewFileAnalyzer.call(root: app.root, app: app, relative_path: path)
       rescue SecurityError => error
         { error: error.message }
       rescue Errno::ENOENT

--- a/lib/rails_ai_bridge/serializers/context_file_serializer.rb
+++ b/lib/rails_ai_bridge/serializers/context_file_serializer.rb
@@ -51,12 +51,12 @@ module RailsAiBridge
       def call
         formats = format == :all ? FORMAT_MAP.keys : Array(format)
         # archspec:disable-next-line dependencies.forbid -- FP: RailsAiBridge is the reopened gem namespace; .configuration accessor is not a cross-component dependency
-        output_dir = RailsAiBridge.configuration.output_dir_for(Rails.application)
+        output_dir = RailsAiBridge.configuration.output_dir_for(AppScope.current_app)
         written = []
         skipped = []
 
         timestamp_now = Time.now.utc.iso8601
-        fingerprint = Fingerprinter.source_fingerprint(Rails.application)
+        fingerprint = Fingerprinter.source_fingerprint(AppScope.current_app)
 
         formats.each do |fmt|
           process_format(fmt, output_dir, timestamp_now, fingerprint, written, skipped)

--- a/lib/rails_ai_bridge/serializers/shared_assistant_guidance.rb
+++ b/lib/rails_ai_bridge/serializers/shared_assistant_guidance.rb
@@ -147,9 +147,10 @@ module RailsAiBridge
 
       # @return [String, nil] absolute path to overrides file if Rails app is available
       def resolved_assistant_overrides_path
-        return nil unless defined?(Rails) && Rails.application
+        app = AppScope.current_app
+        return nil unless app
 
-        base = Rails.application.root.to_s
+        base = app.root.to_s
         # archspec:disable-next-line dependencies.forbid -- FP: RailsAiBridge is the reopened gem namespace; .configuration accessor is not a cross-component dependency
         cfg = RailsAiBridge.configuration
         raw = cfg.assistant_overrides_path

--- a/lib/rails_ai_bridge/tools/base_tool.rb
+++ b/lib/rails_ai_bridge/tools/base_tool.rb
@@ -9,9 +9,11 @@ module RailsAiBridge
     # annotations, and protocol compliance for free.
     class BaseTool < MCP::Tool
       class << self
-        # @return [Rails::Application] the host Rails application
+        # @return [Rails::Application] the host Rails application, resolved
+        #   through {AppScope} so CLI, tests, and standalone processes can
+        #   scope a different app without global leakage.
         def rails_app
-          Rails.application
+          AppScope.current_app
         end
 
         # @return [RailsAiBridge::Configuration] gem configuration

--- a/lib/rails_ai_bridge/tools/list_registry.rb
+++ b/lib/rails_ai_bridge/tools/list_registry.rb
@@ -120,8 +120,8 @@ module RailsAiBridge
         # @return [String] markdown string
         def format
           case @type
-          when 'skills'  then format_catalog(@resolver.list_skills,   noun: 'Skill')
-          when 'agents'  then format_catalog(@resolver.list_agents,   noun: 'Agent')
+          when 'skills'  then format_catalog(@resolver.list_skills, noun: 'Skill')
+          when 'agents'  then format_catalog(@resolver.list_agents, noun: 'Agent')
           when 'packs'   then format_packs(@resolver.active_packs)
           end
         end

--- a/lib/rails_ai_bridge/watcher.rb
+++ b/lib/rails_ai_bridge/watcher.rb
@@ -15,7 +15,7 @@ module RailsAiBridge
 
     # @param app [Rails::Application, nil] defaults to +Rails.application+
     def initialize(app = nil)
-      @app = app || Rails.application
+      @app = app || AppScope.current_app
       @regenerator = BridgeRegenerator.new(@app)
     end
 

--- a/lib/rails_ai_bridge/watcher.rb
+++ b/lib/rails_ai_bridge/watcher.rb
@@ -14,8 +14,11 @@ module RailsAiBridge
     attr_reader :app
 
     # @param app [Rails::Application, nil] defaults to {AppScope.current_app}
+    # @raise [ArgumentError] when no application is available
     def initialize(app = nil)
       @app = app || AppScope.current_app
+      raise ArgumentError, 'No Rails application available — pass an app or set AppScope' unless @app
+
       @regenerator = BridgeRegenerator.new(@app)
     end
 

--- a/lib/rails_ai_bridge/watcher.rb
+++ b/lib/rails_ai_bridge/watcher.rb
@@ -13,7 +13,7 @@ module RailsAiBridge
     # @return [Rails::Application] host application
     attr_reader :app
 
-    # @param app [Rails::Application, nil] defaults to +Rails.application+
+    # @param app [Rails::Application, nil] defaults to {AppScope.current_app}
     def initialize(app = nil)
       @app = app || AppScope.current_app
       @regenerator = BridgeRegenerator.new(@app)

--- a/spec/lib/rails_ai_bridge/app_scope_integration_spec.rb
+++ b/spec/lib/rails_ai_bridge/app_scope_integration_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe 'AppScope consumer integration' do
       end
       expect(watcher.app).to eq(fake_app)
     end
+
+    it 'raises ArgumentError when no app is available' do
+      allow(RailsAiBridge::AppScope).to receive(:current_app).and_return(nil)
+
+      expect { RailsAiBridge::Watcher.new }.to raise_error(ArgumentError, /No Rails application available/)
+    end
   end
 
   describe 'RailsAiBridge.introspect' do
@@ -94,6 +100,19 @@ RSpec.describe 'AppScope consumer integration' do
       RailsAiBridge::AppScope.with_app(fake_app) do
         RailsAiBridge.introspect
       end
+    end
+  end
+
+  describe 'RailsAiBridge.generate_context' do
+    it 'wraps serialization in AppScope.with_app so serializers see the same app' do
+      introspector = instance_double(RailsAiBridge::Introspector, call: {})
+      allow(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
+      serializer = instance_double(RailsAiBridge::Serializers::ContextFileSerializer, call: { written: [], skipped: [] })
+      allow(RailsAiBridge::Serializers::ContextFileSerializer).to receive(:new).and_return(serializer)
+
+      expect(RailsAiBridge::AppScope).to receive(:with_app).with(fake_app).and_call_original
+
+      RailsAiBridge.generate_context(fake_app)
     end
   end
 

--- a/spec/lib/rails_ai_bridge/app_scope_integration_spec.rb
+++ b/spec/lib/rails_ai_bridge/app_scope_integration_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'AppScope consumer integration' do
   describe 'ContextProvider.fetch' do
     it 'passes the scoped app to Introspector' do
       introspector = instance_double(RailsAiBridge::Introspector, call: {})
-      allow(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
+      expect(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
 
       RailsAiBridge::AppScope.with_app(fake_app) do
         RailsAiBridge::ContextProvider.reset!
@@ -45,7 +45,7 @@ RSpec.describe 'AppScope consumer integration' do
   describe 'ContextProvider.fetch_section' do
     it 'passes the scoped app to Introspector' do
       introspector = instance_double(RailsAiBridge::Introspector, call: { models: {} })
-      allow(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
+      expect(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
       allow(introspector).to receive(:call).with(only: [:models]).and_return({ models: {} })
 
       RailsAiBridge::AppScope.with_app(fake_app) do
@@ -89,7 +89,7 @@ RSpec.describe 'AppScope consumer integration' do
   describe 'RailsAiBridge.introspect' do
     it 'passes the scoped app to Introspector' do
       introspector = instance_double(RailsAiBridge::Introspector, call: {})
-      allow(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
+      expect(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
 
       RailsAiBridge::AppScope.with_app(fake_app) do
         RailsAiBridge.introspect

--- a/spec/lib/rails_ai_bridge/app_scope_integration_spec.rb
+++ b/spec/lib/rails_ai_bridge/app_scope_integration_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Consumer-level specs proving that key subsystems resolve the app through
+# AppScope.current_app instead of hardcoding Rails.application.
+RSpec.describe 'AppScope consumer integration' do
+  let(:fake_app) do
+    instance_double(Rails::Application,
+                    root: Pathname.new(Dir.mktmpdir('app-scope-consumer-')),
+                    config: double('Rails::Configuration', eager_load: true),
+                    eager_load!: nil,
+                    paths: {})
+  end
+
+  after do
+    FileUtils.remove_entry(fake_app.root) if fake_app.root&.exist?
+    RailsAiBridge::AppScope.clear_app
+  end
+
+  describe 'BaseTool.rails_app' do
+    it 'returns the scoped app inside with_app' do
+      RailsAiBridge::AppScope.with_app(fake_app) do
+        expect(RailsAiBridge::Tools::BaseTool.rails_app).to eq(fake_app)
+      end
+    end
+
+    it 'falls back to Rails.application outside with_app' do
+      expect(RailsAiBridge::Tools::BaseTool.rails_app).to eq(Rails.application)
+    end
+  end
+
+  describe 'ContextProvider.fetch' do
+    it 'passes the scoped app to Introspector' do
+      introspector = instance_double(RailsAiBridge::Introspector, call: {})
+      allow(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
+
+      RailsAiBridge::AppScope.with_app(fake_app) do
+        RailsAiBridge::ContextProvider.reset!
+        RailsAiBridge::ContextProvider.fetch
+      end
+    end
+  end
+
+  describe 'ContextProvider.fetch_section' do
+    it 'passes the scoped app to Introspector' do
+      introspector = instance_double(RailsAiBridge::Introspector, call: { models: {} })
+      allow(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
+      allow(introspector).to receive(:call).with(only: [:models]).and_return({ models: {} })
+
+      RailsAiBridge::AppScope.with_app(fake_app) do
+        RailsAiBridge::ContextProvider.reset!
+        RailsAiBridge::ContextProvider.fetch_section(:models)
+      end
+    end
+  end
+
+  describe 'CacheWarmer.warm' do
+    it 'uses the scoped app when no explicit app is passed' do
+      expect(RailsAiBridge::ContextProvider).to receive(:fetch).with(fake_app)
+      RailsAiBridge::AppScope.with_app(fake_app) do
+        RailsAiBridge::CacheWarmer.warm
+      end
+    end
+  end
+
+  describe 'Doctor#initialize' do
+    it 'uses the scoped app when no explicit app is passed' do
+      doctor = nil
+      RailsAiBridge::AppScope.with_app(fake_app) do
+        doctor = RailsAiBridge::Doctor.new
+      end
+      expect(doctor.app).to eq(fake_app)
+    end
+  end
+
+  describe 'Watcher#initialize' do
+    it 'uses the scoped app when no explicit app is passed' do
+      stub_const('Listen', Module.new) unless defined?(Listen)
+
+      watcher = nil
+      RailsAiBridge::AppScope.with_app(fake_app) do
+        watcher = RailsAiBridge::Watcher.new
+      end
+      expect(watcher.app).to eq(fake_app)
+    end
+  end
+
+  describe 'RailsAiBridge.introspect' do
+    it 'passes the scoped app to Introspector' do
+      introspector = instance_double(RailsAiBridge::Introspector, call: {})
+      allow(RailsAiBridge::Introspector).to receive(:new).with(fake_app).and_return(introspector)
+
+      RailsAiBridge::AppScope.with_app(fake_app) do
+        RailsAiBridge.introspect
+      end
+    end
+  end
+
+  describe 'Resources.read_view_resource' do
+    it 'returns error hash when app is nil' do
+      # Temporarily clear all app resolution
+      allow(RailsAiBridge::AppScope).to receive(:current_app).and_return(nil)
+      result = RailsAiBridge::Resources.send(:read_view_resource, 'users/index.html.erb')
+      expect(result).to eq({ error: 'No Rails application available' })
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/app_scope_spec.rb
+++ b/spec/lib/rails_ai_bridge/app_scope_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::AppScope do
+  let(:fake_app) { instance_double(Rails::Application) }
+  let(:other_app) { instance_double(Rails::Application) }
+
+  after do
+    described_class.clear_app
+  end
+
+  describe '.current_app' do
+    it 'defaults to Rails.application when no scope is set' do
+      expect(described_class.current_app).to eq(Rails.application)
+    end
+
+    it 'returns the scoped app when inside with_app' do
+      described_class.with_app(fake_app) do
+        expect(described_class.current_app).to eq(fake_app)
+      end
+    end
+
+    it 'returns Rails.application after the scope exits' do
+      described_class.with_app(fake_app) do
+        expect(described_class.current_app).to eq(fake_app)
+      end
+      expect(described_class.current_app).to eq(Rails.application)
+    end
+  end
+
+  describe '.with_app' do
+    it 'returns the block result' do
+      result = described_class.with_app(fake_app) { :value }
+      expect(result).to eq(:value)
+    end
+
+    it 'restores the prior app when the block raises' do
+      described_class.with_app(fake_app) do
+        raise StandardError, 'boom'
+      rescue StandardError
+        # swallow
+      end
+
+      expect(described_class.current_app).to eq(Rails.application)
+    end
+
+    it 'supports nested scopes that restore the prior app' do
+      described_class.with_app(fake_app) do
+        expect(described_class.current_app).to eq(fake_app)
+
+        described_class.with_app(other_app) do
+          expect(described_class.current_app).to eq(other_app)
+        end
+
+        expect(described_class.current_app).to eq(fake_app)
+      end
+
+      expect(described_class.current_app).to eq(Rails.application)
+    end
+
+    it 'restores the outer scope when the inner block raises' do
+      described_class.with_app(fake_app) do
+        described_class.with_app(other_app) do
+          raise StandardError, 'inner boom'
+        rescue StandardError
+          # swallow
+        end
+
+        expect(described_class.current_app).to eq(fake_app)
+      end
+    end
+  end
+
+  describe 'concurrent isolation' do
+    it 'does not leak app across threads' do
+      described_class.with_app(fake_app) do
+        Thread.new do
+          expect(described_class.current_app).to eq(Rails.application)
+        end.join
+      end
+    end
+
+    it 'each thread can scope independently' do
+      results = []
+      mutex = Mutex.new
+      ready = Queue.new
+      start_signal = Queue.new
+
+      threads = [fake_app, other_app].map do |app|
+        Thread.new do
+          ready << true
+          start_signal.pop # wait for signal to proceed
+          described_class.with_app(app) do
+            mutex.synchronize { results << described_class.current_app }
+          end
+        end
+      end
+
+      2.times { ready.pop } # wait for both threads to be ready
+      2.times { start_signal << true } # signal both to proceed
+      threads.each(&:join)
+      expect(results).to contain_exactly(fake_app, other_app)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/context_provider_spec.rb
+++ b/spec/lib/rails_ai_bridge/context_provider_spec.rb
@@ -120,5 +120,17 @@ RSpec.describe RailsAiBridge::ContextProvider do
       expect(key).to include('MyApp::Application')
       expect(key).to include(Rails.env.to_s)
     end
+
+    it 'cache key isolates same-class apps with different roots' do
+      app1 = double('App1', class: double(name: 'Rails::Application'), root: '/srv/app1')
+      app2 = double('App2', class: double(name: 'Rails::Application'), root: '/srv/app2')
+
+      key1 = described_class.send(:cache_key, app1)
+      key2 = described_class.send(:cache_key, app2)
+
+      expect(key1).not_to eq(key2)
+      expect(key1).to include('/srv/app1')
+      expect(key2).to include('/srv/app2')
+    end
   end
 end

--- a/spec/lib/rails_ai_bridge/introspectors/controller_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/controller_introspector_spec.rb
@@ -151,7 +151,8 @@ RSpec.describe RailsAiBridge::Introspectors::ControllerIntrospector do
         root = Pathname.new(root_path)
         controllers_dir = root.join('domain/controllers')
         constant_name = "CustomPathReports#{SecureRandom.hex(4).camelize}Controller"
-        app = double('Rails::Application', root:, paths: { 'app/controllers' => [controllers_dir.to_s] })
+        app = double('Rails::Application', root:, paths: { 'app/controllers' => [controllers_dir.to_s] },
+                                           config: double('Rails::Configuration', eager_load: true), eager_load!: nil)
 
         {
           root_path: root_path,

--- a/spec/lib/rails_ai_bridge/introspectors/model_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/model_introspector_spec.rb
@@ -308,7 +308,8 @@ RSpec.describe RailsAiBridge::Introspectors::ModelIntrospector do
         root_path = Dir.mktmpdir('rails-ai-bridge-model-paths')
         root = Pathname.new(root_path)
         models_dir = root.join('domain/models')
-        app = double('Rails::Application', root:, paths: { 'app/models' => [models_dir.to_s] })
+        app = double('Rails::Application', root:, paths: { 'app/models' => [models_dir.to_s] },
+                                           config: double('Rails::Configuration', eager_load: true), eager_load!: nil)
 
         {
           root_path:,

--- a/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
+++ b/spec/lib/rails_ai_bridge/introspectors/non_ar_models_introspector_spec.rb
@@ -76,9 +76,8 @@ RSpec.describe RailsAiBridge::Introspectors::NonArModelsIntrospector do
       end
 
       after do
-        # rubocop:disable RSpec/RemoveConst
+        # rubocop:disable-next RSpec/RemoveConst
         Object.send(:remove_const, custom_context[:constant_name]) if Object.const_defined?(custom_context[:constant_name], false)
-        # rubocop:enable RSpec/RemoveConst
         FileUtils.rm_rf(custom_context[:root_path])
       end
 

--- a/spec/lib/rails_ai_bridge/resources_config_resource_spec.rb
+++ b/spec/lib/rails_ai_bridge/resources_config_resource_spec.rb
@@ -100,13 +100,15 @@ RSpec.describe RailsAiBridge::Resources do
         FileUtils.mkdir_p(File.join(dir, 'app/views/users'))
         File.write(File.join(dir, 'app/views/users/index.html.erb'), "<%= render 'form' %>")
 
-        allow(Rails).to receive(:root).and_return(Pathname.new(dir))
+        fake_app = instance_double(Rails::Application, root: Pathname.new(dir),
+                                                       paths: { 'app/views' => [File.join(dir, 'app/views')] })
+        RailsAiBridge::AppScope.with_app(fake_app) do
+          rows = described_class.send(:handle_read, { uri: 'rails://views/users/index.html.erb' })
+          json = JSON.parse(rows.first[:text])
 
-        rows = described_class.send(:handle_read, { uri: 'rails://views/users/index.html.erb' })
-        json = JSON.parse(rows.first[:text])
-
-        expect(json['path']).to eq('users/index.html.erb')
-        expect(json['renders']).to include('form')
+          expect(json['path']).to eq('users/index.html.erb')
+          expect(json['renders']).to include('form')
+        end
       end
     end
 
@@ -117,16 +119,15 @@ RSpec.describe RailsAiBridge::Resources do
         FileUtils.mkdir_p(views_root.join('reports'))
         File.write(views_root.join('reports/show.html.erb'), "<%= render 'summary' %>")
 
-        allow(Rails).to receive_messages(
-          application: double(root:, paths: { 'app/views' => [views_root.to_s] }),
-          root:
-        )
+        fake_app = instance_double(Rails::Application, root: root,
+                                                       paths: { 'app/views' => [views_root.to_s] })
+        RailsAiBridge::AppScope.with_app(fake_app) do
+          rows = described_class.send(:handle_read, { uri: 'rails://views/reports/show.html.erb' })
+          json = JSON.parse(rows.first[:text])
 
-        rows = described_class.send(:handle_read, { uri: 'rails://views/reports/show.html.erb' })
-        json = JSON.parse(rows.first[:text])
-
-        expect(json['path']).to eq('reports/show.html.erb')
-        expect(json['renders']).to include('summary')
+          expect(json['path']).to eq('reports/show.html.erb')
+          expect(json['renders']).to include('summary')
+        end
       end
     end
 

--- a/spec/lib/rails_ai_bridge/serializers/context_file_serializer_spec.rb
+++ b/spec/lib/rails_ai_bridge/serializers/context_file_serializer_spec.rb
@@ -277,13 +277,15 @@ RSpec.describe RailsAiBridge::Serializers::ContextFileSerializer do
       it 'keeps the embedded timestamp when opting in with an unchanged fingerprint' do
         Dir.mktmpdir do |dir|
           allow(RailsAiBridge::Fingerprinter).to receive(:source_fingerprint).and_return('a1b2c3d4e5f6')
-          generate(dir)
-          embedded = RailsAiBridge::FreshnessHeader.extract_timestamp(File.read(claude_path(dir)))
+          travel_to(Time.utc(2026, 1, 1, 12, 0, 0)) do
+            generate(dir)
+            embedded = RailsAiBridge::FreshnessHeader.extract_timestamp(File.read(claude_path(dir)))
 
-          generate(dir, managed_region: true)
+            generate(dir, managed_region: true)
 
-          region = RailsAiBridge::Serializers::ManagedRegion.extract(File.read(claude_path(dir)))
-          expect(RailsAiBridge::FreshnessHeader.extract_timestamp(region)).to eq(embedded)
+            region = RailsAiBridge::Serializers::ManagedRegion.extract(File.read(claude_path(dir)))
+            expect(RailsAiBridge::FreshnessHeader.extract_timestamp(region)).to eq(embedded)
+          end
         end
       end
 

--- a/spec/lib/rails_ai_bridge/tools/get_context_spec.rb
+++ b/spec/lib/rails_ai_bridge/tools/get_context_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 # Composite tool fixtures need model/schema/controller/route/test snapshots.
-# rubocop:disable RSpec/MultipleMemoizedHelpers
+# rubocop:disable-next RSpec/MultipleMemoizedHelpers
 RSpec.describe RailsAiBridge::Tools::GetContext do
   let(:response) { described_class.call(**params) }
   let(:content) { response.content.first[:text] }
@@ -494,4 +494,3 @@ RSpec.describe RailsAiBridge::Tools::GetContext do
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ end
 Combustion::Database.setup
 
 require 'rails_ai_bridge'
+require 'active_support/testing/time_helpers'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -31,6 +32,8 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.filter_run_when_matching :focus


### PR DESCRIPTION
## Summary
- Add `RailsAiBridge::AppScope`, a thread-local application scope (`with_app(app) { ... }` / `current_app`) that replaces hardcoded `Rails.application` references throughout the gem
- Defaults to `Rails.application` when no scope is active, preserving backward compatibility with Rails-hosted usage
- Updated 13 production files to use `AppScope.current_app`: BaseTool, ContextProvider, Resources, Middleware, CacheWarmer, Doctor, Watcher, serializers, introspectors, and the public API
- ModelIntrospector and ControllerIntrospector now use `@app` instead of `Rails.application` for eager_load (they already receive app as a constructor param)
- Nil guard added to `Resources.read_view_resource` for static/standalone mode

This is the foundation for Task 12 (static app fallback) and Task 13 (standalone CLI) — both need to scope a non-Rails.application app without global leakage between concurrent requests/tests.

## Test plan
- [x] `bundle exec rspec` — 3202 examples, 0 failures
- [x] `bundle exec rubocop --parallel` — 472 files, 0 offenses
- [x] `bundle exec reek` — 0 warnings
- [x] 9 AppScope unit specs: default fallback, scoped resolution, nested scopes, exception safety, thread isolation with deterministic barrier
- [x] 9 consumer integration specs: BaseTool, ContextProvider, CacheWarmer, Doctor, Watcher, introspect, Resources nil guard

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added application scoping across tools, context generation, caching, diagnostics, resources, and watchers.
  * Added fallback to the default Rails application when no scope is provided.
  * Improved cache separation for applications with different roots.

* **Bug Fixes**
  * Added a clear error when no Rails application is available.

* **Documentation**
  * Documented application-scoping behavior in the unreleased changelog.

* **Tests**
  * Added coverage for nested scopes, thread isolation, fallback behavior, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->