### PR TITLE
feat: report boot failures through Doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ruby 4.0 canary in CI** — CI matrix includes a non-blocking Ruby 4.0 / Rails 8.1 canary job to catch compatibility issues early without blocking the pipeline.
 ### Fixed
 
+- **Unknown Doctor boot failures** — Boot diagnostics now report `UnknownError` when exception class metadata is absent instead of rendering an empty error class.
 - **Request-scoped resolver memoization** — `Registry#with_request_resolver` and `request_active?` now use a frozen sentinel object instead of relying on `Thread.current[REQUEST_RESOLVER_KEY]` being `nil`. Previously `request_resolver?` checked `!Thread.current[REQUEST_RESOLVER_KEY].nil?`, which returned `false` for an active but unbuilt resolver. A sentinel distinguishes "active, not built" from "not active."
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Watcher nil-app guard** — `Watcher#initialize` now raises `ArgumentError` when no application is available instead of storing `nil` and failing later with `NoMethodError` on `app.root`.
 - **StaticApp** — `RailsAiBridge::StaticApp` provides a minimal app-like object (root, paths, config, eager_load!) for static-capable introspectors (schema, gems, tests, migrations, conventions) without booting Rails. Includes a capability map (`STATIC_CAPABLE` / `BOOT_REQUIRED`) so static mode reports unavailable sections honestly.
 - **BootManager** — `RailsAiBridge::BootManager` locates the app root, quarantines boot stdout to stderr, honors a configurable timeout, and returns a structured result for `StandardError`/`ScriptError` failures. Offers `static_fallback` for commands that permit it (`context`, `inspect`, `doctor`).
+- **Doctor boot diagnostics** — `Doctor.run_for` provides a programmatic boot-to-static-fallback path for standalone callers. It reports structured Rails boot failures, continues static-capable checks, and marks runtime-only checks as unavailable rather than presenting partial diagnostics as complete.
 - **Static-mode introspection** — `Introspector` detects `StaticApp` and returns `{ error: "not available without boot" }` for boot-required introspectors. Metadata includes `static_mode: true` and detects Rails version from `Gemfile.lock` without booting.
 
 ### Changed

--- a/lib/rails_ai_bridge/doctor.rb
+++ b/lib/rails_ai_bridge/doctor.rb
@@ -61,21 +61,26 @@ module RailsAiBridge
     # @return [Hash] diagnostic result with `:checks` and `:score`
     def run
       results = CHECKS.map { |name, checker_class| run_check(name, checker_class) }
-      if boot_result && !boot_result[:success]
-        results.unshift(
-          Check.new(
-            name: 'Rails boot',
-            status: :fail,
-            message: "Rails boot failed (#{boot_result[:error_class]})",
-            fix: nil
-          )
-        )
-      end
+      results.unshift(boot_failure_check) if boot_failed?
       score = compute_score(results)
       { checks: results, score: score }
     end
 
     private
+
+    def boot_failed?
+      boot_result && !boot_result[:success]
+    end
+
+    def boot_failure_check
+      error_class = boot_result[:error_class].presence || 'UnknownError'
+      Check.new(
+        name: 'Rails boot',
+        status: :fail,
+        message: "Rails boot failed (#{error_class})",
+        fix: nil
+      )
+    end
 
     def run_check(name, checker_class)
       unavailable_name = STATIC_UNAVAILABLE_CHECKS[name]

--- a/lib/rails_ai_bridge/doctor.rb
+++ b/lib/rails_ai_bridge/doctor.rb
@@ -26,24 +26,68 @@ module RailsAiBridge
       check_registry: Checkers::RegistryChecker
     }.freeze
 
-    attr_reader :app
+    STATIC_UNAVAILABLE_CHECKS = {
+      check_models: 'Models',
+      check_routes: 'Routes',
+      check_controllers: 'Controllers',
+      check_views: 'Views',
+      check_i18n: 'I18n'
+    }.freeze
+    private_constant :STATIC_UNAVAILABLE_CHECKS
+
+    attr_reader :app, :boot_result
+
+    # Boots an application and runs diagnostics, using static fallback on failure.
+    #
+    # @param root [String, Pathname] application root
+    # @param timeout [Numeric] maximum boot duration in seconds
+    # @return [Hash] diagnostic result with `:checks` and `:score`
+    def self.run_for(root, timeout: BootManager::DEFAULT_TIMEOUT)
+      boot_result = BootManager.boot(root, timeout: timeout)
+      app = boot_result[:success] ? boot_result[:app] : BootManager.static_fallback(root)
+      new(app, boot_result: boot_result).run
+    end
 
     # @param app [Rails::Application, nil] application to inspect
+    # @param boot_result [Hash, nil] structured result from {BootManager.boot}
     # @return [void]
-    def initialize(app = nil)
+    def initialize(app = nil, boot_result: nil)
       @app = app || AppScope.current_app
+      @boot_result = boot_result
     end
 
     # Runs all diagnostic checks and computes a readiness score.
     #
     # @return [Hash] diagnostic result with `:checks` and `:score`
     def run
-      results = CHECKS.values.map { |checker_class| checker_class.new(app).call }
+      results = CHECKS.map { |name, checker_class| run_check(name, checker_class) }
+      if boot_result && !boot_result[:success]
+        results.unshift(
+          Check.new(
+            name: 'Rails boot',
+            status: :fail,
+            message: "Rails boot failed (#{boot_result[:error_class]})",
+            fix: nil
+          )
+        )
+      end
       score = compute_score(results)
       { checks: results, score: score }
     end
 
     private
+
+    def run_check(name, checker_class)
+      unavailable_name = STATIC_UNAVAILABLE_CHECKS[name]
+      return checker_class.new(app).call unless app.is_a?(StaticApp) && unavailable_name
+
+      Check.new(
+        name: unavailable_name,
+        status: :warn,
+        message: 'Not available without Rails boot',
+        fix: nil
+      )
+    end
 
     # Weighted score: +:pass+ 10, +:warn+ 5, other 0; scaled to 0–100.
     #

--- a/spec/fixtures/boot_apps/database_outage/config/application.rb
+++ b/spec/fixtures/boot_apps/database_outage/config/application.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'active_record/railtie'
+
+module DatabaseOutage
+  class Application < Rails::Application
+    config.eager_load = false
+    config.secret_key_base = 'x' * 64
+
+    initializer 'database_outage.connect' do
+      raise ActiveRecord::ConnectionNotEstablished, 'database unavailable'
+    end
+  end
+end

--- a/spec/fixtures/boot_apps/database_outage/config/application.rb
+++ b/spec/fixtures/boot_apps/database_outage/config/application.rb
@@ -5,7 +5,6 @@ require 'active_record/railtie'
 module DatabaseOutage
   class Application < Rails::Application
     config.eager_load = false
-    config.secret_key_base = 'x' * 64
 
     initializer 'database_outage.connect' do
       raise ActiveRecord::ConnectionNotEstablished, 'database unavailable'

--- a/spec/fixtures/boot_apps/missing_bundle/config/application.rb
+++ b/spec/fixtures/boot_apps/missing_bundle/config/application.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+raise Bundler::GemNotFound, 'missing locked gem'

--- a/spec/fixtures/boot_apps/stdout_noise/config/application.rb
+++ b/spec/fixtures/boot_apps/stdout_noise/config/application.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+puts 'boot noise'
+raise 'noisy boot failed'

--- a/spec/fixtures/boot_apps/syntax_error/config/application.rb
+++ b/spec/fixtures/boot_apps/syntax_error/config/application.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module BrokenSyntax
+  class Application < Rails::Application
+end

--- a/spec/fixtures/boot_apps/timeout/config/application.rb
+++ b/spec/fixtures/boot_apps/timeout/config/application.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+sleep 2

--- a/spec/fixtures/boot_apps/version_conflict/config/application.rb
+++ b/spec/fixtures/boot_apps/version_conflict/config/application.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+raise Gem::LoadError, 'railties version conflict'

--- a/spec/lib/rails_ai_bridge/boot_manager_process_spec.rb
+++ b/spec/lib/rails_ai_bridge/boot_manager_process_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'open3'
+require 'rbconfig'
+require 'timeout'
+
+RSpec.describe RailsAiBridge::BootManager do
+  let(:boot_script) do
+    <<~RUBY
+      require 'rails'
+      require 'active_record'
+      require 'bundler'
+      require 'rails_ai_bridge'
+
+      result = RailsAiBridge::BootManager.boot(ARGV.fetch(0), timeout: Float(ARGV.fetch(1)))
+      puts JSON.generate(result.except(:app))
+    RUBY
+  end
+
+  def boot_fixture(name, timeout: 1)
+    root = File.expand_path("../../fixtures/boot_apps/#{name}", __dir__)
+    lib = File.expand_path('../../../lib', __dir__)
+    stdout, stderr, status = Timeout.timeout(10) do
+      Open3.capture3(RbConfig.ruby, '-I', lib, '-rjson', '-e', boot_script, root, timeout.to_s)
+    end
+    expect(status).to be_success, stderr
+
+    [JSON.parse(stdout, symbolize_names: true), stderr, status]
+  end
+
+  describe '.boot in an isolated process' do
+    {
+      syntax_error: 'SyntaxError',
+      timeout: 'Timeout::Error',
+      database_outage: 'ActiveRecord::ConnectionNotEstablished',
+      version_conflict: 'Gem::LoadError',
+      missing_bundle: 'Bundler::GemNotFound'
+    }.each do |fixture, error_class|
+      it "captures a #{fixture.to_s.tr('_', ' ')} boot exception" do
+        timeout = fixture == :timeout ? 0.5 : 2
+        result, _stderr, status = boot_fixture(fixture, timeout: timeout)
+
+        expect(status).to be_success
+        expect(result).to include(
+          success: false,
+          error_class: error_class,
+          stdout_quarantined: true
+        )
+      end
+    end
+
+    it 'keeps boot noise off stdout' do
+      result, stderr, status = boot_fixture(:stdout_noise)
+
+      expect(status).to be_success
+      expect(result).to include(success: false, error_class: 'RuntimeError')
+      expect(stderr).to include('boot noise')
+    end
+  end
+end

--- a/spec/lib/rails_ai_bridge/doctor_spec.rb
+++ b/spec/lib/rails_ai_bridge/doctor_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
 
 RSpec.describe RailsAiBridge::Doctor do
   let(:doctor) { described_class.new(Rails.application) }
@@ -100,6 +102,16 @@ RSpec.describe RailsAiBridge::Doctor do
         status: :fail,
         message: 'Rails boot failed (ActiveRecord::ConnectionNotEstablished)'
       )
+    end
+
+    it 'reports an unknown boot error class safely' do
+      static_app = RailsAiBridge::StaticApp.new(static_root)
+      boot_result = { success: false, error: 'unexpected failure', error_class: nil }
+
+      current = described_class.new(static_app, boot_result: boot_result).run
+      boot_check = current[:checks].find { |check| check.name == 'Rails boot' }
+
+      expect(boot_check.message).to eq('Rails boot failed (UnknownError)')
     end
 
     it 'runs Doctor through boot and static fallback' do

--- a/spec/lib/rails_ai_bridge/doctor_spec.rb
+++ b/spec/lib/rails_ai_bridge/doctor_spec.rb
@@ -111,7 +111,11 @@ RSpec.describe RailsAiBridge::Doctor do
       current = described_class.new(static_app, boot_result: boot_result).run
       boot_check = current[:checks].find { |check| check.name == 'Rails boot' }
 
-      expect(boot_check.message).to eq('Rails boot failed (UnknownError)')
+      expect(boot_check).to have_attributes(
+        status: :fail,
+        message: 'Rails boot failed (UnknownError)',
+        fix: nil
+      )
     end
 
     it 'runs Doctor through boot and static fallback' do

--- a/spec/lib/rails_ai_bridge/doctor_spec.rb
+++ b/spec/lib/rails_ai_bridge/doctor_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 
 RSpec.describe RailsAiBridge::Doctor do
   let(:doctor) { described_class.new(Rails.application) }
+  let(:static_root) { Dir.mktmpdir('doctor-static-') }
+
+  after { FileUtils.rm_rf(static_root) }
 
   describe '#run' do
     subject(:result) { doctor.run }
@@ -80,6 +83,45 @@ RSpec.describe RailsAiBridge::Doctor do
 
       # 1 fail (0) + 1 pass (10) + 15 others (all pass = 150) = 160 / 170 = 94
       expect(score).to be < 100
+    end
+
+    it 'reports a Rails boot failure without exposing exception details' do
+      static_app = RailsAiBridge::StaticApp.new(static_root)
+      boot_result = {
+        success: false,
+        error: 'password=secret database.internal.example',
+        error_class: 'ActiveRecord::ConnectionNotEstablished'
+      }
+
+      current = described_class.new(static_app, boot_result: boot_result).run
+      boot_check = current[:checks].find { |check| check.name == 'Rails boot' }
+
+      expect(boot_check).to have_attributes(
+        status: :fail,
+        message: 'Rails boot failed (ActiveRecord::ConnectionNotEstablished)'
+      )
+    end
+
+    it 'runs Doctor through boot and static fallback' do
+      root = File.expand_path('../../fixtures/boot_apps/syntax_error', __dir__)
+
+      current = described_class.run_for(root, timeout: 1)
+      boot_check = current[:checks].find { |check| check.name == 'Rails boot' }
+
+      expect(boot_check).to have_attributes(status: :fail, message: 'Rails boot failed (SyntaxError)')
+      expect(current[:checks]).to include(have_attributes(name: 'Routes', status: :warn))
+    end
+
+    it 'marks runtime-only checks unavailable in static mode' do
+      static_app = RailsAiBridge::StaticApp.new(static_root)
+
+      current = described_class.new(static_app).run
+      routes_check = current[:checks].find { |check| check.name == 'Routes' }
+
+      expect(routes_check).to have_attributes(
+        status: :warn,
+        message: 'Not available without Rails boot'
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary
- add `Doctor.run_for` as the boot-to-static-fallback seam for standalone callers
- report boot failures without exposing raw exception messages
- mark runtime-only Doctor checks unavailable when using `StaticApp`
- cover isolated boot exceptions, timeout handling, and stdout quarantine with process fixtures

## Test plan
- [x] `bundle exec rspec spec/lib/rails_ai_bridge/doctor_spec.rb spec/lib/rails_ai_bridge/boot_manager_process_spec.rb spec/lib/rails_ai_bridge/boot_manager_spec.rb` (32 examples, 0 failures)
- [x] `bundle exec rubocop lib/rails_ai_bridge/doctor.rb spec/lib/rails_ai_bridge/doctor_spec.rb spec/lib/rails_ai_bridge/boot_manager_process_spec.rb spec/fixtures/boot_apps`
- [x] `bundle exec reek lib/rails_ai_bridge/doctor.rb`
- [x] `bundle exec archspec check`
- [x] `bundle exec rake docs:yard` (91.11%; pre-existing warnings only)
- [x] rs-guard: APPROVE, 0 critical/security/important findings
- [ ] `bundle exec rspec` — blocked on main by MCP 1.3 characterization specs while `Gemfile.lock` resolves MCP 1.1.0 (4 failures)
- [ ] `bundle exec rubocop --parallel` — blocked on main by pre-existing malformed `rubocop:disable-next` directives

Closes #225

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured Rails boot diagnostics to Doctor checks.
  - Added automatic fallback to static analysis when application boot fails.
  - Added clear warnings for checks unavailable without a successful Rails boot.
  - Added timeout handling and protection against boot-time output interfering with results.

- **Bug Fixes**
  - Improved handling and reporting of syntax errors, dependency issues, database outages, and other boot failures.

- **Documentation**
  - Documented boot diagnostics and static fallback behavior in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->