### PR TITLE
doc: follow-up fixes for UPGRADING.md from #234 review

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -48,10 +48,10 @@ Bundler will pull in the new dependency floor (`mcp >= 1.3`, `faraday >= 2.0`,
      config.context_providers.enabled = true
      config.context_providers.allowed_hosts = ['context.example.com']
      config.context_providers.auth_resolver = lambda do |_endpoint, canonical_uri|
-      # Set this in your environment, or replace with a real secret-manager call.
-      # The README's "Provider auth" section shows worked Vault/ENV/KMS examples.
-      token = ENV.fetch('MCP_PROVIDER_TOKEN')
-      { 'Authorization' => "Bearer #{token}" }
+     # Set this in your environment, or replace with a real secret-manager call.
+     # The README's "Provider auth" section shows worked Vault/ENV/KMS examples.
+     token = ENV.fetch('MCP_PROVIDER_TOKEN')
+     { 'Authorization' => "Bearer #{token}" }
      end
    end
    ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,7 +41,7 @@ Bundler will pull in the new dependency floor (`mcp >= 1.3`, `faraday >= 2.0`,
 
 1. Declare providers and read-only tools in
    `config/rails_ai_bridge/registry.json`.
-2. Enable and allowlist them in the initializer:
+1. Enable and allowlist them in the initializer:
 
    ```ruby
    RailsAiBridge.configure do |config|
@@ -56,7 +56,7 @@ Bundler will pull in the new dependency floor (`mcp >= 1.3`, `faraday >= 2.0`,
    end
    ```
 
-3. Call `rails_get_provider_context` from your AI client, or run
+1. Call `rails_get_provider_context` from your AI client, or run
    `NETWORK=1 rails ai:doctor` to verify reachability.
 
 ### Production guard for private networks

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -48,9 +48,10 @@ Bundler will pull in the new dependency floor (`mcp >= 1.3`, `faraday >= 2.0`,
      config.context_providers.enabled = true
      config.context_providers.allowed_hosts = ['context.example.com']
      config.context_providers.auth_resolver = lambda do |_endpoint, canonical_uri|
-       # `token_for` is a placeholder — replace it with a real secret-manager call.
-       # The README's "Provider auth" section shows worked Vault/ENV/KMS examples.
-       { 'Authorization' => "Bearer #{token_for(canonical_uri.host)}" }
+      # Set this in your environment, or replace with a real secret-manager call.
+      # The README's "Provider auth" section shows worked Vault/ENV/KMS examples.
+      token = ENV.fetch('MCP_PROVIDER_TOKEN')
+      { 'Authorization' => "Bearer #{token}" }
      end
    end
    ```


### PR DESCRIPTION
Addresses the two remaining CodeRabbit comments on #234:

- Replace the undefined `token_for` placeholder in the auth resolver example with `ENV.fetch('MCP_PROVIDER_TOKEN')`.
- Use `1.` for every ordered-list item in the outbound-provider setup section to satisfy markdownlint MD029.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the outbound provider setup example to retrieve the provider token from the `MCP_PROVIDER_TOKEN` environment variable.
  * Clarified the configuration guidance in the upgrade documentation while preserving the existing setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->