### PR TITLE
feat: bounded app boot and honest static fallback (Task 12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **AppScope runtime seam** — `RailsAiBridge::AppScope` provides a thread-local application scope (`with_app(app) { ... }` / `current_app`) so that CLI, tests, and standalone processes can scope a different app without hardcoding `Rails.application`. Defaults to `Rails.application` for backward compatibility. All MCP tools, `ContextProvider`, `Resources`, `CacheWarmer`, `Doctor`, `Watcher`, serializers, and the public API (`introspect`, `generate_context`, `start_mcp_server`) now resolve the app through `AppScope.current_app`.
 - **Watcher nil-app guard** — `Watcher#initialize` now raises `ArgumentError` when no application is available instead of storing `nil` and failing later with `NoMethodError` on `app.root`.
+- **StaticApp** — `RailsAiBridge::StaticApp` provides a minimal app-like object (root, paths, config, eager_load!) for static-capable introspectors (schema, gems, tests, migrations, conventions) without booting Rails. Includes a capability map (`STATIC_CAPABLE` / `BOOT_REQUIRED`) so static mode reports unavailable sections honestly.
+- **BootManager** — `RailsAiBridge::BootManager` locates the app root, quarantines boot stdout to stderr, honors a configurable timeout, and returns a structured result for `StandardError`/`ScriptError` failures. Offers `static_fallback` for commands that permit it (`context`, `inspect`, `doctor`).
+- **Static-mode introspection** — `Introspector` detects `StaticApp` and returns `{ error: "not available without boot" }` for boot-required introspectors. Metadata includes `static_mode: true` and detects Rails version from `Gemfile.lock` without booting.
 
 ### Changed
 

--- a/lib/rails_ai_bridge/boot_manager.rb
+++ b/lib/rails_ai_bridge/boot_manager.rb
@@ -63,15 +63,15 @@ module RailsAiBridge
       def boot(root, timeout: DEFAULT_TIMEOUT)
         root = Pathname.new(root)
         original_stdout = $stdout
+        original_dir = Dir.pwd
         $stdout = $stderr
         result = { stdout_quarantined: true, success: false, app: nil, error: nil, error_class: nil }
 
         begin
+          Dir.chdir(root)
           Timeout.timeout(timeout) do
-            require 'bundler/setup'
             require File.join(root, 'config', 'application')
-            app_name = root.basename.to_s.classify
-            app = app_name.constantize::Application
+            app = Rails.application
             app.initialize!
             result[:success] = true
             result[:app] = app
@@ -82,6 +82,7 @@ module RailsAiBridge
           result[:error_class] = error.class.name
         ensure
           $stdout = original_stdout
+          Dir.chdir(original_dir)
         end
 
         result

--- a/lib/rails_ai_bridge/boot_manager.rb
+++ b/lib/rails_ai_bridge/boot_manager.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'pathname'
+require 'timeout'
+require 'active_support/core_ext/string/inflections'
+
+module RailsAiBridge
+  # Manages bounded Rails app boot with stdout quarantine and timeout.
+  #
+  # In standalone mode, the executable needs to boot the host app's Rails
+  # without contaminating stdout (which is used for MCP protocol) and without
+  # hanging indefinitely. BootManager handles:
+  #
+  # 1. Locating the app root (Gemfile or config/application.rb)
+  # 2. Quarantining boot stdout to stderr
+  # 3. Honoring a configurable timeout
+  # 4. Returning a structured result for StandardError and ScriptError failures
+  # 5. Offering a StaticApp fallback for commands that permit it
+  #
+  # @example Bounded boot
+  #   result = RailsAiBridge::BootManager.boot('/path/to/app', timeout: 30)
+  #   if result[:success]
+  #     app = result[:app]
+  #   else
+  #     app = RailsAiBridge::BootManager.static_fallback('/path/to/app')
+  #   end
+  #
+  class BootManager
+    # Commands that can operate in static mode (no Rails boot required).
+    STATIC_ALLOWED_COMMANDS = %i[context inspect doctor].freeze
+
+    # Default boot timeout in seconds.
+    DEFAULT_TIMEOUT = 30
+
+    class << self
+      # Locates the Rails app root by searching for a Gemfile or
+      # config/application.rb, walking up from the given path.
+      #
+      # @param start_path [String, Pathname] directory to search from
+      # @return [Pathname, nil] the app root, or nil if not found
+      # :reek:DuplicateMethodCall -- root_markers? is called in loop condition and result, both necessary
+      def locate_root(start_path)
+        current = Pathname.new(start_path).expand_path
+        current = current.parent until current.root? || root_markers?(current)
+
+        root_markers?(current) ? current : nil
+      end
+
+      # Attempts to boot the Rails app at the given root with a bounded timeout.
+      #
+      # Boot stdout is redirected to stderr so that MCP stdio protocol is not
+      # contaminated. The result is always a structured hash — never raises.
+      #
+      # @param root [String, Pathname] the app root to boot
+      # @param timeout [Integer] maximum seconds to wait for boot
+      # @return [Hash] structured result:
+      #   - +:success+ [Boolean] whether boot succeeded
+      #   - +:app+ [Rails::Application, nil] the booted app (on success)
+      #   - +:error+ [String, nil] error message (on failure)
+      #   - +:error_class+ [String, nil] error class name (on failure)
+      #   - +:stdout_quarantined+ [Boolean] whether stdout was redirected
+      # :reek:TooManyStatements -- boot orchestration requires setup, rescue, and ensure
+      def boot(root, timeout: DEFAULT_TIMEOUT)
+        root = Pathname.new(root)
+        original_stdout = $stdout
+        $stdout = $stderr
+        result = { stdout_quarantined: true, success: false, app: nil, error: nil, error_class: nil }
+
+        begin
+          Timeout.timeout(timeout) do
+            require 'bundler/setup'
+            require File.join(root, 'config', 'application')
+            app_name = root.basename.to_s.classify
+            app = app_name.constantize::Application
+            app.initialize!
+            result[:success] = true
+            result[:app] = app
+          end
+        rescue StandardError, ScriptError => error
+          prefix = error.is_a?(Timeout::Error) ? "Boot timed out after #{timeout}s: " : ''
+          result[:error] = "#{prefix}#{error.message}"
+          result[:error_class] = error.class.name
+        ensure
+          $stdout = original_stdout
+        end
+
+        result
+      end
+
+      # Returns a {StaticApp} for the given root, for use when boot fails or
+      # is explicitly skipped via +--no-boot+.
+      #
+      # @param root [String, Pathname] the app root
+      # @return [StaticApp]
+      def static_fallback(root)
+        StaticApp.new(root)
+      end
+
+      # Checks whether a command permits static fallback when boot fails.
+      #
+      # @param command [Symbol] the CLI command (e.g. +:context+, +:serve+)
+      # @return [Boolean]
+      def offer_static_fallback?(command)
+        STATIC_ALLOWED_COMMANDS.include?(command)
+      end
+    end
+
+    # @api private
+    def self.root_markers?(path)
+      path.join('Gemfile').exist? || path.join('config', 'application.rb').exist?
+    end
+
+    private_class_method :root_markers?
+  end
+end

--- a/lib/rails_ai_bridge/introspector.rb
+++ b/lib/rails_ai_bridge/introspector.rb
@@ -174,9 +174,19 @@ module RailsAiBridge
       lockfile = app.root.join('Gemfile.lock')
       return nil unless lockfile.exist?
 
-      lockfile.read.match(/^\s+rails\s+\(([\d.]+)/)&.captures&.first
+      lockfile.read.match(/^\s+rails\s+\(([^)]+)\)/)&.captures&.first
     rescue StandardError
       nil
+    end
+
+    # Returns a logger that is safe in both booted and static mode.
+    # In static mode, Rails.logger may not be available.
+    #
+    # @return [Logger, nil]
+    # :reek:ManualDispatch -- checking Rails.respond_to? is the safe way to guard static mode
+    # :reek:UtilityFunction -- intentional: no instance state needed, just a safe accessor
+    def logger
+      defined?(Rails) && Rails.respond_to?(:logger) ? Rails.logger : nil
     end
 
     # Returns true when the app is a {StaticApp} (no Rails boot).
@@ -211,7 +221,7 @@ module RailsAiBridge
 
       klass = resolve_introspector_class(name)
       timed = TimedRunner.call(klass, app)
-      Rails.logger.debug { "[rails-ai-bridge] #{name} introspection completed in #{timed[:duration_ms]}ms" }
+      logger&.debug { "[rails-ai-bridge] #{name} introspection completed in #{timed[:duration_ms]}ms" }
       timed[:result]
     end
 

--- a/lib/rails_ai_bridge/introspector.rb
+++ b/lib/rails_ai_bridge/introspector.rb
@@ -16,6 +16,7 @@ module RailsAiBridge
   #
   # @example Running a subset of introspectors
   #   context = RailsAiBridge::Introspector.new(app).call(only: %i[schema routes])
+  # :reek:RepeatedConditional -- static_mode? guards in build_metadata/run_single/run_parallel are the cleanest way to branch on app type
   class Introspector
     # @return [Rails::Application] the host application passed at construction
     attr_reader :app
@@ -157,11 +158,32 @@ module RailsAiBridge
       {
         app_name: app_name,
         ruby_version: RUBY_VERSION,
-        rails_version: Rails.version,
-        environment: Rails.env,
-        generated_at: Time.current.iso8601,
-        generator: "rails-ai-bridge v#{RailsAiBridge::VERSION}"
+        rails_version: static_mode? ? detect_rails_version_from_gemfile : Rails.version,
+        environment: static_mode? ? 'static' : Rails.env.to_s,
+        generated_at: (static_mode? ? Time.now.utc : Time.current).iso8601,
+        generator: "rails-ai-bridge v#{RailsAiBridge::VERSION}",
+        static_mode: static_mode?
       }
+    end
+
+    # Detects the Rails version from the app's Gemfile.lock without booting.
+    #
+    # @return [String, nil]
+    # :reek:FeatureEnvy -- lockfile is a Pathname, method is short
+    def detect_rails_version_from_gemfile
+      lockfile = app.root.join('Gemfile.lock')
+      return nil unless lockfile.exist?
+
+      lockfile.read.match(/^\s+rails\s+\(([\d.]+)/)&.captures&.first
+    rescue StandardError
+      nil
+    end
+
+    # Returns true when the app is a {StaticApp} (no Rails boot).
+    #
+    # @return [Boolean]
+    def static_mode?
+      @static_mode ||= app.is_a?(RailsAiBridge::StaticApp)
     end
 
     # Runs introspectors one at a time, each wrapped by {TimedRunner}.
@@ -183,11 +205,23 @@ module RailsAiBridge
     #
     # @param name [Symbol]
     # @return [Object] introspector result or +{ error: String }+ on failure
+    # :reek:TooManyStatements -- static guard adds one branch, still readable
     def run_single(name)
+      return static_unavailable_result(name) if static_mode? && !StaticApp.static_available?(name)
+
       klass = resolve_introspector_class(name)
       timed = TimedRunner.call(klass, app)
       Rails.logger.debug { "[rails-ai-bridge] #{name} introspection completed in #{timed[:duration_ms]}ms" }
       timed[:result]
+    end
+
+    # Returns an honest "not available" result for boot-required
+    # introspectors when running in static mode.
+    #
+    # @param name [Symbol]
+    # @return [Hash{Symbol => String}]
+    def static_unavailable_result(name)
+      { error: "#{name} is not available without boot — use StaticApp only for static-capable sections" }
     end
 
     # Delegates concurrent execution to {ParallelRunner}.
@@ -195,6 +229,8 @@ module RailsAiBridge
     # @param names [Array<Symbol>]
     # @return [Hash{Symbol => Object}]
     def run_parallel(names)
+      return run_sequential(names) if static_mode?
+
       introspector_map = names.index_with { |name| resolve_introspector_class(name) }
       ParallelRunner.call(introspector_map, app)
     end

--- a/lib/rails_ai_bridge/static_app.rb
+++ b/lib/rails_ai_bridge/static_app.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+module RailsAiBridge
+  # A minimal app-like object for static mode (no Rails boot).
+  #
+  # Exposes only +root+, +paths+, +config+, and +eager_load!+ so that
+  # static-capable introspectors (schema, gems, tests, migrations) can
+  # operate without a booted Rails application. Boot-required introspectors
+  # (models, routes, controllers, etc.) are identified via the capability
+  # map and report "not available without boot" when invoked in static mode.
+  #
+  # @example Static introspection
+  #   app = RailsAiBridge::StaticApp.new('/path/to/app')
+  #   RailsAiBridge::AppScope.with_app(app) do
+  #     RailsAiBridge.introspect(app, only: [:schema, :gems])
+  #   end
+  #
+  class StaticApp
+    # Introspectors that work with only file system access (no Rails boot).
+    STATIC_CAPABLE = %i[schema gems tests migrations conventions].freeze
+
+    # Introspectors that require a fully booted Rails application.
+    BOOT_REQUIRED = %i[
+      models non_ar_models routes jobs controllers views stimulus
+      i18n config active_storage action_text auth api rake_tasks
+      assets devops action_mailbox seeds middleware engines
+      multi_database semantic database_stats
+    ].freeze
+
+    # Conventional Rails path mappings used when app.paths is unavailable.
+    CONVENTIONAL_PATHS = {
+      'app/models' => 'app/models',
+      'app/controllers' => 'app/controllers',
+      'app/views' => 'app/views',
+      'app/jobs' => 'app/jobs',
+      'app/mailers' => 'app/mailers',
+      'app/helpers' => 'app/helpers',
+      'app/assets' => 'app/assets',
+      'config' => 'config',
+      'db' => 'db',
+      'lib' => 'lib',
+      'test' => 'test',
+      'spec' => 'spec'
+    }.freeze
+
+    StaticConfig = Struct.new(:api_only, :eager_load) do
+      def initialize
+        super(false, false)
+      end
+    end
+
+    private_constant :StaticConfig
+
+    # @return [Pathname] the application root
+    attr_reader :root
+
+    # @return [StaticConfig] a minimal config stub
+    attr_reader :config
+
+    # @param root [String, Pathname] the application root path
+    def initialize(root)
+      @root = Pathname.new(root)
+      @config = StaticConfig.new
+    end
+
+    # No-op — static mode does not eager load anything.
+    #
+    # @return [nil]
+    def eager_load!
+      nil
+    end
+
+    # Returns conventional Rails paths rooted at the static app root.
+    #
+    # @return [Hash{String => Array<String>}]
+    def paths
+      @paths ||= CONVENTIONAL_PATHS.transform_values { |rel| [root.join(rel).to_s] }
+    end
+
+    class << self
+      # Checks whether a given introspector section is available in static mode.
+      #
+      # @param section [Symbol] the introspector key
+      # @return [Boolean]
+      def static_available?(section)
+        STATIC_CAPABLE.include?(section)
+      end
+    end
+  end
+end

--- a/lib/rails_ai_bridge/static_app.rb
+++ b/lib/rails_ai_bridge/static_app.rb
@@ -72,6 +72,13 @@ module RailsAiBridge
       nil
     end
 
+    # Non-bang counterpart for {#eager_load!}. Also a no-op in static mode.
+    #
+    # @return [nil]
+    def eager_load
+      nil
+    end
+
     # Returns conventional Rails paths rooted at the static app root.
     #
     # @return [Hash{String => Array<String>}]

--- a/spec/lib/rails_ai_bridge/boot_manager_spec.rb
+++ b/spec/lib/rails_ai_bridge/boot_manager_spec.rb
@@ -53,14 +53,15 @@ RSpec.describe RailsAiBridge::BootManager do
     end
 
     it 'returns a structured result with success: true when boot succeeds' do
-      # Pre-load the fixture so constantize can find it
-      load File.join(bootable_root, 'config', 'application.rb')
       allow(described_class).to receive(:require).and_return(true)
+      fake_app = double('App')
+      allow(fake_app).to receive(:initialize!)
+      allow(Rails).to receive(:application).and_return(fake_app)
 
       result = described_class.boot(bootable_root, timeout: 5)
 
       expect(result[:success]).to be(true)
-      expect(result[:app]).to eq(BootFixture::Application)
+      expect(result[:app]).to eq(fake_app)
     end
 
     it 'returns a structured result with success: false when boot fails' do

--- a/spec/lib/rails_ai_bridge/boot_manager_spec.rb
+++ b/spec/lib/rails_ai_bridge/boot_manager_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::BootManager do
+  let(:root_path) { Dir.mktmpdir('boot-manager-test-') }
+
+  after { FileUtils.rm_rf(root_path) }
+
+  describe '.locate_root' do
+    it 'finds root from a directory containing a Gemfile' do
+      File.write(File.join(root_path, 'Gemfile'), "source 'https://rubygems.org'")
+      expect(described_class.locate_root(root_path)).to eq(Pathname.new(root_path))
+    end
+
+    it 'finds root from a directory containing config/application.rb' do
+      FileUtils.mkdir_p(File.join(root_path, 'config'))
+      File.write(File.join(root_path, 'config/application.rb'), 'module TestApp; end')
+      expect(described_class.locate_root(root_path)).to eq(Pathname.new(root_path))
+    end
+
+    it 'returns nil when no Rails app markers are found' do
+      expect(described_class.locate_root(root_path)).to be_nil
+    end
+
+    it 'walks up the tree to find a parent with a Gemfile' do
+      File.write(File.join(root_path, 'Gemfile'), "source 'https://rubygems.org'")
+      subdir = File.join(root_path, 'app', 'models')
+      FileUtils.mkdir_p(subdir)
+      expect(described_class.locate_root(subdir)).to eq(Pathname.new(root_path))
+    end
+  end
+
+  describe '.boot' do
+    let(:bootable_root) do
+      parent = Dir.mktmpdir
+      path = File.join(parent, 'boot_fixture')
+      FileUtils.mkdir_p(File.join(path, 'config'))
+      File.write(File.join(path, 'Gemfile'), "source 'https://rubygems.org'")
+      File.write(File.join(path, 'config/application.rb'), <<~RUBY)
+        module BootFixture
+          class Application
+            def self.initialize!; end
+          end
+        end
+      RUBY
+      path
+    end
+
+    after do
+      parent = File.dirname(bootable_root)
+      FileUtils.rm_rf(parent)
+    end
+
+    it 'returns a structured result with success: true when boot succeeds' do
+      # Pre-load the fixture so constantize can find it
+      load File.join(bootable_root, 'config', 'application.rb')
+      allow(described_class).to receive(:require).and_return(true)
+
+      result = described_class.boot(bootable_root, timeout: 5)
+
+      expect(result[:success]).to be(true)
+      expect(result[:app]).to eq(BootFixture::Application)
+    end
+
+    it 'returns a structured result with success: false when boot fails' do
+      result = described_class.boot(Pathname.new(root_path), timeout: 5)
+
+      expect(result[:success]).to be(false)
+      expect(result).to have_key(:error)
+      expect(result[:error]).to be_a(String)
+    end
+
+    it 'includes the error class in the failure result' do
+      result = described_class.boot(Pathname.new(root_path), timeout: 5)
+
+      expect(result).to have_key(:error_class)
+    end
+
+    it 'quarantines boot stdout to stderr (does not pollute stdout)' do
+      result = described_class.boot(Pathname.new(root_path), timeout: 5)
+
+      expect(result).to have_key(:stdout_quarantined)
+      expect(result[:stdout_quarantined]).to be(true)
+    end
+  end
+
+  describe '.boot with timeout' do
+    it 'honors a configurable timeout' do
+      # A non-bootable path with a very short timeout should fail quickly
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result = described_class.boot(Pathname.new(root_path), timeout: 1)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+      expect(result[:success]).to be(false)
+      expect(elapsed).to be < 5
+    end
+  end
+
+  describe '.static_fallback' do
+    it 'returns a StaticApp for the given root' do
+      app = described_class.static_fallback(root_path)
+
+      expect(app).to be_a(RailsAiBridge::StaticApp)
+      expect(app.root).to eq(Pathname.new(root_path))
+    end
+  end
+
+  describe '.offer_static_fallback?' do
+    it 'returns true for commands that permit static fallback' do
+      expect(described_class.offer_static_fallback?(:context)).to be(true)
+      expect(described_class.offer_static_fallback?(:inspect)).to be(true)
+      expect(described_class.offer_static_fallback?(:doctor)).to be(true)
+    end
+
+    it 'returns false for commands that require boot' do
+      expect(described_class.offer_static_fallback?(:serve)).to be(false)
+      expect(described_class.offer_static_fallback?(:watch)).to be(false)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/static_app_spec.rb
+++ b/spec/lib/rails_ai_bridge/static_app_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RailsAiBridge::StaticApp do
+  let(:root_path) { Pathname.new(Dir.mktmpdir('static-app-test-')) }
+
+  after { FileUtils.remove_entry(root_path) if root_path&.exist? }
+
+  describe '.new' do
+    it 'accepts a string path' do
+      app = described_class.new(root_path.to_s)
+      expect(app.root).to eq(Pathname.new(root_path.to_s))
+    end
+
+    it 'accepts a Pathname' do
+      app = described_class.new(root_path)
+      expect(app.root).to eq(root_path)
+    end
+  end
+
+  describe '#root' do
+    it 'returns a Pathname' do
+      app = described_class.new(root_path)
+      expect(app.root).to be_a(Pathname)
+    end
+  end
+
+  describe '#paths' do
+    it 'returns conventional Rails paths rooted at root' do
+      app = described_class.new(root_path)
+      expect(app.paths['app/models']).to eq([root_path.join('app/models').to_s])
+      expect(app.paths['app/controllers']).to eq([root_path.join('app/controllers').to_s])
+    end
+
+    it 'returns an array for each path key' do
+      app = described_class.new(root_path)
+      expect(app.paths['app/views']).to be_an(Array)
+    end
+  end
+
+  describe '#config' do
+    it 'returns a static config that reports api_only as false' do
+      app = described_class.new(root_path)
+      expect(app.config.api_only).to be(false)
+    end
+
+    it 'returns a static config that reports eager_load as false' do
+      app = described_class.new(root_path)
+      expect(app.config.eager_load).to be(false)
+    end
+  end
+
+  describe '#eager_load!' do
+    it 'is a no-op (does not raise)' do
+      app = described_class.new(root_path)
+      expect { app.eager_load! }.not_to raise_error
+    end
+  end
+
+  describe '#class.name' do
+    it 'reports StaticApp so app_name derivation works' do
+      app = described_class.new(root_path)
+      expect(app.class.name).to eq('RailsAiBridge::StaticApp')
+    end
+  end
+
+  describe 'integration with AppScope' do
+    it 'can be scoped via AppScope.with_app' do
+      app = described_class.new(root_path)
+      RailsAiBridge::AppScope.with_app(app) do
+        expect(RailsAiBridge::AppScope.current_app).to eq(app)
+      end
+    end
+  end
+
+  describe 'integration with static-capable introspectors' do
+    it 'runs SchemaIntrospector against a schema.rb file' do
+      FileUtils.mkdir_p(root_path.join('db'))
+      File.write(root_path.join('db/schema.rb'), <<~RUBY)
+        ActiveRecord::Schema.define(version: 2024_01_01) do
+          create_table "users", force: :cascade do |t|
+            t.string "name"
+            t.timestamps
+          end
+        end
+      RUBY
+
+      app = described_class.new(root_path)
+      result = RailsAiBridge::Introspectors::SchemaIntrospector.new(app).call
+
+      expect(result).to have_key(:tables)
+      expect(result[:tables]).to have_key('users')
+    end
+
+    it 'runs GemIntrospector against a Gemfile.lock' do
+      File.write(root_path.join('Gemfile.lock'), <<~TEXT)
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            rails (7.1.0)
+            pg (1.5.0)
+
+        DEPENDENCIES
+          rails (~> 7.1)
+          pg
+      TEXT
+
+      app = described_class.new(root_path)
+      result = RailsAiBridge::Introspectors::GemIntrospector.new(app).call
+
+      expect(result).to have_key(:categories)
+      expect(result[:categories]).to have_key('database')
+    end
+  end
+
+  describe 'capability map' do
+    it 'reports which introspectors are available in static mode' do
+      expect(described_class::STATIC_CAPABLE).to include(:schema, :gems, :tests, :migrations)
+    end
+
+    it 'reports which introspectors require boot' do
+      expect(described_class::BOOT_REQUIRED).to include(:models, :routes, :controllers)
+    end
+
+    it 'static_available? returns true for static-capable sections' do
+      expect(described_class.static_available?(:schema)).to be(true)
+      expect(described_class.static_available?(:models)).to be(false)
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/static_introspection_spec.rb
+++ b/spec/lib/rails_ai_bridge/static_introspection_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe 'Static mode introspection' do
 
       expect(result[:static_mode]).to be(true)
     end
+
+    it 'detects Rails version from Gemfile.lock including prerelease suffixes' do
+      File.write(root_path.join('Gemfile.lock'), <<~TEXT)
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            rails (8.1.0.rc1)
+
+        DEPENDENCIES
+          rails (~> 8.1.0.rc1)
+      TEXT
+
+      result = RailsAiBridge::Introspector.new(static_app).call(only: %i[schema])
+
+      expect(result[:rails_version]).to eq('8.1.0.rc1')
+    end
   end
 
   describe 'RailsAiBridge.introspect with StaticApp via AppScope' do

--- a/spec/lib/rails_ai_bridge/static_introspection_spec.rb
+++ b/spec/lib/rails_ai_bridge/static_introspection_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Static mode introspection' do
       RUBY
 
       RailsAiBridge::AppScope.with_app(static_app) do
-        result = RailsAiBridge.introspect(static_app, only: %i[schema])
+        result = RailsAiBridge.introspect(only: %i[schema])
         expect(result[:schema]).to have_key(:tables)
         expect(result[:schema][:tables]).to have_key('posts')
       end

--- a/spec/lib/rails_ai_bridge/static_introspection_spec.rb
+++ b/spec/lib/rails_ai_bridge/static_introspection_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Static mode introspection' do
+  let(:root_path) { Pathname.new(Dir.mktmpdir('static-introspect-')) }
+  let(:static_app) { RailsAiBridge::StaticApp.new(root_path) }
+
+  after { FileUtils.remove_entry(root_path) if root_path&.exist? }
+
+  describe 'RailsAiBridge::Introspector with StaticApp' do
+    it 'runs only static-capable introspectors and returns metadata' do
+      # Create a schema.rb so the schema introspector has something to read
+      FileUtils.mkdir_p(root_path.join('db'))
+      File.write(root_path.join('db/schema.rb'), <<~RUBY)
+        ActiveRecord::Schema.define(version: 2024_01_01) do
+          create_table "users", force: :cascade do |t|
+            t.string "name"
+          end
+        end
+      RUBY
+
+      result = RailsAiBridge::Introspector.new(static_app).call(only: %i[schema models routes])
+
+      # Static-capable introspector should produce real results
+      expect(result).to have_key(:schema)
+      expect(result[:schema]).to have_key(:tables)
+
+      # Boot-required introspectors should report unavailable
+      expect(result).to have_key(:models)
+      expect(result[:models]).to have_key(:error)
+      expect(result[:models][:error]).to match(/not available without boot/i)
+
+      expect(result).to have_key(:routes)
+      expect(result[:routes]).to have_key(:error)
+      expect(result[:routes][:error]).to match(/not available without boot/i)
+    end
+
+    it 'includes metadata with app_name derived from StaticApp class' do
+      result = RailsAiBridge::Introspector.new(static_app).call(only: %i[schema])
+
+      expect(result[:app_name]).to eq('RailsAiBridge')
+    end
+
+    it 'includes a static_mode flag in metadata' do
+      result = RailsAiBridge::Introspector.new(static_app).call(only: %i[schema])
+
+      expect(result[:static_mode]).to be(true)
+    end
+  end
+
+  describe 'RailsAiBridge.introspect with StaticApp via AppScope' do
+    it 'works through the public API with AppScope' do
+      FileUtils.mkdir_p(root_path.join('db'))
+      File.write(root_path.join('db/schema.rb'), <<~RUBY)
+        ActiveRecord::Schema.define(version: 2024_01_01) do
+          create_table "posts", force: :cascade do |t|
+            t.string "title"
+          end
+        end
+      RUBY
+
+      RailsAiBridge::AppScope.with_app(static_app) do
+        result = RailsAiBridge.introspect(static_app, only: %i[schema])
+        expect(result[:schema]).to have_key(:tables)
+        expect(result[:schema][:tables]).to have_key('posts')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **StaticApp** — minimal app-like object (root, paths, config, eager_load!) for static-capable introspectors (schema, gems, tests, migrations, conventions) without booting Rails
- **BootManager** — locates app root, quarantines boot stdout to stderr, honors configurable timeout, returns structured result for StandardError/ScriptError failures
- **Capability map** — `StaticApp::STATIC_CAPABLE` / `BOOT_REQUIRED` so static mode reports unavailable sections honestly instead of presenting partial results as complete
- **Static-mode introspection** — Introspector detects StaticApp and returns `{ error: "not available without boot" }` for boot-required introspectors; metadata includes `static_mode: true` and detects Rails version from Gemfile.lock without booting

## Test plan

- [x] 31 new specs covering StaticApp, BootManager, and static introspection
- [x] Full suite: 3503 examples, 0 failures
- [x] RuboCop: 482 files, 0 offenses
- [x] Reek: clean on new files
- [ ] CI matrix passes
- [ ] CodeRabbit review

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added static-mode introspection for selected commands without requiring a full Rails boot.
  * Added automatic Rails app detection and configurable boot timeouts.
  * Added static fallback support for context, inspection, and diagnostics.
  * Static results now include Rails version, environment details, and a static-mode indicator.

* **Bug Fixes**
  * Boot output is redirected to prevent interference with protocol communication.
  * Boot failures now return structured results instead of interrupting processing.
  * Boot-required introspectors display a clear availability message in static mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->